### PR TITLE
Server: Pass, don't inject, FCW CFLAGS

### DIFF
--- a/freeciv/freeciv/configure.ac
+++ b/freeciv/freeciv/configure.ac
@@ -1562,7 +1562,7 @@ AC_CONFIG_COMMANDS([fc_default-5],[[if test x`uname -s` = xBeOS ; then
      fi
    fi]],[[]])
 
-CFLAGS="$EXTRA_DEBUG_CFLAGS $CFLAGS -Werror -Wmissing-prototypes -Wmissing-declarations"   # Modified for FCW.
+CFLAGS="$EXTRA_DEBUG_CFLAGS $CFLAGS"
 CXXFLAGS="$EXTRA_DEBUG_CXXFLAGS $CXXFLAGS"
 LDFLAGS="$EXTRA_DEBUG_LDFLAGS $LDFLAGS"
 

--- a/freeciv/prepare_freeciv.sh
+++ b/freeciv/prepare_freeciv.sh
@@ -31,5 +31,7 @@ if ! cp -a overwrite/* freeciv ; then
 fi
 
 ( cd freeciv
-  ./autogen.sh CFLAGS="-O3" --enable-mapimg=magickwand --with-project-definition=../freeciv-web.project --enable-fcweb --enable-json --disable-delta-protocol --disable-nls --disable-fcmp --enable-freeciv-manual --disable-ruledit --enable-fcdb=no --enable-ai-static=classic,threaded --prefix=${HOME}/freeciv/ && make -s -j$(nproc)
+  ./autogen.sh --no-configure-run --disable-nls
+  ./configure CFLAGS="-O3 -Werror -Wmissing-prototypes -Wmissing-declarations" \
+              --enable-mapimg=magickwand --with-project-definition=../freeciv-web.project --enable-fcweb --enable-json --disable-delta-protocol --disable-nls --disable-fcmp --enable-freeciv-manual --disable-ruledit --enable-fcdb=no --enable-ai-static=classic,threaded --prefix=${HOME}/freeciv/ && make -s -j$(nproc)
 )


### PR DESCRIPTION
I HAVE NOT TESTED THIS CHANGE! There's a chance that setting -Werror that way causes some early configure check to fail. Someone with an officially supported system should test that it's not the case. I use newer compiler versions, with which -Werror causes the compile to fail anyway. The very motive for this change is that I could then have my local modification to remove -Werror outside server source tree, and it (the local modification) would not interact badly with creating patches of the server code.