### PR TITLE
Fix multiple definition of `encoded_unit_emoji' linking errors

### DIFF
--- a/freeciv/freeciv/server/unittools.c
+++ b/freeciv/freeciv/server/unittools.c
@@ -85,6 +85,7 @@
 
 #include "unittools.h"
 
+char encoded_unit_emoji[128];
 
 /* Tools for controlling the client vision of every unit when a unit
  * moves + script effects. See unit_move(). You can access this data with

--- a/freeciv/freeciv/server/unittools.h
+++ b/freeciv/freeciv/server/unittools.h
@@ -189,7 +189,8 @@ bool is_unit_plural(struct unit *punit);
 
 /* get unit emoji icon for FCW */
 char *get_web_unit_icon(const struct unit *punit, char *unit_emoji_str);
-char encoded_unit_emoji[128];
+
+extern char encoded_unit_emoji[128];
 // This macro uses a global string (above) for ease, but if you make two calls to it inside a
 // single text creation (a sprintf or notify_player() call,) one result would overwrite the other.
 // In those cases, do it yourself with get_web_unit_icon() and your own separate strings:


### PR DESCRIPTION
Trying to build with newer buildchain I got endless stream
of linker failures about encoded_unit_emoji:

  CCLD     freeciv-server
/usr/bin/ld: ./.libs/libfreeciv-srv.a(techtools.o):(.bss+0x0): multiple definition of `encoded_unit_emoji'; ./.libs/libfreeciv-srv.a(srv_main.o):(.bss+0x0): first defined here
/usr/bin/ld: ./.libs/libfreeciv-srv.a(unittools.o):(.bss+0x0): multiple definition of `encoded_unit_emoji'; ./.libs/libfreeciv-srv.a(srv_main.o):(.bss+0x0): first defined here
/usr/bin/ld: ./.libs/libfreeciv-srv.a(advdata.o):(.bss+0x0): multiple definition of `encoded_unit_emoji'; ./.libs/libfreeciv-srv.a(srv_main.o):(.bss+0x0): first defined here
/usr/bin/ld: ./.libs/libfreeciv-srv.a(advgoto.o):(.bss+0x0): multiple definition of `encoded_unit_emoji'; ./.libs/libfreeciv-srv.a(srv_main.o):(.bss+0x0): first defined here

...