### PR TITLE
Freeciv server update (git cherry-pick demo)

### DIFF
--- a/freeciv/freeciv/Makefile.am
+++ b/freeciv/freeciv/Makefile.am
@@ -76,6 +76,7 @@ EXTRA_DIST =	autogen.sh 			\
 		m4/winsock2.m4			\
 		m4/testmatic.m4			\
 		meson.build			\
+		meson_options.txt		\
 		scripts/mapimg2anim		\
 		scripts/setup_auth_server.sh	\
 		scripts/diff_ignore		\

--- a/freeciv/freeciv/data/civ1/game.ruleset
+++ b/freeciv/freeciv/data/civ1/game.ruleset
@@ -44,6 +44,7 @@ differences.\
 ; description = ""
 
 ; What capabilities ruleset provides for the scenarios.
+; See doc/README.rulesets for definitions of official capabilities
 capabilities = ""
 
 [options]

--- a/freeciv/freeciv/data/civ2/game.ruleset
+++ b/freeciv/freeciv/data/civ2/game.ruleset
@@ -40,8 +40,8 @@ You are playing with civ2 style rules. These are\
 ; description = ""
 
 ; What capabilities ruleset provides for the scenarios.
-; mimimum-default-sets - Default units, terrains, buildings, etc
-capabilities = "minimum-default-sets"
+; See doc/README.rulesets for definitions of official capabilities
+capabilities = ""
 
 [options]
 global_init_techs=""

--- a/freeciv/freeciv/data/civ2civ3/game.ruleset
+++ b/freeciv/freeciv/data/civ2civ3/game.ruleset
@@ -48,8 +48,9 @@ The differences from the former default ruleset, 'classic', are listed in\
 description = *civ2civ3/README.civ2civ3*
 
 ; What capabilities ruleset provides for the scenarios.
-; mimimum-default-sets - Default units, terrains, buildings, etc
-capabilities = "minimum-default-sets"
+; See doc/README.rulesets for definitions of official capabilities
+; std-terrains         - At least standard set of terrains
+capabilities = "std-terrains"
 
 [options]
 global_init_techs=""

--- a/freeciv/freeciv/data/classic/game.ruleset
+++ b/freeciv/freeciv/data/classic/game.ruleset
@@ -40,8 +40,9 @@ the rules of the game.\n\n\
 description = *classic/README.classic*
 
 ; What capabilities ruleset provides for the scenarios.
-; mimimum-default-sets - Default units, terrains, buildings, etc
-capabilities = "minimum-default-sets"
+; See doc/README.rulesets for definitions of official capabilities
+; std-terrains         - At least standard set of terrains
+capabilities = "std-terrains"
 
 [options]
 global_init_techs=""

--- a/freeciv/freeciv/data/experimental/game.ruleset
+++ b/freeciv/freeciv/data/experimental/game.ruleset
@@ -52,8 +52,9 @@ classic ruleset can be found in README.experimental.\
 description = *experimental/README.experimental*
 
 ; What capabilities ruleset provides for the scenarios.
-; mimimum-default-sets - Default units, terrains, buildings, etc
-capabilities = "minimum-default-sets"
+; See doc/README.rulesets for definitions of official capabilities
+; std-terrains         - At least standard set of terrains
+capabilities = "std-terrains"
 
 [options]
 global_init_techs=""

--- a/freeciv/freeciv/data/multiplayer/game.ruleset
+++ b/freeciv/freeciv/data/multiplayer/game.ruleset
@@ -43,8 +43,9 @@ the differences can be found in README.multiplayer.\
 description = *multiplayer/README.multiplayer*
 
 ; What capabilities ruleset provides for the scenarios.
-; mimimum-default-sets - Default units, terrains, buildings, etc
-capabilities = "minimum-default-sets"
+; See doc/README.rulesets for definitions of official capabilities
+; std-terrains         - At least standard set of terrains
+capabilities = "std-terrains"
 
 [options]
 global_init_techs=""

--- a/freeciv/freeciv/data/sandbox/game.ruleset
+++ b/freeciv/freeciv/data/sandbox/game.ruleset
@@ -46,8 +46,9 @@ as it stood in 2.6.\
 description = *sandbox/README.sandbox*
 
 ; What capabilities ruleset provides for the scenarios.
-; mimimum-default-sets - Default units, terrains, buildings, etc
-capabilities = "minimum-default-sets"
+; See doc/README.rulesets for definitions of official capabilities
+; std-terrains         - At least standard set of terrains
+capabilities = "std-terrains"
 
 [options]
 global_init_techs=""

--- a/freeciv/freeciv/data/scenarios/british-isles.sav
+++ b/freeciv/freeciv/data/scenarios/british-isles.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/scenarios/earth-large.sav
+++ b/freeciv/freeciv/data/scenarios/earth-large.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/scenarios/earth-small.sav
+++ b/freeciv/freeciv/data/scenarios/earth-small.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/scenarios/europe.sav
+++ b/freeciv/freeciv/data/scenarios/europe.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/scenarios/france.sav
+++ b/freeciv/freeciv/data/scenarios/france.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/scenarios/hagworld.sav
+++ b/freeciv/freeciv/data/scenarios/hagworld.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/scenarios/iberian-peninsula.sav
+++ b/freeciv/freeciv/data/scenarios/iberian-peninsula.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/scenarios/italy.sav
+++ b/freeciv/freeciv/data/scenarios/italy.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/scenarios/japan.sav
+++ b/freeciv/freeciv/data/scenarios/japan.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/scenarios/north_america.sav
+++ b/freeciv/freeciv/data/scenarios/north_america.sav
@@ -10,6 +10,8 @@ players=FALSE
 startpos_nations=FALSE
 lake_flooding=TRUE
 handmade=TRUE
+ruleset_locked=FALSE
+ruleset_caps="+std-terrains"
 
 [savefile]
 options=" +version3"

--- a/freeciv/freeciv/data/webperimental/game.ruleset
+++ b/freeciv/freeciv/data/webperimental/game.ruleset
@@ -44,8 +44,9 @@ webperimental ruleset feed back and suggestion thread.\
 description = *webperimental/README.webperimental*
 
 ; What capabilities ruleset provides for the scenarios.
-; mimimum-default-sets - Default units, terrains, buildings, etc
-capabilities = "minimum-default-sets"
+; See doc/README.rulesets for definitions of official capabilities
+; std-terrains         - At least standard set of terrains
+capabilities = "std-terrains"
 
 [options]
 global_init_techs=""

--- a/freeciv/freeciv/doc/INSTALL.Cygwin
+++ b/freeciv/freeciv/doc/INSTALL.Cygwin
@@ -28,6 +28,7 @@ a) Install or update your Cygwin by downloading and running installer
    - libiconv-devel (Libs)
    - libcurl-devel (Libs)
    - zlib-devel (Libs)
+   - libicu-devel (Libs)
 
   Install development packages for the guis you want to compile, one or more of
   - libgtk3-devel (Libs)

--- a/freeciv/freeciv/doc/README.rulesets
+++ b/freeciv/freeciv/doc/README.rulesets
@@ -137,6 +137,24 @@ set =
     }
 
 ----------------------------------------------------------------------
+Scenario capabilities:
+----------------------
+
+Some scenarios can be unlocked from a ruleset, meaning that they are not
+meant to be used with strictly one ruleset only. To control that such
+a scenario file and a ruleset are compatible, capabilities are used.
+Scenario file lists capabilities it requires from the ruleset, and
+ruleset lists capabilities it provides.
+
+Some standard capabilities are:
+
+std-terrains
+  Ruleset provides at least terrain types Inaccessible, Lake, Ocean,
+  Deep Ocean, Glacier, Desert, Forest, Grassland, Hills, Jungle,
+  Mountains, Plains, Swamp, Tundra.
+  Ruleset provides River extra
+
+----------------------------------------------------------------------
 Update information:
 -------------------
 

--- a/freeciv/freeciv/meson.build
+++ b/freeciv/freeciv/meson.build
@@ -1,5 +1,5 @@
 
-project('freeciv', 'c', meson_version: '>= 0.36.0')
+project('freeciv', 'c', meson_version: '>= 0.44.0')
 
 priv_conf_data = configuration_data()
 pub_conf_data = configuration_data()
@@ -443,6 +443,8 @@ executable('freeciv-server',
   install: true
   )
 
+if get_option('clients') != []
+
 client_common = static_library('fc_client_common',
   'client/agents/agents.c',
   'client/agents/cma_core.c',
@@ -494,6 +496,10 @@ client_common = static_library('fc_client_common',
   dependencies: [c_compiler.find_library('m'),
                  c_compiler.find_library('libSDL2_mixer')]
   )
+
+endif
+
+if get_option('clients').contains('gtk3.22')
 
 gtk322_dep = dependency('gtk+-3.0', version : '>= 3.22')
 
@@ -549,6 +555,8 @@ executable('freeciv-gtk3.22',
   link_with: client_common,
   install: true
   )
+
+endif
 
 tool_lib = static_library('fc_toolutil',
   'tools/ruleutil/comments.c',

--- a/freeciv/freeciv/meson_options.txt
+++ b/freeciv/freeciv/meson_options.txt
@@ -1,0 +1,5 @@
+option('clients',
+       type: 'array',
+       choices: ['gtk3.22'],
+       value: ['gtk3.22'],
+       description: 'Clients to build')


### PR DESCRIPTION
I discovered that git cherry-pick with the subtree merge strategy is intelligent enough to back port patches from Freeciv to fcw.org-server even if  fcw.org-server merged Freeciv without adding its history as a parent via a merge commit. This is the result of running

git cherry-pick -x --strategy=subtree bfeddb8de921b388ded19e554757cfd436eb7d7e..fafae400e1c504bedf03e74d4522b287d517df23

as bfeddb8de921b388ded19e554757cfd436eb7d7e was the last commit that I saw Marko had back ported. I have not yet built fcw.org-server so this is completely untested.

@cazfi: You have much more experience with fcw.org-server than I do. Does this look OK to you?