### PR TITLE
Fix vertical team placement in non ISO maps

### DIFF
--- a/freeciv/freeciv/server/gamehand.c
+++ b/freeciv/freeciv/server/gamehand.c
@@ -259,7 +259,7 @@ static int team_placement_vertical(const struct tile *ptile1,
 
   map_distance_vector(&dx, &dy, ptile1, ptile2);
   /* Map vector to natural vector (X axis). */
-  return abs(MAP_IS_ISOMETRIC ? dx - dy : dy);
+  return abs(MAP_IS_ISOMETRIC ? dx - dy : dx);
 }
 
 /************************************************************************//**


### PR DESCRIPTION
Vertical team placement behaved the same as horizontal team placement on FCW. I don't know, why my old fix is in the commits too, but there's only one changed file as expected, so that should be alright.