### PR TITLE
Define freeciv source dir and install dir separately

### DIFF
--- a/scripts/helpdata_gen/ruleset_auto_gen.sh
+++ b/scripts/helpdata_gen/ruleset_auto_gen.sh
@@ -15,19 +15,19 @@
 resolve() { echo "$(cd "$1" >/dev/null && pwd)"; }
 while [[ $# -gt 0 ]]; do
   case $1 in
-    -f) FREECIV_DIR=$(resolve "$2"); shift; shift;;
+    -i) INSTALL_DIR=$(resolve "$2"); shift; shift;;
     -o) WEBAPP_DIR=$(resolve "$2"); shift; shift;;
     *) echo "Unrecognized argument: $1"; shift;;
   esac
 done
-: ${FREECIV_DIR:?Must specify (original) freeciv project dir with -f}
+: ${INSTALL_DIR:?Must specify freeciv install dir with -i}
 : ${WEBAPP_DIR:?Must specify existing freeciv-web (webapp) dir with -o}
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 MAN_DIR="${WEBAPP_DIR}/man"
 
-freeciv_manual="${FREECIV_DIR}/tools/freeciv-manual"
+freeciv_manual="${INSTALL_DIR}/tools/freeciv-manual"
 
 mkdir -p "${MAN_DIR}" && \
 cd "${MAN_DIR}" && \

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -295,6 +295,7 @@ echo "${mig_scripts[-1]}" > checkpoint
 mkdir -p "${basedir}/freeciv-web/src/derived/webapp" && \
 "${basedir}"/scripts/sync-js-hand.sh \
   -f "${basedir}/freeciv/freeciv" \
+  -i "${basedir}/freeciv/freeciv" \
   -o "${basedir}/freeciv-web/src/derived/webapp" \
   -d "${TOMCAT_HOME}/webapps/data" || \
   handle_error 6 "Failed to synchronize freeciv project"

--- a/scripts/sync-js-hand.sh
+++ b/scripts/sync-js-hand.sh
@@ -9,12 +9,14 @@ resolve() { echo "$(cd "$1" >/dev/null && pwd)"; }
 while [[ $# -gt 0 ]]; do
   case $1 in
     -f) FREECIV_DIR=$(resolve "$2"); shift; shift;;
+    -i) INSTALL_DIR=$(resolve "$2"); shift; shift;;
     -o) WEBAPP_DIR=$(resolve "$2"); shift; shift;;
     -d) DATA_APP_DIR=$(resolve "$2"); shift; shift;;
     *) echo "Unrecognized argument: $1"; shift;;
   esac
 done
 : ${FREECIV_DIR:?Must specify (original) freeciv project dir with -f}
+: ${INSTALL_DIR:?Must specify freeciv install dir with -i}
 : ${WEBAPP_DIR:?Must specify existing freeciv-web (webapp) dir with -o}
 : ${DATA_APP_DIR:?Must specify existing save-game data (webapp) dir with -d}
 
@@ -35,7 +37,7 @@ mkdir -p "${DOCS_DEST}" "${JS_DEST}" "${SOUNDS_DEST}" "${GAME_DEST}" && \
 #sync-with-flags.sh is called. Which we should always avoid, except during first time ./install.sh
 #"${DIR}"/freeciv-img-extract/sync-with-flags.sh -f "${FREECIV_DIR}" -o "${WEBAPP_DIR}" && \
 "${DIR}"/freeciv-img-extract/sync.sh -f "${FREECIV_DIR}" -o "${WEBAPP_DIR}" && \
-"${DIR}"/helpdata_gen/ruleset_auto_gen.sh -f "${FREECIV_DIR}" -o "${WEBAPP_DIR}" && \
+"${DIR}"/helpdata_gen/ruleset_auto_gen.sh -i "${INSTALL_DIR}" -o "${WEBAPP_DIR}" && \
 "${DIR}"/generate_js_hand/generate_js_hand.py -f "${FREECIV_DIR}" -o "${WEBAPP_DIR}" && \
 "${DIR}"/gen_event_types/gen_event_types.py -f "${FREECIV_DIR}" -o "${WEBAPP_DIR}" && \
 "${DIR}"/helpdata_gen/helpdata_gen.py -f "${FREECIV_DIR}" -o "${WEBAPP_DIR}" && \

--- a/scripts/vagrant-sync-js-hand.sh
+++ b/scripts/vagrant-sync-js-hand.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./sync-js-hand.sh -f "/vagrant/freeciv/freeciv" -o "/vagrant/freeciv-web/src/derived/webapp" -d "/var/lib/tomcat8/webapps/data"
+./sync-js-hand.sh -f "/vagrant/freeciv/freeciv" -i "/vagrant/freeciv/freeciv" -o "/vagrant/freeciv-web/src/derived/webapp" -d "/var/lib/tomcat8/webapps/data"


### PR DESCRIPTION
They still are the same directory, but this is a preparatory
step for making them different in the future.
Installing in top of source directory is bad as
1) that pollutes source directory
2) the two directories have different hierarchy; some files
   are twice in the different parts of the combined hierarchy
3) some source files get overwritten by install ones, though
   usually by identical ones

Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>