### PR TITLE
startpos default

### DIFF
--- a/freeciv/freeciv/data/ag/game.ruleset
+++ b/freeciv/freeciv/data/ag/game.ruleset
@@ -2086,8 +2086,8 @@ set =
       "slot_control_style", 1, FALSE      ; 1 = Shield2Gold units only
       "spaceship_travel_time", 225, FALSE
       "specials", 350, FALSE
-      "startpos", "SINGLE", FALSE
-      "startunits", "xxcccwwwaA", FALSE
+      "startpos", "DEFAULT", FALSE
+      "startunits", "xxcccwwwA", FALSE
       "techleak", 25, FALSE
       "techpenalty", 0, FALSE
       "tinyisles", FALSE, FALSE

--- a/freeciv/freeciv/data/ag2/game.ruleset
+++ b/freeciv/freeciv/data/ag2/game.ruleset
@@ -2099,8 +2099,8 @@ set =
       "slot_control_style", 1, FALSE      ; 1 = Shield2Gold units only
       "spaceship_travel_time", 225, FALSE
       "specials", 350, FALSE
-      "startpos", "SINGLE", FALSE
-      "startunits", "xxcccwwwaADD", FALSE
+      "startpos", "DEFAULT", FALSE
+      "startunits", "xxcccwwwADD", FALSE
       "techleak", 25, FALSE
       "techpenalty", 0, FALSE
       "tinyisles", FALSE, FALSE

--- a/freeciv/freeciv/data/mp2-brava/game.ruleset
+++ b/freeciv/freeciv/data/mp2-brava/game.ruleset
@@ -2189,8 +2189,8 @@ set =
       "slot_control_style", 1, FALSE      ; 1 = Shield2Gold units only
       "spaceship_travel_time", 225, FALSE
       "specials", 350, FALSE
-      "startpos", "SINGLE", FALSE
-      "startunits", "xxcccwwwaADD", FALSE
+      "startpos", "DEFAULT", FALSE
+      "startunits", "xxcccwwwADD", FALSE
       "techleak", 25, FALSE
       "techlossforgiveness", 200, FALSE
       "techlossrestore", 100, FALSE

--- a/freeciv/freeciv/data/mp2-caravel/game.ruleset
+++ b/freeciv/freeciv/data/mp2-caravel/game.ruleset
@@ -2756,7 +2756,7 @@ set =
       "slot_control_style", 1, FALSE      ; 1 = Shield2Gold units only
       "spaceship_travel_time", 225, FALSE
       "specials", 350, FALSE
-      "startpos", "SINGLE", FALSE
+      "startpos", "DEFAULT", FALSE
       "startunits", "DDDwwwAccca", "FALSE"
       "steepness", 20, FALSE
       "techleak", 25, FALSE

--- a/rulesets/mpplus/game.ruleset
+++ b/rulesets/mpplus/game.ruleset
@@ -1326,7 +1326,7 @@ set =
       "revolen", 1, FALSE
       "separatepoles", FALSE, FALSE
       "specials", 350, FALSE
-      "startpos", "SINGLE", FALSE
+      "startpos", "DEFAULT", FALSE
       "startunits", "cccwwwxx", FALSE
       "techpenalty", 0, FALSE
       "tinyisles", FALSE, FALSE


### PR DESCRIPTION
startpos was set to SINGLE (single nation per continent) which does not work properly with /generator RANDOM which is the default generator. 

changed startpos to DEFAULT to fix this.

also removed well-digger as a start unit in old rulesets. new players don't know to remove this