### PR TITLE
Server: Increase buffer size to match potential size of contents

### DIFF
--- a/freeciv/freeciv/server/unittools.c
+++ b/freeciv/freeciv/server/unittools.c
@@ -2753,7 +2753,8 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
     else if (unitcount-1 <= MAX_SECONDARY_CASUALTIES_TO_REPORT
              && kill_counter <= MAX_KILLED_UNITS_TO_REPORT_TO_ALL_PLAYERS) {
         char dead_units_str[1024];
-        char killed_unit_str[128];
+        char killed_unit_str[512];
+
         memset(dead_units_str, '\0', sizeof(dead_units_str));
         // Make a string out of all the secondary casualty unit types and nationalities.
         for (int k = 0; k < kill_counter; k++) {
@@ -2882,8 +2883,9 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
           else if (num_killed[i]-1 <= MAX_SECONDARY_CASUALTIES_TO_REPORT
                    && kill_counter <= MAX_KILLED_UNITS_TO_REPORT_TO_ALL_PLAYERS) {
             char dead_units_str[1024];
-            char killed_unit_str[128];
+            char killed_unit_str[512];
             char plural_string[32];
+
             plural_string[0] = 0;
             memset(dead_units_str, '\0', sizeof(dead_units_str));
             for (int k = 0; k < kill_counter; k++) {
@@ -2943,8 +2945,9 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
                    && kill_counter <= MAX_KILLED_UNITS_TO_REPORT_TO_ALL_PLAYERS) 
             {
               char dead_units_str[1024];
-              char killed_unit_str[128];
+              char killed_unit_str[512];
               char plural_string[32];
+
               plural_string[0] = 0;
               memset(dead_units_str, '\0', sizeof(dead_units_str));
               for (int k = 0; k < kill_counter; k++) {


### PR DESCRIPTION
This is enough to get rid of a compiler error, but that code
should be changed to use freeciv's safe string handling functions
instead of unsafe sprintf(), strcat()

Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>