### PR TITLE
Srvup

### DIFF
--- a/freeciv/freeciv/.gitignore
+++ b/freeciv/freeciv/.gitignore
@@ -30,6 +30,7 @@
 /fcgui
 /fcser
 /fcruledit
+/fcruleup
 /.deps
 /*.sav
 /*.sav.gz

--- a/freeciv/freeciv/INSTALL
+++ b/freeciv/freeciv/INSTALL
@@ -125,6 +125,11 @@ library support and for development support (for compiling programs
 which use those libraries).  To compile Freeciv on such systems you 
 will need to have the appropriate "development" packages installed.
 
+Sound support is built in by default if "SDL2_mixer" library development
+files are found from the system.
+
+     https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.tar.gz
+
 
 1a. Prerequisites for the Gtk+ 3.0 client:
 ==========================================

--- a/freeciv/freeciv/bootstrap/Makefile.am
+++ b/freeciv/freeciv/bootstrap/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST =	freeciv.project		\
 		fcgui.in		\
 		fcser.in		\
 		fcruledit.in		\
+		fcruleup.in		\
 		fc_gitrev_gen.h.tmpl	\
 		generate_gitrev.sh	\
 		generate_langstat.sh	\

--- a/freeciv/freeciv/bootstrap/fcruleup.in
+++ b/freeciv/freeciv/bootstrap/fcruleup.in
@@ -1,0 +1,35 @@
+#!/bin/sh
+#/***********************************************************************
+# Freeciv - Copyright (C) 1996 - A Kjeldberg, L Gregersen, P Unold
+# script by Rene Schalburg
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2, or (at your option)
+#   any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#***********************************************************************/
+
+BUILDDIR=`dirname $0`
+PROGNAME=freeciv-ruleup
+EXENAME=${PROGNAME}@EXEEXT@
+
+if test "x$FREECIV_DATA_PATH" = "x" ; then
+  FREECIV_DATA_PATH=".@HOST_PATH_SEPARATOR@data"
+fi
+FREECIV_DATA_PATH="${FREECIV_DATA_PATH}@HOST_PATH_SEPARATOR@@top_builddir@@HOST_DIR_SEPARATOR@data@HOST_PATH_SEPARATOR@@top_srcdir@@HOST_DIR_SEPARATOR@data"
+export FREECIV_DATA_PATH
+
+[ -x $BUILDDIR@HOST_DIR_SEPARATOR@tools@HOST_DIR_SEPARATOR@$EXENAME ] && EXE=$BUILDDIR@HOST_DIR_SEPARATOR@tools@HOST_DIR_SEPARATOR@$EXENAME
+[ -x $BUILDDIR@HOST_DIR_SEPARATOR@$EXENAME ] && EXE=$BUILDDIR@HOST_DIR_SEPARATOR@$EXENAME
+
+if [ "$EXE" = "" ]; then
+  echo $0: Unable to find rule upgrader executable $EXENAME.
+  exit 1
+fi
+
+exec $EXE ${1+"$@"}

--- a/freeciv/freeciv/client/packhand.c
+++ b/freeciv/freeciv/client/packhand.c
@@ -3875,8 +3875,6 @@ void handle_ruleset_extra(const struct packet_ruleset_extra *p)
     }
   }
 
-  extra_to_category_list(pextra, pextra->category);
-
   if (pextra->causes == 0) {
     extra_to_caused_by_list(pextra, EC_NONE);
   } else {

--- a/freeciv/freeciv/common/extras.c
+++ b/freeciv/freeciv/common/extras.c
@@ -32,7 +32,6 @@ static struct extra_type extras[MAX_EXTRA_TYPES];
 
 static struct user_flag user_extra_flags[MAX_NUM_USER_EXTRA_FLAGS];
 
-static struct extra_type_list *category_extra[ECAT_COUNT];
 static struct extra_type_list *caused_by[EC_LAST];
 static struct extra_type_list *removed_by[ERM_COUNT];
 static struct extra_type_list *unit_hidden;
@@ -49,9 +48,6 @@ void extras_init(void)
   }
   for (i = 0; i < ERM_COUNT; i++) {
     removed_by[i] = extra_type_list_new();
-  }
-  for (i = 0; i < ECAT_COUNT; i++) {
-    category_extra[i] = extra_type_list_new();
   }
   unit_hidden = extra_type_list_new();
 
@@ -109,11 +105,6 @@ void extras_free(void)
   for (i = 0; i < ERM_COUNT; i++) {
     extra_type_list_destroy(removed_by[i]);
     removed_by[i] = NULL;
-  }
-
-  for (i = 0; i < ECAT_COUNT; i++) {
-    extra_type_list_destroy(category_extra[i]);
-    category_extra[i] = NULL;
   }
 
   extra_type_list_destroy(unit_hidden);
@@ -250,16 +241,6 @@ struct extra_type_list *extra_type_list_by_cause(enum extra_cause cause)
 }
 
 /************************************************************************//**
-  Returns extra types of the category.
-****************************************************************************/
-struct extra_type_list *extra_type_list_for_category(enum extra_category cat)
-{
-  fc_assert(cat < ECAT_LAST);
-
-  return category_extra[cat];
-}
-
-/************************************************************************//**
   Returns extra types that hide units.
 ****************************************************************************/
 struct extra_type_list *extra_type_list_of_unit_hiders(void)
@@ -304,16 +285,6 @@ void extra_to_caused_by_list(struct extra_type *pextra, enum extra_cause cause)
   fc_assert(cause < EC_LAST);
 
   extra_type_list_append(caused_by[cause], pextra);
-}
-
-/************************************************************************//**
-  Add extra type to list of extras of a category
-****************************************************************************/
-void extra_to_category_list(struct extra_type *pextra, enum extra_category cat)
-{
-  fc_assert(cat < ECAT_LAST);
-
-  extra_type_list_append(category_extra[cat], pextra);
 }
 
 /************************************************************************//**

--- a/freeciv/freeciv/common/extras.h
+++ b/freeciv/freeciv/common/extras.h
@@ -187,9 +187,6 @@ struct extra_type *rand_extra_for_tile(struct tile *ptile, enum extra_cause caus
 
 struct extra_type_list *extra_type_list_of_unit_hiders(void);
 
-void extra_to_category_list(struct extra_type *pextra, enum extra_category cat);
-struct extra_type_list *extra_type_list_for_category(enum extra_category cat);
-
 #define is_extra_caused_by(e, c) (e->causes & (1 << c))
 bool is_extra_caused_by_worker_action(const struct extra_type *pextra);
 bool is_extra_caused_by_action(const struct extra_type *pextra,
@@ -316,17 +313,6 @@ bool player_knows_extra_exist(const struct player *pplayer,
 
 #define extra_type_by_rmcause_iterate_end                \
   } extra_type_list_iterate_rev_end                      \
-}
-
-#define extra_type_by_category_iterate(_cat, _extra)                \
-{                                                                   \
-  struct extra_type_list *_etl_##_extra = extra_type_list_for_category(_cat); \
-  if (_etl_##_extra != NULL) {                                              \
-    extra_type_list_iterate(_etl_##_extra, _extra) {
-
-#define extra_type_by_category_iterate_end                 \
-    } extra_type_list_iterate_end                          \
-  }                                                        \
 }
 
 #define extra_deps_iterate(_reqs, _dep)                 \

--- a/freeciv/freeciv/common/fc_types.h
+++ b/freeciv/freeciv/common/fc_types.h
@@ -741,7 +741,6 @@ typedef int server_setting_id;
 #define SPECENUM_COUNT ECAT_COUNT
 #include "specenum_gen.h"
 #define ECAT_NONE ECAT_COUNT
-#define ECAT_LAST ECAT_COUNT
 
 /* Used in the network protocol. */
 #define SPECENUM_NAME extra_cause

--- a/freeciv/freeciv/common/mapimg.c
+++ b/freeciv/freeciv/common/mapimg.c
@@ -2147,8 +2147,8 @@ static bool img_save_magickwand(const struct img *pimg,
     }
 
     /* Show a line displaying the colors of alive players */
-    plrwidth = MAX(map_width / player_slot_count(), 1);
-    plroffset = (map_width - plrwidth * player_slot_count()) / 2;
+    plrwidth = map_width / MIN(map_width, player_count());
+    plroffset = (map_width - MIN(map_width, plrwidth * player_count())) / 2;
 
     imw = NewPixelRegionIterator(mw, IMG_BORDER_WIDTH,
                                  IMG_BORDER_HEIGHT + IMG_TEXT_HEIGHT

--- a/freeciv/freeciv/common/requirements.c
+++ b/freeciv/freeciv/common/requirements.c
@@ -3970,6 +3970,27 @@ int universal_build_shield_cost(const struct city *pcity,
 }
 
 /**********************************************************************//**
+  Replaces all instances of the universal to_replace with replacement in
+  the requirement vector reqs and returns TRUE iff any requirements were
+  replaced.
+**************************************************************************/
+bool universal_replace_in_req_vec(struct requirement_vector *reqs,
+                                  const struct universal *to_replace,
+                                  const struct universal *replacement)
+{
+  bool changed = FALSE;
+
+  requirement_vector_iterate(reqs, preq) {
+    if (universal_is_mentioned_by_requirement(preq, to_replace)) {
+      preq->source = *replacement;
+      changed = TRUE;
+    }
+  } requirement_vector_iterate_end;
+
+  return changed;
+}
+
+/**********************************************************************//**
   Returns TRUE iff the universal 'psource' is directly mentioned by any of
   the requirements in 'reqs'.
 **************************************************************************/

--- a/freeciv/freeciv/common/requirements.c
+++ b/freeciv/freeciv/common/requirements.c
@@ -3970,6 +3970,23 @@ int universal_build_shield_cost(const struct city *pcity,
 }
 
 /**********************************************************************//**
+  Returns TRUE iff the universal 'psource' is directly mentioned by any of
+  the requirements in 'reqs'.
+**************************************************************************/
+bool universal_is_mentioned_by_requirements(
+    const struct requirement_vector *reqs,
+    const struct universal *psource)
+{
+  requirement_vector_iterate(reqs, preq) {
+    if (universal_is_mentioned_by_requirement(preq, psource)) {
+      return TRUE;
+    }
+  } requirement_vector_iterate_end;
+
+  return FALSE;
+}
+
+/**********************************************************************//**
   Will the universal 'source' fulfill this requirement?
 **************************************************************************/
 enum req_item_found

--- a/freeciv/freeciv/common/requirements.h
+++ b/freeciv/freeciv/common/requirements.h
@@ -162,6 +162,10 @@ const char *universal_type_rule_name(const struct universal *psource);
 int universal_build_shield_cost(const struct city *pcity,
                                 const struct universal *target);
 
+bool universal_replace_in_req_vec(struct requirement_vector *reqs,
+                                  const struct universal *to_replace,
+                                  const struct universal *replacement);
+
 #define universal_is_mentioned_by_requirement(preq, psource)               \
   are_universals_equal(&preq->source, psource)
 bool universal_is_mentioned_by_requirements(

--- a/freeciv/freeciv/common/requirements.h
+++ b/freeciv/freeciv/common/requirements.h
@@ -162,6 +162,12 @@ const char *universal_type_rule_name(const struct universal *psource);
 int universal_build_shield_cost(const struct city *pcity,
                                 const struct universal *target);
 
+#define universal_is_mentioned_by_requirement(preq, psource)               \
+  are_universals_equal(&preq->source, psource)
+bool universal_is_mentioned_by_requirements(
+    const struct requirement_vector *reqs,
+    const struct universal *psource);
+
 /* An item contradicts, fulfills or is irrelevant to the requirement */
 enum req_item_found {ITF_NO, ITF_YES, ITF_NOT_APPLICABLE};
 

--- a/freeciv/freeciv/configure.ac
+++ b/freeciv/freeciv/configure.ac
@@ -1743,6 +1743,7 @@ AC_CONFIG_FILES([Makefile
           tools/ruledit/freeciv-ruledit.appdata.xml:bootstrap/freeciv-ruledit.appdata.xml.in])
 AC_CONFIG_FILES([fcgui:bootstrap/fcgui.in], [chmod +x fcgui])
 AC_CONFIG_FILES([fcser:bootstrap/fcser.in], [chmod +x fcser])
+AC_CONFIG_FILES([fcruleup:bootstrap/fcruleup.in], [chmod +x fcruleup])
 if test "x$ruledit" = "xyes" ; then
   AC_CONFIG_FILES([fcruledit:bootstrap/fcruledit.in], [chmod +x fcruledit])
 fi

--- a/freeciv/freeciv/scripts/diff_ignore
+++ b/freeciv/freeciv/scripts/diff_ignore
@@ -57,6 +57,7 @@ ref-add.sed
 ref-del.sed
 fcser
 fcruledit
+fcruleup
 stamp-cat-id
 stamp-h
 stamp-h1

--- a/freeciv/freeciv/server/ruleset.c
+++ b/freeciv/freeciv/server/ruleset.c
@@ -3112,8 +3112,6 @@ static bool load_ruleset_terrain(struct section_file *file,
           }
         }
 
-        extra_to_category_list(pextra, pextra->category);
-
         if (pextra->causes == 0) {
           /* Extras that do not have any causes added to EC_NONE list */
           extra_to_caused_by_list(pextra, EC_NONE);

--- a/freeciv/freeciv/server/unittools.c
+++ b/freeciv/freeciv/server/unittools.c
@@ -3623,7 +3623,7 @@ static void unit_enter_hut(struct unit *punit)
     return;
   }
 
-  extra_type_by_category_iterate(ECAT_BONUS, pextra) {
+  extra_type_by_cause_iterate(EC_HUT, pextra) {
     if (tile_has_extra(ptile, pextra)) {
       pplayer->server.huts++;
 
@@ -3646,7 +3646,7 @@ static void unit_enter_hut(struct unit *punit)
       /* FIXME: Should have parameter for hut extra type */
       script_server_signal_emit("hut_enter", punit);
     }
-  } extra_type_by_category_iterate_end;
+  } extra_type_by_cause_iterate_end;
 
   send_player_info_c(pplayer, pplayer->connections); /* eg, gold */
   return;

--- a/freeciv/freeciv/tools/ruledit/effect_edit.cpp
+++ b/freeciv/freeciv/tools/ruledit/effect_edit.cpp
@@ -134,7 +134,8 @@ static bool effect_list_fill_cb(struct effect *peffect, void *data)
       fc_assert(cbdata->efmc == EFMC_ALL);
       cbdata->edit->add_effect_to_list(peffect, cbdata);
     }
-  } else if (universal_in_req_vec(cbdata->filter, &peffect->reqs)) {
+  } else if (universal_is_mentioned_by_requirements(&peffect->reqs,
+                                                    cbdata->filter)) {
     cbdata->edit->add_effect_to_list(peffect, cbdata);
   }
 

--- a/freeciv/freeciv/tools/ruledit/validity.h
+++ b/freeciv/freeciv/tools/ruledit/validity.h
@@ -17,9 +17,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-bool universal_in_req_vec(const struct universal *uni,
-                          const struct requirement_vector *preqs);
-
 typedef void (*requirers_cb)(const char *msg, void *data);
 
 bool is_tech_needed(struct advance *padv, requirers_cb cb, void *data);

--- a/freeciv/freeciv/tools/ruleutil/comments.c
+++ b/freeciv/freeciv/tools/ruleutil/comments.c
@@ -70,34 +70,53 @@ bool comments_load(void)
     return FALSE;
   }
 
-  comments_storage.file_header = fc_strdup(secfile_lookup_str(comment_file, "common.header"));
-  comments_storage.buildings = fc_strdup(secfile_lookup_str(comment_file, "typedoc.buildings"));
-  comments_storage.tech_classes = fc_strdup(secfile_lookup_str(comment_file, "typedoc.tech_classes"));
-  comments_storage.techs = fc_strdup(secfile_lookup_str(comment_file, "typedoc.techs"));
-  comments_storage.govs = fc_strdup(secfile_lookup_str(comment_file, "typedoc.governments"));
-  comments_storage.policies = fc_strdup(secfile_lookup_str(comment_file, "typedoc.policies"));
-  comments_storage.uclasses = fc_strdup(secfile_lookup_str(comment_file, "typedoc.uclasses"));
-  comments_storage.utypes = fc_strdup(secfile_lookup_str(comment_file, "typedoc.utypes"));
-  comments_storage.terrains = fc_strdup(secfile_lookup_str(comment_file, "typedoc.terrains"));
-  comments_storage.resources = fc_strdup(secfile_lookup_str(comment_file, "typedoc.resources"));
-  comments_storage.extras = fc_strdup(secfile_lookup_str(comment_file, "typedoc.extras"));
-  comments_storage.bases = fc_strdup(secfile_lookup_str(comment_file, "typedoc.bases"));
-  comments_storage.roads = fc_strdup(secfile_lookup_str(comment_file, "typedoc.roads"));
-  comments_storage.styles = fc_strdup(secfile_lookup_str(comment_file, "typedoc.styles"));
-  comments_storage.citystyles = fc_strdup(secfile_lookup_str(comment_file, "typedoc.citystyles"));
-  comments_storage.musicstyles = fc_strdup(secfile_lookup_str(comment_file, "typedoc.musicstyles"));
-  comments_storage.effects = fc_strdup(secfile_lookup_str(comment_file, "typedoc.effects"));
-  comments_storage.disasters = fc_strdup(secfile_lookup_str(comment_file, "typedoc.disasters"));
-  comments_storage.achievements = fc_strdup(secfile_lookup_str(comment_file,
-                                                               "typedoc.achievements"));
-  comments_storage.goods = fc_strdup(secfile_lookup_str(comment_file, "typedoc.goods"));
-  comments_storage.enablers = fc_strdup(secfile_lookup_str(comment_file, "typedoc.enablers"));
-  comments_storage.specialists = fc_strdup(secfile_lookup_str(comment_file, "typedoc.specialists"));
-  comments_storage.nations = fc_strdup(secfile_lookup_str(comment_file, "typedoc.nations"));
-  comments_storage.nationgroups = fc_strdup(secfile_lookup_str(comment_file,
-                                                               "typedoc.nationgroups"));
-  comments_storage.nationsets = fc_strdup(secfile_lookup_str(comment_file, "typedoc.nationsets"));
-  comments_storage.clauses = fc_strdup(secfile_lookup_str(comment_file, "typedoc.clauses"));
+#define comment_load(target, comment_file, comment_path)                  \
+{                                                                         \
+  const char *comment;                                                    \
+                                                                          \
+  if ((comment = secfile_lookup_str(comment_file, comment_path))) {       \
+    target = fc_strdup(comment);                                          \
+  } else {                                                                \
+    return FALSE;                                                         \
+  }                                                                       \
+}
+
+  comment_load(comments_storage.file_header, comment_file, "common.header");
+  comment_load(comments_storage.buildings,
+               comment_file, "typedoc.buildings");
+  comment_load(comments_storage.tech_classes,
+               comment_file, "typedoc.tech_classes");
+  comment_load(comments_storage.techs, comment_file, "typedoc.techs");
+  comment_load(comments_storage.govs, comment_file, "typedoc.governments");
+  comment_load(comments_storage.policies, comment_file, "typedoc.policies");
+  comment_load(comments_storage.uclasses, comment_file, "typedoc.uclasses");
+  comment_load(comments_storage.utypes, comment_file, "typedoc.utypes");
+  comment_load(comments_storage.terrains, comment_file, "typedoc.terrains");
+  comment_load(comments_storage.resources,
+               comment_file, "typedoc.resources");
+  comment_load(comments_storage.extras, comment_file, "typedoc.extras");
+  comment_load(comments_storage.bases, comment_file, "typedoc.bases");
+  comment_load(comments_storage.roads, comment_file, "typedoc.roads");
+  comment_load(comments_storage.styles, comment_file, "typedoc.styles");
+  comment_load(comments_storage.citystyles,
+               comment_file, "typedoc.citystyles");
+  comment_load(comments_storage.musicstyles,
+               comment_file, "typedoc.musicstyles");
+  comment_load(comments_storage.effects, comment_file, "typedoc.effects");
+  comment_load(comments_storage.disasters,
+               comment_file, "typedoc.disasters");
+  comment_load(comments_storage.achievements,
+               comment_file, "typedoc.achievements");
+  comment_load(comments_storage.goods, comment_file, "typedoc.goods");
+  comment_load(comments_storage.enablers, comment_file, "typedoc.enablers");
+  comment_load(comments_storage.specialists,
+               comment_file, "typedoc.specialists");
+  comment_load(comments_storage.nations, comment_file, "typedoc.nations");
+  comment_load(comments_storage.nationgroups,
+               comment_file, "typedoc.nationgroups");
+  comment_load(comments_storage.nationsets,
+               comment_file, "typedoc.nationsets");
+  comment_load(comments_storage.clauses, comment_file, "typedoc.clauses");
 
   secfile_check_unused(comment_file);
   secfile_destroy(comment_file);


### PR DESCRIPTION
Going forward from this set (to the next freeciv.org commit) will first require some planning how to handle ruleset updates as it will change the format.
Two medium risk commits in this small set.

--

There's a semantic fix to Hut extras handling. It can theoretically affect exotic, or simply badly implemented, hut extras that depended on buggy handling. In reality it's unlikely to affect any ruleset.

There's a mapimg fix that replaces old FCW modification. I think that FCW already was immune to division by zero (crash) part of the bug thanks to that modification, but otherwise the calculation was off.