### PR TITLE
Srvup

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/fc_types.js
+++ b/freeciv-web/src/main/webapp/javascript/fc_types.js
@@ -55,7 +55,9 @@ var ACTIVITY_FALLOUT = 16;
 var ACTIVITY_BASE = 18;			/* building base */
 var ACTIVITY_GEN_ROAD = 19;
 var ACTIVITY_CONVERT = 20;
-var ACTIVITY_LAST = 21;   /* leave this one last */
+var ACTIVITY_CULTIVATE = 21;
+var ACTIVITY_PLANT = 22;
+var ACTIVITY_LAST = 23;   /* leave this one last */
 
 var IDENTITY_NUMBER_ZERO = 0;
 

--- a/freeciv/freeciv/ai/default/aitools.c
+++ b/freeciv/freeciv/ai/default/aitools.c
@@ -939,6 +939,7 @@ bool dai_unit_move(struct ai_type *ait, struct unit *punit, struct tile *ptile)
   }
 
   /* barbarians shouldn't enter huts */
+  /* FIXME: use unit_can_displace_hut(punit, ptile) better */
   if (is_barbarian(pplayer) && hut_on_tile(ptile)) {
     return FALSE;
   }

--- a/freeciv/freeciv/ai/default/aiunit.c
+++ b/freeciv/freeciv/ai/default/aiunit.c
@@ -495,9 +495,8 @@ static int dai_rampage_want(struct unit *punit, struct tile *ptile)
 
     /* ...or tiny pleasant hut here! */
     /* FIXME: unhardcode and variate the desire to enter a hut. */
-    if (hut_on_tile(ptile) && !is_barbarian(pplayer)
-        && is_native_tile(unit_type_get(punit), ptile)
-        && unit_class_get(punit)->hut_behavior == HUT_NORMAL) {
+    if (unit_can_enter_hut(punit, ptile) && !is_barbarian(pplayer)
+        && is_native_tile(unit_type_get(punit), ptile)) {
       return -RAMPAGE_HUT_OR_BETTER;
     }
   }

--- a/freeciv/freeciv/client/gui-gtk-3.0/menu.c
+++ b/freeciv/freeciv/client/gui-gtk-3.0/menu.c
@@ -1822,7 +1822,7 @@ static void menu_entry_init(GtkBuildable *item)
       if (path == NULL) {
         char buf[512];
 
-        fc_snprintf(buf, sizeof(buf), "<MENU>/%s", key + strlen("MENU_"));
+        fc_snprintf(buf, sizeof(buf), "<MENU>/%s", key);
         gtk_menu_item_set_accel_path(GTK_MENU_ITEM(item), buf);
         path = buf; /* Not NULL, but not usable either outside this block */
       }

--- a/freeciv/freeciv/client/gui-gtk-3.22/menu.c
+++ b/freeciv/freeciv/client/gui-gtk-3.22/menu.c
@@ -1833,7 +1833,7 @@ static void menu_entry_init(GtkBuildable *item)
       if (path == NULL) {
         char buf[512];
 
-        fc_snprintf(buf, sizeof(buf), "<MENU>/%s", key + strlen("MENU_"));
+        fc_snprintf(buf, sizeof(buf), "<MENU>/%s", key);
         gtk_menu_item_set_accel_path(GTK_MENU_ITEM(item), buf);
         path = buf; /* Not NULL, but not usable either outside this block */
       }

--- a/freeciv/freeciv/client/gui-gtk-4.0/menu.c
+++ b/freeciv/freeciv/client/gui-gtk-4.0/menu.c
@@ -1821,7 +1821,7 @@ static void menu_entry_init(GtkBuildable *item)
       if (path == NULL) {
         char buf[512];
 
-        fc_snprintf(buf, sizeof(buf), "<MENU>/%s", key + strlen("MENU_"));
+        fc_snprintf(buf, sizeof(buf), "<MENU>/%s", key);
         gtk_menu_item_set_accel_path(GTK_MENU_ITEM(item), buf);
         path = buf; /* Not NULL, but not usable either outside this block */
       }

--- a/freeciv/freeciv/client/gui-qt/plrdlg.cpp
+++ b/freeciv/freeciv/client/gui-qt/plrdlg.cpp
@@ -465,7 +465,7 @@ void plr_widget::nation_selected(const QItemSelection &sl,
   if (player_has_embassy(me, pplayer)) {
     etax = QString::number(pplayer->economic.tax) + "%";
     esci = QString::number(pplayer->economic.science) + "%";
-    elux = QString::number(pplayer->economic.science) + "%";
+    elux = QString::number(pplayer->economic.luxury) + "%";
     cult = QString::number(pplayer->client.culture);
   } else {
     etax = _("(Unknown)");

--- a/freeciv/freeciv/client/helpdata.c
+++ b/freeciv/freeciv/client/helpdata.c
@@ -3417,6 +3417,11 @@ void helptext_extra(char *buf, size_t bufsz, struct player *pplayer,
             _("Placed by map generator.\n"));
   }
 
+  if (is_extra_removed_by(pextra, ERM_ENTER)) {
+    CATLSTR(buf, bufsz,
+            _("Can be explored by certain units.\n"));
+  }
+
   if (is_extra_caused_by(pextra, EC_APPEARANCE)) {
     CATLSTR(buf, bufsz,
             _("May appear spontaneously.\n"));
@@ -3527,6 +3532,19 @@ void helptext_extra(char *buf, size_t bufsz, struct player *pplayer,
                    PL_("Can be cleaned by units (takes %d turn).\n",
                        "Can be cleaned by units (takes %d turns).\n",
                        clean_time), clean_time);
+    }
+  }
+
+  if (requirement_vector_size(&pextra->rmreqs) > 0) {
+    char reqsbuf[8192] = "";
+
+    requirement_vector_iterate(&pextra->rmreqs, preq) {
+      (void) req_text_insert_nl(reqsbuf, sizeof(reqsbuf), pplayer, preq,
+                                VERB_DEFAULT, Q_("?bullet:* "));
+    } requirement_vector_iterate_end;
+    if (reqsbuf[0] != '\0') {
+      CATLSTR(buf, bufsz, _("Requirements to remove:\n"));
+      CATLSTR(buf, bufsz, reqsbuf);
     }
   }
 

--- a/freeciv/freeciv/client/tilespec.c
+++ b/freeciv/freeciv/client/tilespec.c
@@ -76,12 +76,12 @@
 
 #include "tilespec.h"
 
-#define TILESPEC_CAPSTR "+Freeciv-tilespec-Devel-2016-Jun-07 duplicates_ok"
+#define TILESPEC_CAPSTR "+Freeciv-tilespec-Devel-2019-Jul-03 duplicates_ok"
 /*
  * Tilespec capabilities acceptable to this program:
  *
- * +Freeciv-2.4-tilespec
- *    - basic format for Freeciv versions 2.4.x; required
+ * +Freeciv-3.1-tilespec
+ *    - basic format for Freeciv versions 3.1.x; required
  *
  * +Freeciv-tilespec-Devel-YYYY.MMM.DD
  *    - tilespec of the development version at the given data
@@ -92,12 +92,12 @@
  *      "duplicates_ok")
  */
 
-#define SPEC_CAPSTR "+Freeciv-spec-Devel-2019-Mar-09"
+#define SPEC_CAPSTR "+Freeciv-spec-Devel-2019-Jul-03"
 /*
  * Individual spec file capabilities acceptable to this program:
  *
- * +Freeciv-3.0-spec
- *    - basic format for Freeciv versions 3.0.x; required
+ * +Freeciv-3.1-spec
+ *    - basic format for Freeciv versions 3.1.x; required
  */
 
 #define TILESPEC_SUFFIX ".tilespec"

--- a/freeciv/freeciv/client/tilespec.c
+++ b/freeciv/freeciv/client/tilespec.c
@@ -5378,6 +5378,7 @@ static int fill_goto_sprite_array(const struct tileset *t,
 
 /************************************************************************//**
   Should the given extra be drawn
+  FIXME: Some extras can not be switched
 ****************************************************************************/
 static bool is_extra_drawing_enabled(struct extra_type *pextra)
 {
@@ -5408,7 +5409,7 @@ static bool is_extra_drawing_enabled(struct extra_type *pextra)
     }
     no_disable = FALSE;
   }
-  if (is_extra_caused_by(pextra, EC_HUT)) {
+  if (is_extra_removed_by(pextra, ERM_ENTER)) {
     if (gui_options.draw_huts) {
       return TRUE;
     }

--- a/freeciv/freeciv/common/actions.c
+++ b/freeciv/freeciv/common/actions.c
@@ -1316,11 +1316,13 @@ enum unit_activity action_get_activity(const struct action *paction)
     return ACTIVITY_TRANSFORM;
   } else if (action_has_result(paction, ACTION_CONVERT)) {
     return ACTIVITY_CONVERT;
-  } else if (action_has_result(paction, ACTION_PLANT)
-             || action_has_result(paction, ACTION_MINE)) {
+  } else if (action_has_result(paction, ACTION_PLANT)) {
+    return ACTIVITY_PLANT;
+  } else if (action_has_result(paction, ACTION_MINE)) {
     return ACTIVITY_MINE;
-  } else if (action_has_result(paction, ACTION_CULTIVATE)
-             || action_has_result(paction, ACTION_IRRIGATE)) {
+  } else if (action_has_result(paction, ACTION_CULTIVATE)) {
+    return ACTIVITY_CULTIVATE;
+  } else if (action_has_result(paction, ACTION_IRRIGATE)) {
     return ACTIVITY_IRRIGATE;
   } else {
     return ACTIVITY_LAST;
@@ -1353,6 +1355,8 @@ int action_get_act_time(const struct action *paction,
   case ACTIVITY_GEN_ROAD:
   case ACTIVITY_IRRIGATE:
   case ACTIVITY_MINE:
+  case ACTIVITY_CULTIVATE:
+  case ACTIVITY_PLANT:
   case ACTIVITY_TRANSFORM:
     return tile_activity_time(pactivity, tgt_tile, tgt_extra);
   case ACTIVITY_FORTIFYING:

--- a/freeciv/freeciv/common/aicore/path_finding.c
+++ b/freeciv/freeciv/common/aicore/path_finding.c
@@ -2886,7 +2886,7 @@ static bool pf_fuel_map_iterate(struct pf_map *pfm)
           if (cost == PF_IMPOSSIBLE_MC) {
             continue;
           }
-        } else if (cost == PF_IMPOSSIBLE_MC - 2) {
+        } else if (cost == PF_IMPOSSIBLE_MC + 2) {
           continue;
         } else {
           cost -= 2;

--- a/freeciv/freeciv/common/aicore/path_finding.c
+++ b/freeciv/freeciv/common/aicore/path_finding.c
@@ -2870,10 +2870,18 @@ static bool pf_fuel_map_iterate(struct pf_map *pfm)
             cost = params->get_MC(tile, scope, tile1, node1->move_scope,
                                   params);
           }
+
+          if (cost == FC_INFINITY) {
+            /* tile_move_cost_ptrs() uses FC_INFINITY to flag that all
+             * movement is spent, e.g., when disembarking from transport. */
+            cost = params->move_rate;
+          }
+
 #ifdef PF_DEBUG
           fc_assert(1 << (8 * sizeof(node1->cost_to_here[dir])) > cost + 2);
           fc_assert(0 < cost + 2);
-#endif
+#endif /* PF_DEBUG */
+
           node1->cost_to_here[dir] = cost + 2;
           if (cost == PF_IMPOSSIBLE_MC) {
             continue;

--- a/freeciv/freeciv/common/aicore/path_finding.c
+++ b/freeciv/freeciv/common/aicore/path_finding.c
@@ -2937,7 +2937,8 @@ static bool pf_fuel_map_iterate(struct pf_map *pfm)
         /* Step 1: We test if this route is the best to this tile, by a
          * direct way, not taking in account waiting. */
 
-        if (NS_INIT == node1->status || cost_of_path < old_cost_of_path) {
+        if (NS_INIT == node1->status
+            || (node1->status == NS_NEW && cost_of_path < old_cost_of_path)) {
           /* We are reaching this node for the first time, or we found a
            * better route to 'tile1', or we would have more moves lefts
            * at previous position. Let's register 'tindex1' to the
@@ -3047,6 +3048,7 @@ static bool pf_fuel_map_iterate(struct pf_map *pfm)
     } else {
 #ifdef PF_DEBUG
       bool success = map_index_pq_remove(pffm->queue, &tindex);
+
       fc_assert(TRUE == success);
 #else
       map_index_pq_remove(pffm->queue, &tindex);
@@ -3056,9 +3058,10 @@ static bool pf_fuel_map_iterate(struct pf_map *pfm)
       tile = index_to_tile(params->map, tindex);
       pfm->tile = tile;
       node = pffm->lattice + tindex;
+
 #ifdef PF_DEBUG
       fc_assert(NS_PROCESSED != node->status);
-#endif
+#endif /* PF_DEBUG */
 
       if (NS_WAITING != node->status && !pf_fuel_node_dangerous(node)) {
         /* Node status step C. and D. */

--- a/freeciv/freeciv/common/city.h
+++ b/freeciv/freeciv/common/city.h
@@ -26,6 +26,7 @@ extern "C" {
 #include "name_translation.h"
 #include "improvement.h"
 #include "traderoutes.h"
+#include "unit.h"
 #include "unitlist.h"
 #include "vision.h"
 #include "workertask.h"
@@ -395,6 +396,15 @@ struct city {
   int steal; /* diplomats steal once; for spies, gets harder */
 
   struct cm_parameter *cm_parameter;
+
+  struct {
+    int length;
+    /* If true, rally point is active until owner cancels or loses city. */
+    bool persistent;
+    /* Orders should be cleared if an enemy is met. */
+    bool vigilant;
+    struct unit_order *orders;
+  } rally_point;
 
   union {
     struct {

--- a/freeciv/freeciv/common/culture.c
+++ b/freeciv/freeciv/common/culture.c
@@ -18,6 +18,7 @@
 /* common */
 #include "city.h"
 #include "effects.h"
+#include "game.h"
 #include "player.h"
 
 #include "culture.h"
@@ -35,7 +36,8 @@ int city_culture(const struct city *pcity)
 ****************************************************************************/
 int city_history_gain(const struct city *pcity)
 {
-  return get_city_bonus(pcity, EFT_HISTORY);
+  return get_city_bonus(pcity, EFT_HISTORY)
+    + pcity->history * game.info.history_interest_pml / 1000;
 }
 
 /************************************************************************//**
@@ -58,5 +60,6 @@ int player_culture(const struct player *plr)
 ****************************************************************************/
 int nation_history_gain(const struct player *pplayer)
 {
-  return get_player_bonus(pplayer, EFT_NATION_HISTORY);
+  return get_player_bonus(pplayer, EFT_NATION_HISTORY)
+    + pplayer->history * game.info.history_interest_pml / 1000;
 }

--- a/freeciv/freeciv/common/extras.h
+++ b/freeciv/freeciv/common/extras.h
@@ -233,9 +233,12 @@ bool is_native_tile_to_extra(const struct extra_type *pextra,
                              const struct tile *ptile);
 bool extra_conflicting_on_tile(const struct extra_type *pextra,
                                const struct tile *ptile);
-/* This macro defines when there is an extra which is removed by entering.
- * FIXME: invent a rmcause for this purpose and use it instead. */
-#define hut_on_tile(ptile) tile_has_cause_extra((ptile), EC_HUT)
+
+bool hut_on_tile(const struct tile *ptile);
+bool unit_can_enter_hut(const struct unit *punit,
+                        const struct tile *ptile);
+bool unit_can_displace_hut(const struct unit *punit,
+                           const struct tile *ptile);
 
 bool extra_has_flag(const struct extra_type *pextra, enum extra_flag_id flag);
 bool is_extra_flag_card_near(const struct tile *ptile,

--- a/freeciv/freeciv/common/fc_types.h
+++ b/freeciv/freeciv/common/fc_types.h
@@ -784,6 +784,8 @@ FC_STATIC_ASSERT(EC_COUNT < 16, extra_causes_over_limit);
 #define SPECENUM_VALUE2NAME "CleanFallout"
 #define SPECENUM_VALUE3 ERM_DISAPPEARANCE
 #define SPECENUM_VALUE3NAME "Disappear"
+#define SPECENUM_VALUE4 ERM_ENTER
+#define SPECENUM_VALUE4NAME "Enter"
 #define SPECENUM_COUNT ERM_COUNT
 #define SPECENUM_BITVECTOR bv_rmcauses
 #include "specenum_gen.h"

--- a/freeciv/freeciv/common/fc_types.h
+++ b/freeciv/freeciv/common/fc_types.h
@@ -137,6 +137,10 @@ enum output_type_id {
 #define SPECENUM_VALUE19NAME N_("Road")
 #define SPECENUM_VALUE20 ACTIVITY_CONVERT
 #define SPECENUM_VALUE20NAME N_("Convert")
+#define SPECENUM_VALUE21 ACTIVITY_CULTIVATE
+#define SPECENUM_VALUE21NAME N_("Cultivate")
+#define SPECENUM_VALUE22 ACTIVITY_PLANT
+#define SPECENUM_VALUE22NAME N_("Plant")
 #define SPECENUM_COUNT ACTIVITY_LAST
 #include "specenum_gen.h"       // #13 above is now used as Vigil
 

--- a/freeciv/freeciv/common/game.h
+++ b/freeciv/freeciv/common/game.h
@@ -819,7 +819,7 @@ extern struct world wld;
 
 /* ruleset settings */
 
-#define RS_MAX_VALUE                             10000
+#define RS_MAX_VALUE                             1000000
 
 /* TRANS: year label (Anno Domini) */
 #define RS_DEFAULT_POS_YEAR_LABEL                N_("AD")
@@ -904,11 +904,11 @@ extern struct world wld;
 
 #define RS_DEFAULT_HAPPY_COST                    2
 #define RS_MIN_HAPPY_COST                        0
-#define RS_MAX_HAPPY_COST                        100
+#define RS_MAX_HAPPY_COST                        10000
 
 #define RS_DEFAULT_FOOD_COST                     2
 #define RS_MIN_FOOD_COST                         0
-#define RS_MAX_FOOD_COST                         100
+#define RS_MAX_FOOD_COST                         10000
 
 #define RS_DEFAULT_CIVIL_WAR_CELEB               -5
 #define RS_DEFAULT_CIVIL_WAR_UNHAPPY             5
@@ -944,7 +944,7 @@ extern struct world wld;
 
 #define RS_DEFAULT_BASE_TECH_COST                20
 #define RS_MIN_BASE_TECH_COST                    0
-#define RS_MAX_BASE_TECH_COST                    200
+#define RS_MAX_BASE_TECH_COST                    20000
 
 #define RS_DEFAULT_FORCE_TRADE_ROUTE             FALSE
 #define RS_DEFAULT_FORCE_CAPTURE_UNITS           FALSE

--- a/freeciv/freeciv/common/mapimg.c
+++ b/freeciv/freeciv/common/mapimg.c
@@ -640,11 +640,16 @@ char *mapimg_help(const char *cmdname)
   /* Possible 'show' settings. */
   for (showplr = show_player_begin(); showplr != show_player_end();
        showplr = show_player_next(showplr)) {
-    char name[10];
-    fc_snprintf(name, sizeof(name), "'%s'", show_player_name(showplr));
-    astr_add(&str_showplr, " - %-9s %s", name, showname_help(showplr));
-    if (showplr != show_player_max()) {
-      astr_add(&str_showplr, "\n");
+    const char *nameptr = show_player_name(showplr);
+
+    if (nameptr != NULL) {
+      char name[10];
+
+      fc_snprintf(name, sizeof(name), "'%s'", nameptr);
+      astr_add(&str_showplr, " - %-9s %s", name, showname_help(showplr));
+      if (showplr != show_player_max()) {
+        astr_add(&str_showplr, "\n");
+      }
     }
   }
 

--- a/freeciv/freeciv/common/networking/packets.def
+++ b/freeciv/freeciv/common/networking/packets.def
@@ -742,6 +742,15 @@ PACKET_CITY_INFO = 31; sc, lsend, is-game-info, force, cancel(PACKET_CITY_SHORT_
   BV_CITY_OPTIONS city_options;
   ESTRING name[MAX_LEN_CITYNAME];
 
+  UINT16 rally_point_length;
+  BOOL rally_point_persistent;
+  BOOL rally_point_vigilant;
+  ORDERS rally_point_orders[MAX_LEN_ROUTE:rally_point_length];
+  DIRECTION rally_point_dirs[MAX_LEN_ROUTE:rally_point_length];
+  ACTIVITY rally_point_activities[MAX_LEN_ROUTE:rally_point_length];
+  ACTION_SUB_TGT rally_point_sub_targets[MAX_LEN_ROUTE:rally_point_length];
+  ACTION_ID rally_point_actions[MAX_LEN_ROUTE:rally_point_length];
+
   BOOL cma_enabled;
   CM_PARAMETER cm_parameter;
 end
@@ -853,6 +862,18 @@ PACKET_CITY_MANAGER = 139; cs
   BOOL enabled;
   BOOL apply_once;
   CM_PARAMETER parameter;
+end
+
+PACKET_CITY_RALLY_POINT = 138; cs
+  CITY city_id;
+  UINT16 length;
+  BOOL persistent;
+  BOOL vigilant;
+  ORDERS orders[MAX_LEN_ROUTE:length];
+  DIRECTION dirs[MAX_LEN_ROUTE:length];
+  ACTIVITY activities[MAX_LEN_ROUTE:length];
+  ACTION_SUB_TGT sub_targets[MAX_LEN_ROUTE:length];
+  ACTION_ID actions[MAX_LEN_ROUTE:length];
 end
 
 PACKET_WORKER_TASK = 241; cs, sc, lsend, handle-via-packet

--- a/freeciv/freeciv/common/networking/packets.def
+++ b/freeciv/freeciv/common/networking/packets.def
@@ -479,6 +479,7 @@ PACKET_GAME_INFO = 16; sc, is-info
   UINT32 culture_vic_points;
   UINT16 culture_vic_lead;
   UINT16 culture_migration_pml;
+  UINT16 history_interest_pml;
   /* size limit for cities before they can celebrate */
   UINT8 celebratesize;
   BOOL changable_tax;

--- a/freeciv/freeciv/common/tile.c
+++ b/freeciv/freeciv/common/tile.c
@@ -458,6 +458,10 @@ int tile_activity_time(enum unit_activity activity, const struct tile *ptile,
     return terrain_extra_removal_time(pterrain, activity, tgt) * ACTIVITY_FACTOR;
   case ACTIVITY_TRANSFORM:
     return pterrain->transform_time * ACTIVITY_FACTOR;
+  case ACTIVITY_CULTIVATE:
+    return pterrain->irrigation_time * ACTIVITY_FACTOR;
+  case ACTIVITY_PLANT:
+    return pterrain->mining_time * ACTIVITY_FACTOR;
   case ACTIVITY_IRRIGATE:
   case ACTIVITY_MINE:
   case ACTIVITY_BASE:
@@ -659,7 +663,7 @@ static void tile_mine(struct tile *ptile, struct extra_type *tgt)
 }
 
 /************************************************************************//**
-  Transform (ACTIVITY_TRANSFORM) the tile.  This usually changes the tile's
+  Transform (ACTIVITY_TRANSFORM) the tile. This usually changes the tile's
   terrain type.
 ****************************************************************************/
 static void tile_transform(struct tile *ptile)
@@ -668,6 +672,34 @@ static void tile_transform(struct tile *ptile)
 
   if (pterrain->transform_result != T_NONE) {
     tile_change_terrain(ptile, pterrain->transform_result);
+  }
+}
+
+/************************************************************************//**
+  Plant (ACTIVITY_PLANT) the tile. This usually changes the tile's
+  terrain type.
+****************************************************************************/
+static void tile_plant(struct tile *ptile)
+{
+  struct terrain *pterrain = tile_terrain(ptile);
+
+  if (pterrain->mining_result != T_NONE
+      && pterrain->mining_result != pterrain) {
+    tile_change_terrain(ptile, pterrain->mining_result);
+  }
+}
+
+/************************************************************************//**
+  Cultivate (ACTIVITY_CULTIVATE) the tile. This usually changes the tile's
+  terrain type.
+****************************************************************************/
+static void tile_cultivate(struct tile *ptile)
+{
+  struct terrain *pterrain = tile_terrain(ptile);
+
+  if (pterrain->irrigation_result != T_NONE
+      && pterrain->irrigation_result != pterrain) {
+    tile_change_terrain(ptile, pterrain->irrigation_result);
   }
 }
 
@@ -692,6 +724,14 @@ bool tile_apply_activity(struct tile *ptile, Activity_type_id act,
 
   case ACTIVITY_TRANSFORM:
     tile_transform(ptile);
+    return TRUE;
+
+  case ACTIVITY_CULTIVATE:
+    tile_cultivate(ptile);
+    return TRUE;
+
+  case ACTIVITY_PLANT:
+    tile_plant(ptile);
     return TRUE;
 
   case ACTIVITY_OLD_ROAD:

--- a/freeciv/freeciv/common/unit.c
+++ b/freeciv/freeciv/common/unit.c
@@ -534,6 +534,8 @@ bool activity_requires_target(enum unit_activity activity)
   case ACTIVITY_GOTO:
   case ACTIVITY_EXPLORE:
   case ACTIVITY_TRANSFORM:
+  case ACTIVITY_CULTIVATE:
+  case ACTIVITY_PLANT:
   case ACTIVITY_FORTIFYING:
   case ACTIVITY_CONVERT:
     return FALSE;
@@ -612,8 +614,12 @@ const char *get_activity_text(enum unit_activity activity)
   case ACTIVITY_MINE:
     /* TRANS: Activity name, verb in English */
     return _("Plant");
+  case ACTIVITY_PLANT:
+    return _("Plant");
   case ACTIVITY_IRRIGATE:
     return _("Irrigate");
+  case ACTIVITY_CULTIVATE:
+    return _("Cultivate");
   case ACTIVITY_FORTIFYING:
     return _("Fortifying");
   case ACTIVITY_FORTIFIED:
@@ -980,6 +986,18 @@ bool can_unit_do_activity_targeted_at(const struct unit *punit,
       return FALSE;
     }
 
+  case ACTIVITY_PLANT:
+    if (pterrain->mining_result != pterrain
+        && pterrain->mining_result != T_NONE) {
+      /* The call below doesn't support actor tile speculation. */
+      fc_assert_msg(unit_tile(punit) == ptile,
+                    "Please use action_speculate_unit_on_tile()");
+      return is_action_enabled_unit_on_tile(ACTION_PLANT,
+                                            punit, ptile, NULL);
+    } else {
+      return FALSE;
+    }
+
   case ACTIVITY_IRRIGATE:
     if (pterrain->irrigation_result != pterrain
         && pterrain->irrigation_result != T_NONE) {
@@ -998,6 +1016,18 @@ bool can_unit_do_activity_targeted_at(const struct unit *punit,
                     "Please use action_speculate_unit_on_tile()");
       return is_action_enabled_unit_on_tile(ACTION_IRRIGATE, punit,
                                             ptile, target);
+    } else {
+      return FALSE;
+    }
+
+  case ACTIVITY_CULTIVATE:
+    if (pterrain->irrigation_result != pterrain
+        && pterrain->irrigation_result != T_NONE) {
+      /* The call below doesn't support actor tile speculation. */
+      fc_assert_msg(unit_tile(punit) == ptile,
+                    "Please use action_speculate_unit_on_tile()");
+      return is_action_enabled_unit_on_tile(ACTION_CULTIVATE,
+                                            punit, ptile, NULL);
     } else {
       return FALSE;
     }
@@ -1240,6 +1270,8 @@ void unit_activity_astr(const struct unit *punit, struct astring *astr)
   case ACTIVITY_GOTO:
   case ACTIVITY_EXPLORE:
   case ACTIVITY_CONVERT:
+  case ACTIVITY_CULTIVATE:
+  case ACTIVITY_PLANT:
     astr_add_line(astr, "%s", get_activity_text(punit->activity));
     return;
   case ACTIVITY_MINE:

--- a/freeciv/freeciv/configure.ac
+++ b/freeciv/freeciv/configure.ac
@@ -1006,7 +1006,7 @@ FC_LD_FLAGS(["-Wl,-rpath=${lib_prefix}"], [], [LDFLAGS])
 AM_CONDITIONAL([CLIENT], [test "x$client" = "xyes"])
 
 AC_ARG_ENABLE([freeciv-manual],
-  AS_HELP_STRING([--enable-freeciv-manual], [build freeciv-manual]),
+  AS_HELP_STRING([--enable-freeciv-manual], [build freeciv-manual [yes]]),
 [case "${enableval}" in
   yes) fcmanual=yes ;;
   no)  fcmanual=no ;;
@@ -1014,6 +1014,16 @@ AC_ARG_ENABLE([freeciv-manual],
 esac], [fcmanual=yes])
 
 AM_CONDITIONAL([FCMANUAL], [test "x$fcmanual" != "xno"])
+
+AC_ARG_ENABLE([freeciv-ruleup],
+  AS_HELP_STRING([--enable-freeciv-ruleup], [build freeciv-ruleup [yes]]),
+[case "${enableval}" in
+  yes) fcruleup=yes ;;
+  no)  fcruleup=no ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --enable-freeciv-ruleup]) ;;
+esac], [fcruleup=yes])
+
+AM_CONDITIONAL([FCRULEUP], [test "x$fcruleup" != "xno"])
 
 dnl freeciv-modpack checks
 AC_ARG_ENABLE([fcmp],
@@ -1203,8 +1213,6 @@ if test "x$ruledit" = "xtest" ; then
 fi
 AM_CONDITIONAL([RULEDIT], [test "x$ruledit" = "xyes"])
 
-dnl TODO: Make ruleup optional
-fcruleup=yes
 AM_CONDITIONAL([SRV_LIB],
   [test "x$server" = "xyes" || test "x$fcmanual" = "xyes" || test "x$ruledit" = "xyes" || test "x$fcruleup" = "xyes"])
 
@@ -1816,6 +1824,7 @@ AC_MSG_NOTICE([
   == Tools ==
   Modpack installers:   $fcmp_list
   Ruleset editor:        $ruledit
+  Ruleset updater:       $fcruleup
   Manual generator:      $fcmanual
 
   == Gotchas ==

--- a/freeciv/freeciv/data/3d.tilespec
+++ b/freeciv/freeciv/data/3d.tilespec
@@ -1,7 +1,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Trident"

--- a/freeciv/freeciv/data/alien/game.ruleset
+++ b/freeciv/freeciv/data/alien/game.ruleset
@@ -903,6 +903,11 @@ victory_min_points = 1000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/alien/terrain.ruleset
+++ b/freeciv/freeciv/data/alien/terrain.ruleset
@@ -641,8 +641,8 @@ ui_name_base_airbase = _("?gui_type:Build Airforce base")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic
@@ -824,7 +824,7 @@ of pollution appearing each turn.\
 name           = _("Space Capsule")
 category       = "Bonus"
 causes         = "Hut"
-;rmcauses       = ""
+rmcauses       = "Enter"
 graphic        = "tx.capsule"
 graphic_alt    = "tx.village"
 activity_gfx   = "None"

--- a/freeciv/freeciv/data/alio.tilespec
+++ b/freeciv/freeciv/data/alio.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Alio"

--- a/freeciv/freeciv/data/alio/burrowtubes.spec
+++ b/freeciv/freeciv/data/alio/burrowtubes.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/alio/fortresses.spec
+++ b/freeciv/freeciv/data/alio/fortresses.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/alio/hills.spec
+++ b/freeciv/freeciv/data/alio/hills.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 artists = "
 	 Peter Arbor <peter.arbor@gmail.com> (original terrain)

--- a/freeciv/freeciv/data/alio/riversbrown.spec
+++ b/freeciv/freeciv/data/alio/riversbrown.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/alio/riversgreen.spec
+++ b/freeciv/freeciv/data/alio/riversgreen.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/alio/roads.spec
+++ b/freeciv/freeciv/data/alio/roads.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/alio/terrain.spec
+++ b/freeciv/freeciv/data/alio/terrain.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/alio/tunnels.spec
+++ b/freeciv/freeciv/data/alio/tunnels.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio.tilespec
+++ b/freeciv/freeciv/data/amplio.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Amplio"

--- a/freeciv/freeciv/data/amplio/ancientcities.spec
+++ b/freeciv/freeciv/data/amplio/ancientcities.spec
@@ -16,7 +16,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/explosions.spec
+++ b/freeciv/freeciv/data/amplio/explosions.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/fog.spec
+++ b/freeciv/freeciv/data/amplio/fog.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 artists = "

--- a/freeciv/freeciv/data/amplio/grid.spec
+++ b/freeciv/freeciv/data/amplio/grid.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/maglev.spec
+++ b/freeciv/freeciv/data/amplio/maglev.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/medievalcities.spec
+++ b/freeciv/freeciv/data/amplio/medievalcities.spec
@@ -16,7 +16,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/moderncities.spec
+++ b/freeciv/freeciv/data/amplio/moderncities.spec
@@ -16,7 +16,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/nuke.spec
+++ b/freeciv/freeciv/data/amplio/nuke.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/ocean.spec
+++ b/freeciv/freeciv/data/amplio/ocean.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 ; TODO: FIX ARTISTS

--- a/freeciv/freeciv/data/amplio/select.spec
+++ b/freeciv/freeciv/data/amplio/select.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/terrain1.spec
+++ b/freeciv/freeciv/data/amplio/terrain1.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/terrain2.spec
+++ b/freeciv/freeciv/data/amplio/terrain2.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/tiles.spec
+++ b/freeciv/freeciv/data/amplio/tiles.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/units.spec
+++ b/freeciv/freeciv/data/amplio/units.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/upkeep.spec
+++ b/freeciv/freeciv/data/amplio/upkeep.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio/water.spec
+++ b/freeciv/freeciv/data/amplio/water.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2.tilespec
+++ b/freeciv/freeciv/data/amplio2.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Amplio2"

--- a/freeciv/freeciv/data/amplio2/activities.spec
+++ b/freeciv/freeciv/data/amplio2/activities.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/bases.spec
+++ b/freeciv/freeciv/data/amplio2/bases.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/cities.spec
+++ b/freeciv/freeciv/data/amplio2/cities.spec
@@ -16,7 +16,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/explosions.spec
+++ b/freeciv/freeciv/data/amplio2/explosions.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/extra_units.spec
+++ b/freeciv/freeciv/data/amplio2/extra_units.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/fog.spec
+++ b/freeciv/freeciv/data/amplio2/fog.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 artists = "

--- a/freeciv/freeciv/data/amplio2/grid.spec
+++ b/freeciv/freeciv/data/amplio2/grid.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/hills.spec
+++ b/freeciv/freeciv/data/amplio2/hills.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 artists = "

--- a/freeciv/freeciv/data/amplio2/maglev.spec
+++ b/freeciv/freeciv/data/amplio2/maglev.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/mountains.spec
+++ b/freeciv/freeciv/data/amplio2/mountains.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 artists = "

--- a/freeciv/freeciv/data/amplio2/nuke.spec
+++ b/freeciv/freeciv/data/amplio2/nuke.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/ocean.spec
+++ b/freeciv/freeciv/data/amplio2/ocean.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 ; TODO: FIX ARTISTS

--- a/freeciv/freeciv/data/amplio2/select.spec
+++ b/freeciv/freeciv/data/amplio2/select.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/terrain1.spec
+++ b/freeciv/freeciv/data/amplio2/terrain1.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/terrain2.spec
+++ b/freeciv/freeciv/data/amplio2/terrain2.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 artists = "

--- a/freeciv/freeciv/data/amplio2/tiles.spec
+++ b/freeciv/freeciv/data/amplio2/tiles.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/units.spec
+++ b/freeciv/freeciv/data/amplio2/units.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/upkeep.spec
+++ b/freeciv/freeciv/data/amplio2/upkeep.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/veterancy.spec
+++ b/freeciv/freeciv/data/amplio2/veterancy.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/water.spec
+++ b/freeciv/freeciv/data/amplio2/water.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/cimpletoon.tilespec
+++ b/freeciv/freeciv/data/cimpletoon.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Cimpletoon"

--- a/freeciv/freeciv/data/cimpletoon/orient_units.spec
+++ b/freeciv/freeciv/data/cimpletoon/orient_units.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/civ1/game.ruleset
+++ b/freeciv/freeciv/data/civ1/game.ruleset
@@ -780,6 +780,11 @@ victory_min_points = 1000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/civ1/terrain.ruleset
+++ b/freeciv/freeciv/data/civ1/terrain.ruleset
@@ -774,8 +774,8 @@ ui_name_base_airbase = _("?gui_type:Build None")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic
@@ -993,7 +993,7 @@ name           = _("Minor Tribe Village")
 rule_name      = "Hut"
 category       = "Bonus"
 causes         = "Hut"
-;rmcauses       = ""
+rmcauses       = "Enter"
 graphic        = "tx.village"
 graphic_alt    = "-"
 activity_gfx   = "None"

--- a/freeciv/freeciv/data/civ1/terrain.ruleset
+++ b/freeciv/freeciv/data/civ1/terrain.ruleset
@@ -1132,7 +1132,7 @@ buildable      = FALSE
 native_to      = "Land"
 flags          = "NaturalDefense"
 helptext       = _("\
-Any land terrain type may have a River on it.\
+Grassland tile may have a River on it.\
 "), _("\
 Roads and railroads can only be built on River tiles if your\
  civilization has learned Bridge Building technology.\

--- a/freeciv/freeciv/data/civ2/game.ruleset
+++ b/freeciv/freeciv/data/civ2/game.ruleset
@@ -1016,6 +1016,11 @@ victory_min_points = 1000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/civ2/terrain.ruleset
+++ b/freeciv/freeciv/data/civ2/terrain.ruleset
@@ -845,8 +845,8 @@ ui_name_base_airbase = _("?gui_type:Build Airforce base")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic
@@ -1065,7 +1065,7 @@ name           = _("Minor Tribe Village")
 rule_name      = "Hut"
 category       = "Bonus"
 causes         = "Hut"
-;rmcauses       = ""
+rmcauses       = "Enter"
 graphic        = "tx.village"
 graphic_alt    = "-"
 activity_gfx   = "None"

--- a/freeciv/freeciv/data/civ2civ3/game.ruleset
+++ b/freeciv/freeciv/data/civ2civ3/game.ruleset
@@ -1214,6 +1214,11 @@ victory_min_points = 18000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/civ2civ3/terrain.ruleset
+++ b/freeciv/freeciv/data/civ2civ3/terrain.ruleset
@@ -1044,8 +1044,8 @@ ui_name_base_airbase = _("?gui_type:Build Airstrip/Airbase")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic
@@ -1333,7 +1333,7 @@ name           = _("Minor Tribe Village")
 rule_name      = "Hut"
 category       = "Bonus"
 causes         = "Hut"
-;rmcauses       = ""
+rmcauses       = "Enter"
 graphic        = "tx.village"
 graphic_alt    = "-"
 activity_gfx   = "None"

--- a/freeciv/freeciv/data/classic/game.ruleset
+++ b/freeciv/freeciv/data/classic/game.ruleset
@@ -1062,6 +1062,11 @@ victory_min_points = 1000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/classic/terrain.ruleset
+++ b/freeciv/freeciv/data/classic/terrain.ruleset
@@ -1027,8 +1027,8 @@ ui_name_base_airbase = _("?gui_type:Build Airbase")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic
@@ -1278,7 +1278,7 @@ name           = _("Minor Tribe Village")
 rule_name      = "Hut"
 category       = "Bonus"
 causes         = "Hut"
-;rmcauses       = ""
+rmcauses       = "Enter"
 graphic        = "tx.village"
 graphic_alt    = "-"
 activity_gfx   = "None"

--- a/freeciv/freeciv/data/experimental/game.ruleset
+++ b/freeciv/freeciv/data/experimental/game.ruleset
@@ -1067,6 +1067,11 @@ victory_min_points = 15000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/experimental/terrain.ruleset
+++ b/freeciv/freeciv/data/experimental/terrain.ruleset
@@ -1003,8 +1003,8 @@ ui_name_base_airbase = _("?gui_type:Build Airbase")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic
@@ -1254,7 +1254,7 @@ name           = _("Minor Tribe Village")
 rule_name      = "Hut"
 category       = "Bonus"
 causes         = "Hut"
-;rmcauses       = ""
+rmcauses       = "Enter"
 graphic        = "tx.village"
 graphic_alt    = "-"
 activity_gfx   = "None"

--- a/freeciv/freeciv/data/granularity/game.ruleset
+++ b/freeciv/freeciv/data/granularity/game.ruleset
@@ -281,7 +281,8 @@ bombard_max_range = 1
 ; the following character as a mnemonic in its graphical toolkit.
 ; The second %s marks where extra details should be inserted.
 
-; ui_name_xxx = _("%s%s")
+; /* TRANS: _Build City (100% chance of success). */
+ui_name_found_city = _("%sBuild City%s")
 
 ; /* <-- avoid gettext warnings
 ;
@@ -308,6 +309,15 @@ bombard_max_range = 1
 ;
 ; Can make the help text less redundant when you document it your self.
 ;quiet_actions = "Targeted Sabotage City", "Targeted Steal Tech"
+
+[actionenabler_found_city]
+action = "Found City"
+actor_reqs    =
+    { "type",   "name", "range"
+      "UnitFlag", "Cities", "Local"
+      "UnitState", "OnLivableTile", "Local"
+      "MinMoveFrags", "1", "Local"
+    }
 
 [borders]
 ; Base border radius from city.

--- a/freeciv/freeciv/data/granularity/game.ruleset
+++ b/freeciv/freeciv/data/granularity/game.ruleset
@@ -400,6 +400,11 @@ victory_min_points = 1000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/granularity/terrain.ruleset
+++ b/freeciv/freeciv/data/granularity/terrain.ruleset
@@ -350,8 +350,8 @@ ui_name_base_airbase = _("?gui_type:Build Type B Base")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic

--- a/freeciv/freeciv/data/granularity/units.ruleset
+++ b/freeciv/freeciv/data/granularity/units.ruleset
@@ -380,8 +380,40 @@ flags         = ""
 ;
 ; */ <-- avoid gettext warnings
 
-[unit_generic]
-name          = _("Generic")
+[unit_nomad]
+name          = _("Nomad")
+class         = "Generic"
+tech_req      = "None"
+obsolete_by   = "None"
+graphic       = "u.nomad"
+graphic_alt   = "u.worker"
+sound_move    = "m_nomad"
+sound_move_alt = "m_generic"
+sound_fight   = "f_nomad"
+sound_fight_alt = "f_generic"
+build_cost    = 10
+pop_cost      = 2
+attack        = 1
+defense       = 1
+hitpoints     = 10
+firepower     = 1
+move_rate     = 1
+vision_radius_sq = 2
+transport_cap = 0
+fuel          = 0
+uk_happy      = 0
+uk_shield     = 0
+uk_food       = 0
+uk_gold       = 0
+flags         = "Settlers", "Cities"
+roles         = "ExplorerStartUnit", "Firstbuild", "CitiesStartUnit"
+helptext      = _("\
+  Nomads can both fight and found new cities, but unlike specialized\
+  units they cost two population points to build.\
+")
+
+[unit_warriors]
+name          = _("Warriors")
 class         = "Generic"
 tech_req      = "None"
 obsolete_by   = "None"
@@ -405,10 +437,10 @@ uk_happy      = 0
 uk_shield     = 0
 uk_food       = 0
 uk_gold       = 0
-flags         = "Settlers"
-roles         = "ExplorerStartUnit", "Firstbuild"
+;flags         =
+roles         = "Firstbuild"
 helptext      = _("\
-  This is the only land unit type you can build.\
+  Warriors are the first unit specialized in war.\
 ")
 
 [unit_settlers]
@@ -423,7 +455,7 @@ sound_move_alt = "m_generic"
 sound_fight   = "f_settlers"
 sound_fight_alt = "f_generic"
 build_cost    = 10
-pop_cost      = 0
+pop_cost      = 1
 attack        = 0
 defense       = 0
 hitpoints     = 10
@@ -437,9 +469,8 @@ uk_shield     = 0
 uk_food       = 0
 uk_gold       = 0
 flags         = "Cities"
-roles         = "CitiesStartUnit"
 helptext      = _("\
-  Settlers can found new cities.\
+  Settlers are specialized in founding new cities.\
 ")
 
 [unit_ship]

--- a/freeciv/freeciv/data/granularity/units.ruleset
+++ b/freeciv/freeciv/data/granularity/units.ruleset
@@ -25,9 +25,10 @@ format_version=20
 ;                 as part of some sentences, so try to make it descriptive
 ;                 and sensible.
 ; helptxt       = displayed in the help for unit types with this flag (optional)
-; flags =
-;   { "name", "helptxt"
-;   }
+ flags =
+   { "name", "helptxt"
+     _("Cities")
+   }
 
 ; Names for custom unit class flags. There can be up to 8 of these.
 ; name          = rule name; In some circumstances user may see this
@@ -405,9 +406,40 @@ uk_shield     = 0
 uk_food       = 0
 uk_gold       = 0
 flags         = "Settlers"
-roles         = "ExplorerStartUnit", "Firstbuild", "CitiesStartUnit"
+roles         = "ExplorerStartUnit", "Firstbuild"
 helptext      = _("\
   This is the only land unit type you can build.\
+")
+
+[unit_settlers]
+name          = _("Settlers")
+class         = "Generic"
+tech_req      = "None"
+obsolete_by   = "None"
+graphic       = "u.settlers"
+graphic_alt   = "-"
+sound_move    = "m_settlers"
+sound_move_alt = "m_generic"
+sound_fight   = "f_settlers"
+sound_fight_alt = "f_generic"
+build_cost    = 10
+pop_cost      = 0
+attack        = 0
+defense       = 0
+hitpoints     = 10
+firepower     = 1
+move_rate     = 1
+vision_radius_sq = 2
+transport_cap = 0
+fuel          = 0
+uk_happy      = 0
+uk_shield     = 0
+uk_food       = 0
+uk_gold       = 0
+flags         = "Cities"
+roles         = "CitiesStartUnit"
+helptext      = _("\
+  Settlers can found new cities.\
 ")
 
 [unit_ship]

--- a/freeciv/freeciv/data/hex2t.tilespec
+++ b/freeciv/freeciv/data/hex2t.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Hex-2"

--- a/freeciv/freeciv/data/hex2t/grid.spec
+++ b/freeciv/freeciv/data/hex2t/grid.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hex2t/items.spec
+++ b/freeciv/freeciv/data/hex2t/items.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hex2t/overlays.spec
+++ b/freeciv/freeciv/data/hex2t/overlays.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hex2t/select.spec
+++ b/freeciv/freeciv/data/hex2t/select.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hex2t/tiles.spec
+++ b/freeciv/freeciv/data/hex2t/tiles.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hex2t/unitcost.spec
+++ b/freeciv/freeciv/data/hex2t/unitcost.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio.tilespec
+++ b/freeciv/freeciv/data/hexemplio.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Hexemplio"

--- a/freeciv/freeciv/data/hexemplio/activities.spec
+++ b/freeciv/freeciv/data/hexemplio/activities.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/bases.spec
+++ b/freeciv/freeciv/data/hexemplio/bases.spec
@@ -16,7 +16,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/cities.spec
+++ b/freeciv/freeciv/data/hexemplio/cities.spec
@@ -16,7 +16,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/embellishments.spec
+++ b/freeciv/freeciv/data/hexemplio/embellishments.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/forests.spec
+++ b/freeciv/freeciv/data/hexemplio/forests.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/grid.spec
+++ b/freeciv/freeciv/data/hexemplio/grid.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/hills.spec
+++ b/freeciv/freeciv/data/hexemplio/hills.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 artists = "
 	 Peter Arbor <peter.arbor@gmail.com> (original terrain)

--- a/freeciv/freeciv/data/hexemplio/mountains.spec
+++ b/freeciv/freeciv/data/hexemplio/mountains.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 artists = "
 	 Peter Arbor <peter.arbor@gmail.com> (original terrain)

--- a/freeciv/freeciv/data/hexemplio/rivers.spec
+++ b/freeciv/freeciv/data/hexemplio/rivers.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/roads-maglevs.spec
+++ b/freeciv/freeciv/data/hexemplio/roads-maglevs.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/roads-rails.spec
+++ b/freeciv/freeciv/data/hexemplio/roads-rails.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/roads.spec
+++ b/freeciv/freeciv/data/hexemplio/roads.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/select.spec
+++ b/freeciv/freeciv/data/hexemplio/select.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/terrain.spec
+++ b/freeciv/freeciv/data/hexemplio/terrain.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/tiles.spec
+++ b/freeciv/freeciv/data/hexemplio/tiles.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/unitcost.spec
+++ b/freeciv/freeciv/data/hexemplio/unitcost.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/unitextras.spec
+++ b/freeciv/freeciv/data/hexemplio/unitextras.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/water1.spec
+++ b/freeciv/freeciv/data/hexemplio/water1.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/water2.spec
+++ b/freeciv/freeciv/data/hexemplio/water2.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/hexemplio/water3.spec
+++ b/freeciv/freeciv/data/hexemplio/water3.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isophex.tilespec
+++ b/freeciv/freeciv/data/isophex.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Isophex"

--- a/freeciv/freeciv/data/isophex/darkness.spec
+++ b/freeciv/freeciv/data/isophex/darkness.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isophex/grid.spec
+++ b/freeciv/freeciv/data/isophex/grid.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isophex/rivers.spec
+++ b/freeciv/freeciv/data/isophex/rivers.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isophex/terrain1.spec
+++ b/freeciv/freeciv/data/isophex/terrain1.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isophex/terrain2.spec
+++ b/freeciv/freeciv/data/isophex/terrain2.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident.tilespec
+++ b/freeciv/freeciv/data/isotrident.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "MacroIsoTrident"

--- a/freeciv/freeciv/data/isotrident/cities.spec
+++ b/freeciv/freeciv/data/isotrident/cities.spec
@@ -16,7 +16,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident/fog.spec
+++ b/freeciv/freeciv/data/isotrident/fog.spec
@@ -1,6 +1,6 @@
 [spec]
 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 artists = "unknown"

--- a/freeciv/freeciv/data/isotrident/grid.spec
+++ b/freeciv/freeciv/data/isotrident/grid.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident/morecities.spec
+++ b/freeciv/freeciv/data/isotrident/morecities.spec
@@ -16,7 +16,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident/nuke.spec
+++ b/freeciv/freeciv/data/isotrident/nuke.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident/select.spec
+++ b/freeciv/freeciv/data/isotrident/select.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident/terrain1.spec
+++ b/freeciv/freeciv/data/isotrident/terrain1.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident/terrain2.spec
+++ b/freeciv/freeciv/data/isotrident/terrain2.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident/tiles.spec
+++ b/freeciv/freeciv/data/isotrident/tiles.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident/unitcost.spec
+++ b/freeciv/freeciv/data/isotrident/unitcost.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/isotrident/unitextras.spec
+++ b/freeciv/freeciv/data/isotrident/unitextras.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/buildings-large.spec
+++ b/freeciv/freeciv/data/misc/buildings-large.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/buildings.spec
+++ b/freeciv/freeciv/data/misc/buildings.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/chiefs.spec
+++ b/freeciv/freeciv/data/misc/chiefs.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/citybar.spec
+++ b/freeciv/freeciv/data/misc/citybar.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/cursors.spec
+++ b/freeciv/freeciv/data/misc/cursors.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/editor.spec
+++ b/freeciv/freeciv/data/misc/editor.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/events.spec
+++ b/freeciv/freeciv/data/misc/events.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/flags-large.spec
+++ b/freeciv/freeciv/data/misc/flags-large.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09-large"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/flags.spec
+++ b/freeciv/freeciv/data/misc/flags.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/governments.spec
+++ b/freeciv/freeciv/data/misc/governments.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/icons.spec
+++ b/freeciv/freeciv/data/misc/icons.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/overlays.spec
+++ b/freeciv/freeciv/data/misc/overlays.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/shields-large.spec
+++ b/freeciv/freeciv/data/misc/shields-large.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/shields.spec
+++ b/freeciv/freeciv/data/misc/shields.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/small.spec
+++ b/freeciv/freeciv/data/misc/small.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/space.spec
+++ b/freeciv/freeciv/data/misc/space.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/specialists.spec
+++ b/freeciv/freeciv/data/misc/specialists.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/techs.spec
+++ b/freeciv/freeciv/data/misc/techs.spec
@@ -1,5 +1,5 @@
 [spec]
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 [info]
 artists = "
  Frederic Rodrigo 

--- a/freeciv/freeciv/data/misc/treaty.spec
+++ b/freeciv/freeciv/data/misc/treaty.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/misc/wonders-large.spec
+++ b/freeciv/freeciv/data/misc/wonders-large.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/multiplayer/game.ruleset
+++ b/freeciv/freeciv/data/multiplayer/game.ruleset
@@ -1057,6 +1057,11 @@ victory_min_points = 1000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/multiplayer/terrain.ruleset
+++ b/freeciv/freeciv/data/multiplayer/terrain.ruleset
@@ -1001,8 +1001,8 @@ ui_name_base_airbase = _("?gui_type:Build Airbase")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic

--- a/freeciv/freeciv/data/ruledit/comments.txt
+++ b/freeciv/freeciv/data/ruledit/comments.txt
@@ -737,8 +737,8 @@ extras = "\
 ;                           (the last three require a corresponding\n\
 ;                           [resource_*] / [base_*] / [road_*] section)\n\
 ; rmcauses                = events that can remove extra type.\n\
-;                           \"CleanPollution\", \"CleanFallout\", \"Pillage\", or\n\
-;                           \"Disappear\"\n\
+;                           \"CleanPollution\", \"CleanFallout\", \"Pillage\",\n\
+;                           \"Disappear\", or \"Enter\"\n\
 ; infracost               = Number of infrapoints it costs to place this\n\
 ;                           extra. 0 means extra cannot be placed. Default is 1\n\
 ; graphic                 = tag specifying preferred graphic\n\

--- a/freeciv/freeciv/data/sandbox/game.ruleset
+++ b/freeciv/freeciv/data/sandbox/game.ruleset
@@ -1355,6 +1355,11 @@ victory_min_points = 18000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/sandbox/terrain.ruleset
+++ b/freeciv/freeciv/data/sandbox/terrain.ruleset
@@ -1045,8 +1045,8 @@ ui_name_base_airbase = _("?gui_type:Build Airstrip/Airbase")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic
@@ -1334,7 +1334,7 @@ name           = _("Minor Tribe Village")
 rule_name      = "Hut"
 category       = "Bonus"
 causes         = "Hut"
-;rmcauses       = ""
+rmcauses       = "Enter"
 graphic        = "tx.village"
 graphic_alt    = "-"
 activity_gfx   = "None"
@@ -1364,15 +1364,14 @@ by other aircraft will cause the villagers to take fright and disband.\
 name             = _("Hermit's Place")
 rule_name        = "Hermit"
 category         = "Bonus"
-causes           = "Appear", "Hut"
-;rmcauses         = ""
+causes           = "Appear"
+rmcauses         = "Enter"
 graphic          = "tx.hermit"
 graphic_alt      = "tx.village"
 activity_gfx     = "None"
 act_gfx_alt      = "-"
 rmact_gfx        = "None"
 rmact_gfx_alt    = "-"
-generated        = FALSE
 appearance_reqs  =
     { "type", "name", "range", "present", "quiet"
       "TerrainClass", "Land", "Local", TRUE, FALSE

--- a/freeciv/freeciv/data/stub/game.ruleset
+++ b/freeciv/freeciv/data/stub/game.ruleset
@@ -382,6 +382,11 @@ victory_min_points = 1000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/stub/terrain.ruleset
+++ b/freeciv/freeciv/data/stub/terrain.ruleset
@@ -341,8 +341,8 @@ ui_name_base_airbase = _("?gui_type:Build Type B Base")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic

--- a/freeciv/freeciv/data/toonhex.tilespec
+++ b/freeciv/freeciv/data/toonhex.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Toonhex"

--- a/freeciv/freeciv/data/trident.tilespec
+++ b/freeciv/freeciv/data/trident.tilespec
@@ -1,7 +1,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2016-Jun-07"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03"
 
 ; A simple name for the tileset specified by this file:
 name = "Trident"

--- a/freeciv/freeciv/data/trident/auto_ll.spec
+++ b/freeciv/freeciv/data/trident/auto_ll.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/trident/cities.spec
+++ b/freeciv/freeciv/data/trident/cities.spec
@@ -16,7 +16,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/trident/earth.spec
+++ b/freeciv/freeciv/data/trident/earth.spec
@@ -1,6 +1,6 @@
 [spec]
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 artists = "

--- a/freeciv/freeciv/data/trident/explosions.spec
+++ b/freeciv/freeciv/data/trident/explosions.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/trident/extra_units.spec
+++ b/freeciv/freeciv/data/trident/extra_units.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/trident/fog.spec
+++ b/freeciv/freeciv/data/trident/fog.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 artists = "unknown"

--- a/freeciv/freeciv/data/trident/grid.spec
+++ b/freeciv/freeciv/data/trident/grid.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/trident/roads.spec
+++ b/freeciv/freeciv/data/trident/roads.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/trident/select.spec
+++ b/freeciv/freeciv/data/trident/select.spec
@@ -1,7 +1,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/trident/tiles.spec
+++ b/freeciv/freeciv/data/trident/tiles.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/trident/units.spec
+++ b/freeciv/freeciv/data/trident/units.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-spec-Devel-2019-Mar-09"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/webperimental/game.ruleset
+++ b/freeciv/freeciv/data/webperimental/game.ruleset
@@ -1313,6 +1313,11 @@ victory_min_points = 1000
 ; How big lead relative to second best player is needed for victory
 victory_lead_pct   = 200
 
+; How much existing history grows each turn. This makes older history
+; of the same original value more valuable as newer history, as it has
+; gained more interest.
+history_interest_pml = 0
+
 ; How much each culture point affects the migration
 ; from/to the city. Each culture point count as this many permilles
 ; of a migration point.

--- a/freeciv/freeciv/data/webperimental/terrain.ruleset
+++ b/freeciv/freeciv/data/webperimental/terrain.ruleset
@@ -1027,8 +1027,8 @@ ui_name_base_airbase = _("?gui_type:Build Airbase")
 ;                           (the last three require a corresponding
 ;                           [resource_*] / [base_*] / [road_*] section)
 ; rmcauses                = events that can remove extra type.
-;                           "CleanPollution", "CleanFallout", "Pillage", or
-;                           "Disappear"
+;                           "CleanPollution", "CleanFallout", "Pillage",
+;                           "Disappear", or "Enter"
 ; infracost               = Number of infrapoints it costs to place this
 ;                           extra. 0 means extra cannot be placed. Default is 1
 ; graphic                 = tag specifying preferred graphic

--- a/freeciv/freeciv/doc/INSTALL.meson
+++ b/freeciv/freeciv/doc/INSTALL.meson
@@ -8,6 +8,18 @@ supported official way to compile and install Freeciv is still using
 autotools as described in INSTALL.
 
 
+Prerequisites:
+==============
+
+Freeciv has mostly the same prerequisites no matter if it's built
+with autotools or meson and ninja. The only difference is the requirement
+of the build system itself. Meson build does not need autotools, nor does
+autotools build need meson. See main (autotools) INSTALL file for the
+common prerequisites.
+
+For the meson based build minimum version of meson is 0.44.0.
+
+
 Overview:
 =========
 

--- a/freeciv/freeciv/doc/README.scenarios
+++ b/freeciv/freeciv/doc/README.scenarios
@@ -66,5 +66,19 @@ Savegame [scenario] section can have following fields
   required capabilities of compatible rulesets
 
 - datafile
-  Luadata to load. Ruleset's generic luadata is used when this field
-  is missing.
+  Luadata to load. See chapter 'Luadata' for details
+
+
+Luadata:
+--------
+Some rulesets have a lua script that can parse special luadata file
+to adjust their behavior. Such luadata file can be provided by the
+ruleset itself, or by the scenario using the ruleset. This is controlled
+by 'datafile' field in the scenario savegames [scenario] section.
+- If the field is omitted, ruleset's own luadata is used, if present
+- If field has value 'None' (case insensitive), luadata is not used
+  at all, as if it was not present even in the ruleset
+- Any other value of datafile is considered prefix part of a filename
+  of form <prefix>.luadata to use as the luadata file. The file must
+  be found from the freeciv's savegame path, usually from the same
+  directory where the scenario savegame itself is.

--- a/freeciv/freeciv/doc/README.scenarios
+++ b/freeciv/freeciv/doc/README.scenarios
@@ -13,3 +13,58 @@ is that latter have is_scenario set to TRUE in [scenario] section.
 Freeciv saves current game situation as a scenario file, with the full
 [scenario] section, when one saves by the /scensave server command or
 uses "Save Scenario" from the client Edit -menu.
+
+
+[scenario] section:
+-------------------
+Savegame [scenario] section can have following fields
+
+- is_scenario
+  Always TRUE in a scenario savegame
+
+- name
+  Name of the scenario
+
+- authors
+  Text listing authors of the scenario
+
+- description
+  Description of the scenario
+
+- save_random
+  Whether random number state is saved to the scenario
+
+- players
+  Whether player information is saved to the scenario, or is it map-only
+  scenario
+
+- startpos_nations
+  Whether nations should use start positions defined in the scenario map
+
+- prevent new cities
+  Is founding new cities prevented in the scenario, locking it to cities
+  present on the map
+
+- lake_flooding
+  Should ocean tiles connecting to a lake tile flood the lake tile
+
+- handmade
+  Set to TRUE when savegame file is manually edited. This has no gameplay
+  effect, but it indicates that scenario might have some properties that
+  are not yet supported in the editor. When editing such a scenario in the
+  editor, warning is shown that some properties might get lost
+
+- allow_ai_type_fallback
+  Is it ok to fallback to another player AI type if one defined in the
+  scenario file is not available when scenario is loaded
+
+- ruleset_locked
+  Is the scenario locked to one specific ruleset. Default is TRUE
+
+- ruleset_caps
+  When scenario is not ruleset_locked, this capability string defines
+  required capabilities of compatible rulesets
+
+- datafile
+  Luadata to load. Ruleset's generic luadata is used when this field
+  is missing.

--- a/freeciv/freeciv/gen_headers/meson_fc_config.h.in
+++ b/freeciv/freeciv/gen_headers/meson_fc_config.h.in
@@ -27,6 +27,9 @@
 
 #define MPICON_PATH "@DATADIR@/freeciv/misc/mpicon.png"
 
+/* Release cycle information */
+#mesondefine IS_DEVEL_VERSION
+
 /* Produce debug version */
 #mesondefine FREECIV_DEBUG
 

--- a/freeciv/freeciv/gen_headers/meson_fc_config.h.in
+++ b/freeciv/freeciv/gen_headers/meson_fc_config.h.in
@@ -30,6 +30,12 @@
 /* Produce debug version */
 #mesondefine FREECIV_DEBUG
 
+/* enable audio */
+#mesondefine AUDIO_SDL
+
+/* audio via SDL2_mixer */
+#mesondefine AUDIO_SDL2
+
 /* arpa/inet.h available */
 #mesondefine HAVE_ARPA_INET_H
 

--- a/freeciv/freeciv/meson.build
+++ b/freeciv/freeciv/meson.build
@@ -23,6 +23,9 @@ if get_option('debug')
   pub_conf_data.set('FREECIV_DEBUG', 1)
 endif
 
+priv_conf_data.set('AUDIO_SDL', 1)
+priv_conf_data.set('AUDIO_SDL2', 1)
+
 c_compiler = meson.get_compiler('c')
 
 pub_headers = [
@@ -1075,6 +1078,7 @@ client_common = static_library('fc_client_common',
   include_directories: client_inc,
   link_with: [common_lib],
   dependencies: [c_compiler.find_library('m'),
+                 c_compiler.find_library('libSDL2'),
                  c_compiler.find_library('libSDL2_mixer')]
   )
 

--- a/freeciv/freeciv/meson.build
+++ b/freeciv/freeciv/meson.build
@@ -18,6 +18,8 @@ priv_conf_data.set('DATADIR',
                    join_paths(get_option('prefix'), get_option('datadir')))
 priv_conf_data.set('DATASUBDIR', 'dev')
 
+priv_conf_data.set('IS_DEVEL_VERSION', 1)
+
 if get_option('debug')
   priv_conf_data.set('FREECIV_DEBUG', 1)
   pub_conf_data.set('FREECIV_DEBUG', 1)

--- a/freeciv/freeciv/meson.build
+++ b/freeciv/freeciv/meson.build
@@ -1084,6 +1084,7 @@ client_common = static_library('fc_client_common',
 
 install_data('data/helpdata.txt',
              'data/hexemplio.tilespec',
+             'data/stdmusic.musicspec',
              install_dir : join_paths(get_option('datadir'), 'freeciv'))
 
 install_data('data/misc/colors.tilespec',
@@ -1173,6 +1174,9 @@ install_data('data/amplio2/units.png',
              'data/amplio2/explosions.png',
              'data/amplio2/explosions.spec',
              install_dir : join_paths(get_option('datadir'), 'freeciv/amplio2'))
+
+install_data('data/stdmusic/CullamBruce-Lockhart--Dawning_Fanfare.ogg',
+             install_dir : join_paths(get_option('datadir'), 'freeciv/stdmusic'))
 
 endif
 

--- a/freeciv/freeciv/server/advisors/autoexplorer.c
+++ b/freeciv/freeciv/server/advisors/autoexplorer.c
@@ -209,6 +209,7 @@ static int explorer_desirable(struct tile *ptile, struct player *pplayer,
 
   /* First do some checks that would make a tile completely non-desirable.
    * If we're a barbarian and the tile has a hut, don't go there. */
+  /* FIXME: HUT_NOTHING ok */
   if (is_barbarian(pplayer) && hut_on_tile(ptile)) {
     return 0;
   }
@@ -250,9 +251,10 @@ static int explorer_desirable(struct tile *ptile, struct player *pplayer,
 
   if ((!is_ai(pplayer) || !has_handicap(pplayer, H_HUTS))
       && map_is_known(ptile, pplayer)
-      && hut_on_tile(ptile)) {
+      && unit_can_displace_hut(punit, ptile)) {
     /* we want to explore huts whenever we can,
      * even if doing so will not uncover any tiles. */
+    /* FIXME: should HUT_FRIGHTEN explorer strive to destroy huts? */
     desirable += HUT_SCORE;
   }
 

--- a/freeciv/freeciv/server/advisors/autosettlers.c
+++ b/freeciv/freeciv/server/advisors/autosettlers.c
@@ -1264,6 +1264,18 @@ bool auto_settlers_speculate_can_act_at(const struct unit *punit,
       return FALSE;
     }
 
+  case ACTIVITY_PLANT:
+    if (pterrain->mining_result != pterrain
+        && pterrain->mining_result != T_NONE) {
+      return action_prob_possible(action_speculate_unit_on_tile(
+                                    ACTION_PLANT,
+                                    punit, unit_home(punit), ptile,
+                                    omniscient_cheat,
+                                    ptile, target));
+    } else {
+      return FALSE;
+    }
+
   case ACTIVITY_IRRIGATE:
     if (pterrain->irrigation_result != pterrain
         && pterrain->irrigation_result != T_NONE) {
@@ -1275,6 +1287,18 @@ bool auto_settlers_speculate_can_act_at(const struct unit *punit,
     } else if (pterrain->irrigation_result == pterrain) {
       return action_prob_possible(action_speculate_unit_on_tile(
                                     ACTION_IRRIGATE,
+                                    punit, unit_home(punit), ptile,
+                                    omniscient_cheat,
+                                    ptile, target));
+    } else {
+      return FALSE;
+    }
+
+  case ACTIVITY_CULTIVATE:
+    if (pterrain->irrigation_result != pterrain
+        && pterrain->irrigation_result != T_NONE) {
+      return action_prob_possible(action_speculate_unit_on_tile(
+                                    ACTION_CULTIVATE,
                                     punit, unit_home(punit), ptile,
                                     omniscient_cheat,
                                     ptile, target));

--- a/freeciv/freeciv/server/animals.c
+++ b/freeciv/freeciv/server/animals.c
@@ -54,12 +54,13 @@ static void place_animal(struct player *plr)
   struct tile *ptile = rand_map_pos(&(wld.map));
   const struct unit_type *ptype;
 
-  extra_type_by_cause_iterate(EC_HUT, pextra) {
+  extra_type_by_rmcause_iterate(ERM_ENTER, pextra) {
     if (tile_has_extra(ptile, pextra)) {
       /* Animals should not displace huts */
+      /* FIXME: might HUT_NOTHING animals appear here? */
       return;
     }
-  } extra_type_by_cause_iterate_end;
+  } extra_type_by_rmcause_iterate_end;
 
   if (unit_list_size(ptile->units) > 0 || tile_city(ptile)) {
     return;

--- a/freeciv/freeciv/server/barbarian.c
+++ b/freeciv/freeciv/server/barbarian.c
@@ -554,12 +554,13 @@ static void try_summon_barbarians(void)
   log_debug("Barbarians are willing to fight");
 
   /* Remove huts in place of uprising */
-  extra_type_by_cause_iterate(EC_HUT, pextra) {
+  /* FIXME: Should we really always do it? */
+  extra_type_by_rmcause_iterate(ERM_ENTER, pextra) {
     if (tile_has_extra(utile, pextra)) {
       tile_extra_rm_apply(utile, pextra);
       hut_present = TRUE;
     }
-  } extra_type_by_cause_iterate_end;
+  } extra_type_by_rmcause_iterate_end;
 
   if (hut_present) {
     update_tile_knowledge(utile);
@@ -596,8 +597,8 @@ static void try_summon_barbarians(void)
         log_debug("Created barbarian unit %s",utype_rule_name(punittype));
       }
     }
- 
-    if (is_native_tile(leader_type, utile)) { 
+
+    if (is_native_tile(leader_type, utile)) {
       (void) create_unit(barbarians, utile,
                          leader_type, 0, 0, -1);
       really_created++;

--- a/freeciv/freeciv/server/cityhand.c
+++ b/freeciv/freeciv/server/cityhand.c
@@ -22,6 +22,7 @@
 /* utility */
 #include "fcintl.h"
 #include "log.h"
+#include "mem.h"
 #include "rand.h"
 #include "support.h"
 
@@ -46,6 +47,7 @@
 #include "plrhand.h"
 #include "sanitycheck.h"
 #include "unithand.h"
+#include "unittools.h"
 
 #include "cityhand.h"
 
@@ -703,4 +705,56 @@ void handle_city_manager(struct player *pplayer, int city_id, bool enabled,
         }
       }      
   }
+}
+
+/**********************************************************************//**
+  Handles a request to set city rally point for new units.
+**************************************************************************/
+void handle_city_rally_point(struct player *pplayer,
+                             const struct packet_city_rally_point *packet)
+{
+  int length = packet->length;
+  struct city *pcity = player_city_by_number(pplayer, packet->city_id);
+  struct unit_order *orders;
+
+  if (NULL == pcity) {
+    /* Probably lost. */
+    log_verbose("handle_city_rally_point() bad city number %d.",
+                packet->city_id);
+    return;
+  }
+
+  if (0 > length || MAX_LEN_ROUTE < length) {
+    /* Shouldn't happen */
+    log_error("handle_city_rally_point() invalid packet length %d (max %d)",
+              length, MAX_LEN_ROUTE);
+    return;
+  }
+
+  pcity->rally_point.length = length;
+
+  if (length == 0) {
+    pcity->rally_point.vigilant = FALSE;
+    pcity->rally_point.persistent = FALSE;
+    if (pcity->rally_point.orders) {
+      free(pcity->rally_point.orders);
+      pcity->rally_point.orders = NULL;
+    }
+  } else {
+    orders = create_unit_orders(length, packet->orders, packet->dirs,
+                                packet->activities, packet->sub_targets,
+                                packet->actions);
+    if (!orders) {
+      pcity->rally_point.length = 0;
+      log_error("invalid rally point orders for city number %d.",
+                packet->city_id);
+      return;
+    }
+
+    pcity->rally_point.persistent = packet->persistent;
+    pcity->rally_point.vigilant = packet->vigilant;
+    pcity->rally_point.orders = orders;
+  }
+
+  send_city_info(pplayer, pcity);
 }

--- a/freeciv/freeciv/server/citytools.c
+++ b/freeciv/freeciv/server/citytools.c
@@ -2576,6 +2576,21 @@ void package_city(struct city *pcity, struct packet_city_info *packet,
   sz_strlcpy(packet->can_build_unit, can_build_unit_buf);
 
 
+  packet->rally_point_length = pcity->rally_point.length;
+  if (pcity->rally_point.length) {
+    packet->rally_point_persistent = pcity->rally_point.persistent;
+    packet->rally_point_vigilant = pcity->rally_point.vigilant;
+    for (i = 0; i < pcity->rally_point.length; i++) {
+      packet->rally_point_orders[i] = pcity->rally_point.orders[i].order;
+      packet->rally_point_dirs[i] = pcity->rally_point.orders[i].dir;
+      packet->rally_point_activities[i] = pcity->rally_point.orders[i]
+                                          .activity;
+      packet->rally_point_sub_targets[i] = pcity->rally_point.orders[i]
+                                           .sub_target;
+      packet->rally_point_actions[i] = pcity->rally_point.orders[i].action;
+    }
+  }
+
   BV_CLR_ALL(packet->improvements);
   improvement_iterate(pimprove) {
     if (city_has_building(pcity, pimprove)) {

--- a/freeciv/freeciv/server/cityturn.c
+++ b/freeciv/freeciv/server/cityturn.c
@@ -3381,6 +3381,17 @@ static bool city_build_unit(struct player *pplayer, struct city *pcity)
       }
       pplayer->score.units_built++;
 
+      /* If city has a rally point set, give the unit a move order. */
+      if (pcity->rally_point.length) {
+        punit->has_orders = TRUE;
+        punit->orders.length = pcity->rally_point.length;
+        punit->orders.vigilant = pcity->rally_point.vigilant;
+        punit->orders.list = fc_malloc(pcity->rally_point.length
+                                       * sizeof(struct unit_order));
+	memcpy(punit->orders.list, pcity->rally_point.orders,
+               pcity->rally_point.length * sizeof(struct unit_order));
+      }
+
       /* After we created the unit remove the citizen. This will also
        * rearrange the worker to take into account the extra resources
        * (food) needed. */
@@ -3427,6 +3438,14 @@ static bool city_build_unit(struct player *pplayer, struct city *pcity)
         // Current production will be set to last thing that was made
         pcity->production.value.utype = utype;
       }
+    }
+
+    if (pcity->rally_point.length && !pcity->rally_point.persistent) {
+      pcity->rally_point.length = 0;
+      pcity->rally_point.persistent = FALSE;
+      pcity->rally_point.vigilant = FALSE;
+      free(pcity->rally_point.orders);
+      pcity->rally_point.orders = NULL;
     }
 
     if (city_exist(saved_city_id)) {

--- a/freeciv/freeciv/server/gamehand.c
+++ b/freeciv/freeciv/server/gamehand.c
@@ -178,12 +178,13 @@ static struct tile *place_starting_unit(struct tile *starttile,
    * other cases, huts are avoided as start positions).  Remove any such hut,
    * and make sure to tell the client, since we may have already sent this
    * tile (with the hut) earlier: */
-  extra_type_by_cause_iterate(EC_HUT, pextra) {
+  /* FIXME: don't remove under a HUT_NOTHING unit */
+  extra_type_by_rmcause_iterate(ERM_ENTER, pextra) {
     if (tile_has_extra(ptile, pextra)) {
       tile_extra_rm_apply(ptile, pextra);
       hut_present = TRUE;
     }
-  } extra_type_by_cause_iterate_end;
+  } extra_type_by_rmcause_iterate_end;
 
   if (hut_present) {
     update_tile_knowledge(ptile);

--- a/freeciv/freeciv/server/generator/startpos.c
+++ b/freeciv/freeciv/server/generator/startpos.c
@@ -200,6 +200,7 @@ static bool is_valid_start_pos(const struct tile *ptile, const void *dataptr)
   }
 
   /* Don't start on a hut. */
+  /* FIXME: for HUT_NOTHING might be valid */
   if (hut_on_tile(ptile)) {
     return FALSE;
   }

--- a/freeciv/freeciv/server/rscompat.c
+++ b/freeciv/freeciv/server/rscompat.c
@@ -462,3 +462,19 @@ const char *rscompat_utype_flag_name_3_1(struct rscompat_info *compat,
 
   return old_type;
 }
+
+/**********************************************************************//**
+  Adjust freeciv-3.0 ruleset extra definitions to freeciv-3.1
+**************************************************************************/
+void rscompat_extra_adjust_3_1(struct rscompat_info *compat,
+                               struct extra_type *pextra)
+{
+  if (compat->compat_mode && compat->ver_terrain < 20) {
+
+    /* Give remove cause ERM_ENTER for huts */
+    if (is_extra_caused_by(pextra, EC_HUT)) {
+      pextra->rmcauses |= (1 << ERM_ENTER);
+      extra_to_removed_by_list(pextra, ERM_ENTER);
+    }
+  }
+}

--- a/freeciv/freeciv/server/rscompat.h
+++ b/freeciv/freeciv/server/rscompat.h
@@ -1,4 +1,4 @@
-/********************************************************************** 
+/***********************************************************************
  Freeciv - Copyright (C) 1996 - A Kjeldberg, L Gregersen, P Unold
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -67,6 +67,8 @@ const char *rscompat_utype_flag_name_3_1(struct rscompat_info *info,
                                          const char *old_type);
 bool rscompat_old_effect_3_1(const char *type, struct section_file *file,
                              const char *sec_name, struct rscompat_info *compat);
+void rscompat_extra_adjust_3_1(struct rscompat_info *compat,
+                               struct extra_type *pextra);
 
 #ifdef __cplusplus
 }

--- a/freeciv/freeciv/server/rssanity.c
+++ b/freeciv/freeciv/server/rssanity.c
@@ -949,6 +949,14 @@ bool sanity_check_ruleset_data(bool ignore_retired)
                     "Extras have conflicting or invalid removal requirements!");
       ok = FALSE;
     }
+    if ((requirement_vector_size(&pextra->rmreqs) > 0)
+        && !(pextra->rmcauses
+             & (ERM_ENTER | ERM_CLEANPOLLUTION
+                | ERM_CLEANFALLOUT | ERM_PILLAGE))) {
+      ruleset_error(LOG_WARN,
+                    "Requirements for extra removal defined but not "
+                    "a valid remove cause!");
+    }
   } extra_type_iterate_end;
 
   /* Roads */

--- a/freeciv/freeciv/server/ruleset.c
+++ b/freeciv/freeciv/server/ruleset.c
@@ -6505,6 +6505,9 @@ static bool load_ruleset_game(struct section_file *file, bool act,
     game.info.culture_migration_pml
       = secfile_lookup_int_default(file, RS_DEFAULT_CULTURE_MIGRATION_PML,
                                    "culture.migration_pml");
+    game.info.history_interest_pml
+      = secfile_lookup_int_default(file, RS_DEFAULT_HISTORY_INTEREST_PML,
+                                   "culture.history_interest_pml");
 
     /* section: calendar */
     game.calendar.calendar_skip_0

--- a/freeciv/freeciv/server/ruleset.c
+++ b/freeciv/freeciv/server/ruleset.c
@@ -3391,6 +3391,8 @@ static bool load_ruleset_terrain(struct section_file *file,
 
         pextra->helptext = lookup_strvec(file, section, "helptext");
       }
+
+      rscompat_extra_adjust_3_1(compat, pextra);
     } extra_type_iterate_end;
   }
 

--- a/freeciv/freeciv/server/ruleset.h
+++ b/freeciv/freeciv/server/ruleset.h
@@ -88,6 +88,7 @@ char *get_parser_buffer(void);
 #define RS_DEFAULT_CULTURE_VIC_POINTS    1000
 #define RS_DEFAULT_CULTURE_VIC_LEAD      300
 #define RS_DEFAULT_CULTURE_MIGRATION_PML 50
+#define RS_DEFAULT_HISTORY_INTEREST_PML  0
 
 /* Changes to these two values must also change
    const of same names in extras.js for FCW */

--- a/freeciv/freeciv/server/savegame/savegame2.c
+++ b/freeciv/freeciv/server/savegame/savegame2.c
@@ -652,6 +652,8 @@ static char activity2char(enum unit_activity activity)
   case ACTIVITY_UNKNOWN:
     return 'v';           // new vigil activity
   case ACTIVITY_PATROL_UNUSED:
+  case ACTIVITY_CULTIVATE:
+  case ACTIVITY_PLANT:
     return '?';
   case ACTIVITY_LAST:
     break;

--- a/freeciv/freeciv/server/savegame/savegame3.c
+++ b/freeciv/freeciv/server/savegame/savegame3.c
@@ -845,8 +845,12 @@ static char activity2char(enum unit_activity activity)
     return 'r';
   case ACTIVITY_MINE:
     return 'm';
+  case ACTIVITY_PLANT:
+    return 'M';
   case ACTIVITY_IRRIGATE:
     return 'i';
+  case ACTIVITY_CULTIVATE:
+    return 'I';
   case ACTIVITY_FORTIFIED:
     return 'f';
   case ACTIVITY_FORTRESS:
@@ -5382,6 +5386,7 @@ static bool sg_load_player_unit(struct loaddata *loading,
       if (tgt != NULL) {
         set_unit_activity_targeted(punit, ACTIVITY_IRRIGATE, tgt);
       } else {
+        /* TODO: Set ACTIVITY_CULTIVATE */
         set_unit_activity_targeted(punit, ACTIVITY_IRRIGATE, NULL);
       }
     } else if (activity == ACTIVITY_MINE) {
@@ -5392,6 +5397,7 @@ static bool sg_load_player_unit(struct loaddata *loading,
       if (tgt != NULL) {
         set_unit_activity_targeted(punit, ACTIVITY_MINE, tgt);
       } else {
+        /* TODO: Set ACTIVITY_PLANT */
         set_unit_activity_targeted(punit, ACTIVITY_MINE, NULL);
       }
     } else {

--- a/freeciv/freeciv/server/savegame/savegame3.c
+++ b/freeciv/freeciv/server/savegame/savegame3.c
@@ -4910,6 +4910,94 @@ static bool sg_load_player_city(struct loaddata *loading, struct player *plr,
     }
   }  
 
+  /* Load the city rally point. */
+  {
+    int len = secfile_lookup_int_default(loading->file, 0,
+                                         "%s.rally_point_length", citystr);
+    int unconverted;
+
+    pcity->rally_point.length = len;
+    if (len > 0) {
+      const char *rally_orders, *rally_dirs, *rally_activities;
+      const char *rally_actions;
+
+      pcity->rally_point.orders
+        = fc_malloc(len * sizeof(*(pcity->rally_point.orders)));
+      pcity->rally_point.persistent
+        = secfile_lookup_bool_default(loading->file, FALSE,
+                                      "%s.rally_point_persistent", citystr);
+      pcity->rally_point.vigilant
+        = secfile_lookup_bool_default(loading->file, FALSE,
+                                      "%s.rally_point_vigilant", citystr);
+
+      rally_orders
+        = secfile_lookup_str_default(loading->file, "",
+                                     "%s.rally_point_orders", citystr);
+      rally_dirs
+        = secfile_lookup_str_default(loading->file, "",
+                                     "%s.rally_point_dirs", citystr);
+      rally_activities
+        = secfile_lookup_str_default(loading->file, "",
+                                     "%s.rally_point_activities", citystr);
+      rally_actions
+        = secfile_lookup_str_default(loading->file, "",
+                                     "%s.rally_point_actions", citystr);
+
+      for (i = 0; i < len; i++) {
+        struct unit_order *order = &pcity->rally_point.orders[i];
+
+        if (rally_orders[i] == '\0' || rally_dirs[i] == '\0'
+            || rally_activities[i] == '\0') {
+          log_sg("Invalid rally point.");
+	  free(pcity->rally_point.orders);
+	  pcity->rally_point.orders = NULL;
+	  pcity->rally_point.length = 0;
+          break;
+        }
+        order->order = char2order(rally_orders[i]);
+        order->dir = char2dir(rally_dirs[i]);
+        order->activity = char2activity(rally_activities[i]);
+
+        if (rally_actions[i] == '?') {
+          order->action = ACTION_NONE;
+        } else {
+          unconverted = char2num(rally_actions[i]);
+
+          if (unconverted >= 0 && unconverted < loading->action.size) {
+            /* Look up what action id the unconverted number represents. */
+            order->action = loading->action.order[unconverted];
+          } else {
+            log_sg("Invalid action id in order for city rally point %d",
+                   pcity->id);
+
+            order->action = ACTION_NONE;
+          }
+        }
+
+        order->sub_target
+          = secfile_lookup_int_default(loading->file, -1,
+                                       "%s.rally_point_sub_tgt_vec,%d",
+                                       citystr, i);
+      }
+    } else {
+      pcity->rally_point.orders = NULL;
+
+      (void) secfile_entry_lookup(loading->file, "%s.rally_point_persistent",
+                                  citystr);
+      (void) secfile_entry_lookup(loading->file, "%s.rally_point_vigilant",
+                                  citystr);
+      (void) secfile_entry_lookup(loading->file, "%s.rally_point_orders",
+                                  citystr);
+      (void) secfile_entry_lookup(loading->file, "%s.rally_point_dirs",
+                                  citystr);
+      (void) secfile_entry_lookup(loading->file, "%s.rally_point_activities",
+                                  citystr);
+      (void) secfile_entry_lookup(loading->file, "%s.rally_point_actions",
+                                  citystr);
+      (void) secfile_entry_lookup(loading->file,
+                                  "%s.rally_point_sub_tgt_vec", citystr);
+    }
+  }
   CALL_FUNC_EACH_AI(city_load, loading->file, pcity, citystr);
 
   return TRUE;
@@ -4969,7 +5057,7 @@ static void sg_load_player_city_citizens(struct loaddata *loading,
 static void sg_save_player_cities(struct savedata *saving,
                                   struct player *plr)
 {
-  int wlist_max_length = 0;
+  int wlist_max_length = 0, rally_point_max_length = 0;
   int i = 0;
   int plrno = player_number(plr);
   bool nations[MAX_NUM_PLAYER_SLOTS];
@@ -4987,7 +5075,8 @@ static void sg_save_player_cities(struct savedata *saving,
     } player_slots_iterate_end;
   }
 
-  /* First determine lenght of longest worklist and the nations we have. */
+  /* First determine length of longest worklist, rally point order, and the
+   * nationalities we have. */
   city_list_iterate(plr->cities, pcity) {
     /* Check the sanity of the city. */
     city_refresh(pcity);
@@ -4995,6 +5084,10 @@ static void sg_save_player_cities(struct savedata *saving,
 
     if (pcity->worklist.length > wlist_max_length) {
       wlist_max_length = pcity->worklist.length;
+    }
+
+    if (pcity->rally_point.length > rally_point_max_length) {
+      rally_point_max_length = pcity->rally_point.length;
     }
 
     if (game.info.citizen_nationality) {
@@ -5177,6 +5270,90 @@ static void sg_save_player_cities(struct savedata *saving,
       secfile_insert_bool(saving->file, FALSE, "%s.allow_disorder", buf);
       secfile_insert_bool(saving->file, FALSE, "%s.allow_specialists", buf);
       secfile_insert_int(saving->file, 0, "%s.happy_factor", buf);
+    }
+
+    secfile_insert_int(saving->file, pcity->rally_point.length,
+                       "%s.rally_point_length", buf);
+    if (pcity->rally_point.length) {
+      int len = pcity->rally_point.length;
+      char orders[len + 1], dirs[len + 1], activities[len + 1];
+      char actions[len + 1];
+      int sub_targets[len];
+
+      secfile_insert_bool(saving->file, pcity->rally_point.persistent,
+                          "%s.rally_point_persistent", buf);
+      secfile_insert_bool(saving->file, pcity->rally_point.vigilant,
+                          "%s.rally_point_vigilant", buf);
+
+      for (j = 0; j < len; j++) {
+        orders[j] = order2char(pcity->rally_point.orders[j].order);
+        dirs[j] = '?';
+        activities[j] = '?';
+        sub_targets[j] = -1;
+        actions[j] = '?';
+        switch (pcity->rally_point.orders[j].order) {
+        case ORDER_MOVE:
+        case ORDER_ACTION_MOVE:
+          dirs[j] = dir2char(pcity->rally_point.orders[j].dir);
+          break;
+        case ORDER_ACTIVITY:
+          sub_targets[j] = pcity->rally_point.orders[j].sub_target;
+          activities[j]
+            = activity2char(pcity->rally_point.orders[j] .activity);
+          break;
+        case ORDER_PERFORM_ACTION:
+          actions[j] = num2char(pcity->rally_point.orders[j].action);
+          sub_targets[j] = pcity->rally_point.orders[j].sub_target;
+          if (direction8_is_valid(pcity->rally_point.orders[j].dir)) {
+            /* The action target is on another tile. */
+            dirs[j] = dir2char(pcity->rally_point.orders[j].dir);
+          }
+          break;
+        case ORDER_FULL_MP:
+        case ORDER_LAST:
+          break;
+        }
+      }
+      orders[len] = dirs[len] = activities[len] = actions[len] = '\0';
+
+      secfile_insert_str(saving->file, orders, "%s.rally_point_orders", buf);
+      secfile_insert_str(saving->file, dirs, "%s.rally_point_dirs", buf);
+      secfile_insert_str(saving->file, activities,
+                         "%s.rally_point_activities", buf);
+      secfile_insert_str(saving->file, actions, "%s.rally_point_actions",
+                         buf);
+      secfile_insert_int_vec(saving->file, sub_targets, len,
+                             "%s.rally_point_sub_tgt_vec", buf);
+
+      /* Fill in dummy values for order targets so the registry will save
+       * the unit table in a tabular format. */
+      for (j = len; j < rally_point_max_length; j++) {
+        secfile_insert_int(saving->file, -1, "%s.rally_point_sub_tgt_vec,%d",
+                           buf, j);
+      }
+    } else {
+      /* Put all the same fields into the savegame - otherwise the
+       * registry code can't correctly use a tabular format and the
+       * savegame will be bigger. */
+      secfile_insert_bool(saving->file, FALSE, "%s.rally_point_persistent",
+                         buf);
+      secfile_insert_bool(saving->file, FALSE, "%s.rally_point_vigilant",
+                         buf);
+      secfile_insert_str(saving->file, "-", "%s.rally_point_orders", buf);
+      secfile_insert_str(saving->file, "-", "%s.rally_point_dirs", buf);
+      secfile_insert_str(saving->file, "-", "%s.rally_point_activities",
+                         buf);
+      secfile_insert_str(saving->file, "-", "%s.rally_point_actions", buf);
+
+      /* The start of a vector has no number. */
+      secfile_insert_int(saving->file, -1, "%s.rally_point_sub_tgt_vec",
+                         buf);
+
+      /* Fill in dummy values for order targets so the registry will save
+       * the unit table in a tabular format. */
+      for (j = 1; j < rally_point_max_length; j++) {
+        secfile_insert_int(saving->file, -1, "%s.sub_tgt_vec,%d", buf, j);
+      }
     }
 
     i++;

--- a/freeciv/freeciv/server/settings.c
+++ b/freeciv/freeciv/server/settings.c
@@ -1856,7 +1856,8 @@ static struct setting settings[] = {
   GEN_INT("huts", wld.map.server.huts,
           SSET_MAP_ADD, SSET_GEOLOGY, SSET_VITAL, ALLOW_NONE, ALLOW_BASIC,
           N_("Amount of huts (bonus extras)"),
-          N_("Huts are tile extras that may be investigated by units. "
+          N_("Huts are tile extras that usually may be investigated by "
+             "units."
              "The server variable's scale is huts per thousand tiles."),
           huts_help, NULL, huts_action,
           MAP_MIN_HUTS, MAP_MAX_HUTS, MAP_DEFAULT_HUTS)

--- a/freeciv/freeciv/server/unithand.c
+++ b/freeciv/freeciv/server/unithand.c
@@ -2866,13 +2866,13 @@ bool unit_perform_action(struct player *pplayer,
   case ACTION_CULTIVATE:
     ACTION_STARTED_UNIT_TILE(action_type, actor_unit, target_tile,
                              unit_activity_handling_targeted(actor_unit,
-                                                             ACTIVITY_IRRIGATE,
+                                                             ACTIVITY_CULTIVATE,
                                                              &target_extra));
     break;
   case ACTION_PLANT:
     ACTION_STARTED_UNIT_TILE(action_type, actor_unit, target_tile,
                              unit_activity_handling_targeted(actor_unit,
-                                                             ACTIVITY_MINE,
+                                                             ACTIVITY_PLANT,
                                                              &target_extra));
     break;
   case ACTION_PILLAGE:
@@ -5588,6 +5588,8 @@ void handle_unit_orders(struct player *pplayer,
       case ACTIVITY_MINE:
       case ACTIVITY_IRRIGATE:
       case ACTIVITY_TRANSFORM:
+      case ACTIVITY_CULTIVATE:
+      case ACTIVITY_PLANT:
       case ACTIVITY_CONVERT:
       case ACTIVITY_UNKNOWN:        // new vigil activity
 	/* Simple activities. */

--- a/freeciv/freeciv/server/unithand.c
+++ b/freeciv/freeciv/server/unithand.c
@@ -5524,9 +5524,13 @@ void handle_unit_unload(struct player *pplayer, int cargo_id, int trans_id)
 void handle_unit_orders(struct player *pplayer,
                         const struct packet_unit_orders *packet)
 {
-  int length = packet->length, i;
+  int length = packet->length;
   struct unit *punit = player_unit_by_number(pplayer, packet->unit_id);
   struct tile *src_tile = index_to_tile(&(wld.map), packet->src_tile);
+  struct unit_order *order_list;
+#ifdef FREECIV_DEBUG
+  int i;
+#endif
 
   if (NULL == punit) {
     /* Probably died or bribed. */
@@ -5559,286 +5563,14 @@ void handle_unit_orders(struct player *pplayer,
     unit_activity_handling(punit, ACTIVITY_IDLE);
   }
 
-  for (i = 0; i < length; i++) {
-    if (packet->orders[i] < 0 || packet->orders[i] > ORDER_LAST) {
-      log_error("%s() %s (player nb %d) has sent an invalid order %d "
-                "at index %d, truncating", __FUNCTION__,
-                player_name(pplayer), player_number(pplayer),
-                packet->orders[i], i);
-      length = i;
-      break;
-    }
-    switch (packet->orders[i]) {
-    case ORDER_MOVE:
-    case ORDER_ACTION_MOVE:
-      if (!map_untrusted_dir_is_valid(packet->dir[i])) {
-        log_error("handle_unit_orders() %d isn't a valid move direction. "
-                  "Sent in order number %d from %s to unit number %d.",
-                  packet->dir[i], i,
-                  player_name(pplayer), packet->unit_id);
-
-	return;
-      }
-      break;
-    case ORDER_ACTIVITY:
-      switch (packet->activity[i]) {
-      case ACTIVITY_FALLOUT:
-      case ACTIVITY_POLLUTION:
-      case ACTIVITY_PILLAGE:
-      case ACTIVITY_MINE:
-      case ACTIVITY_IRRIGATE:
-      case ACTIVITY_TRANSFORM:
-      case ACTIVITY_CULTIVATE:
-      case ACTIVITY_PLANT:
-      case ACTIVITY_CONVERT:
-      case ACTIVITY_UNKNOWN:        // new vigil activity
-	/* Simple activities. */
-	break;
-      case ACTIVITY_FORTIFYING:
-      case ACTIVITY_SENTRY:
-        if (i != length - 1) {
-          /* Only allowed as the last order. */
-          log_error("handle_unit_orders() activity %d is only allowed in "
-                    "the last order. "
-                    "Sent in order number %d from %s to unit number %d.",
-                    packet->activity[i], i,
-                    player_name(pplayer), packet->unit_id);
-
-          return;
-        }
-        break;
-      case ACTIVITY_BASE:
-        if (!is_extra_caused_by(extra_by_number(packet->sub_target[i]),
-                                EC_BASE)) {
-          log_error("handle_unit_orders() %s isn't a base. "
-                    "Sent in order number %d from %s to unit number %d.",
-                    extra_rule_name(extra_by_number(packet->sub_target[i])),
-                    i, player_name(pplayer), packet->unit_id);
-
-          return;
-        }
-        break;
-      case ACTIVITY_GEN_ROAD:
-        if (!is_extra_caused_by(extra_by_number(packet->sub_target[i]),
-                                EC_ROAD)) {
-          log_error("handle_unit_orders() %s isn't a road. "
-                    "Sent in order number %d from %s to unit number %d.",
-                    extra_rule_name(extra_by_number(packet->sub_target[i])),
-                    i, player_name(pplayer), packet->unit_id);
-
-          return;
-        }
-        break;
-      /* Not supported yet. */
-      case ACTIVITY_EXPLORE:
-      case ACTIVITY_IDLE:
-      /* Not set from the client. */
-      case ACTIVITY_GOTO:
-      case ACTIVITY_FORTIFIED:
-      /* Compatiblity, used in savegames. */
-      case ACTIVITY_OLD_ROAD:
-      case ACTIVITY_OLD_RAILROAD:
-      case ACTIVITY_FORTRESS:
-      case ACTIVITY_AIRBASE:
-      /* Unused. */
-      case ACTIVITY_PATROL_UNUSED:
-      case ACTIVITY_LAST:
-        log_error("handle_unit_orders() unsupported activity %d. "
-                  "Sent in order number %d from %s to unit number %d.",
-                  packet->activity[i], i,
-                  player_name(pplayer), packet->unit_id);
-
-        return;
-      }
-
-      if (packet->sub_target[i] == EXTRA_NONE
-          && unit_activity_needs_target_from_client(packet->activity[i])) {
-        /* The orders system can't do server side target assignment for
-         * this activity. */
-        log_error("handle_unit_orders() can't assign target for %d. "
-                  "Sent in order number %d from %s to unit number %d.",
-                  packet->activity[i], i,
-                  player_name(pplayer), packet->unit_id);
-
-        return;
-      }
-
-      break;
-    case ORDER_PERFORM_ACTION:
-      if (!action_id_exists(packet->action[i])) {
-        /* Non existing action */
-        log_error("handle_unit_orders() the action %d doesn't exist. "
-                  "Sent in order number %d from %s to unit number %d.",
-                  packet->action[i], i,
-                  player_name(pplayer), packet->unit_id);
-
-        return;
-      }
-
-      if (action_id_distance_inside_max(packet->action[i], 2)) {
-        /* Long range actions aren't supported in unit orders. Clients
-         * should order them performed via the unit_do_action packet.
-         *
-         * Reason: A unit order stores an action's target as the tile it is
-         * located on. The tile is stored as a direction (when the target
-         * is at a tile adjacent to the actor unit tile) or as no
-         * direction (when the target is at the same tile as the actor
-         * unit). The order system will pick a suitable target at the
-         * specified tile during order execution. This makes it impossible
-         * to target something that isn't at or next to the actors tile.
-         * Being unable to exploit the full range of an action handicaps
-         * it.
-         *
-         * A patch that allows a distant target in an order should remove
-         * this check and update the comment in the Qt client's
-         * go_act_menu::create(). */
-
-        log_error("handle_unit_orders() the action %s isn't supported in "
-                  "unit orders. "
-                  "Sent in order number %d from %s to unit number %d.",
-                  action_id_name_translation(packet->action[i]), i,
-                  player_name(pplayer), packet->unit_id);
-
-        return;
-      }
-
-      if (!action_id_distance_inside_max(packet->action[i], 1)
-          && map_untrusted_dir_is_valid(packet->dir[i])) {
-        /* Actor must be on the target tile. */
-        log_error("handle_unit_orders() can't do %s to a neighbor tile. "
-                  "Sent in order number %d from %s to unit number %d.",
-                  action_id_rule_name(packet->action[i]), i,
-                  player_name(pplayer), packet->unit_id);
-
-        return;
-      }
-
-      /* Validate individual actions. */
-      switch ((enum gen_action) packet->action[i]) {
-      case ACTION_SPY_TARGETED_SABOTAGE_CITY:
-      case ACTION_SPY_TARGETED_SABOTAGE_CITY_ESC:
-        /* Sabotage target is production (-1) or a building. */
-        if (!(packet->sub_target[i] - 1 == -1
-              || improvement_by_number(packet->sub_target[i] - 1))) {
-          /* Sabotage target is invalid. */
-
-          log_error("handle_unit_orders() can't do %s without a target. "
-                    "Sent in order number %d from %s to unit number %d.",
-                    action_id_rule_name(packet->action[i]), i,
-                    player_name(pplayer), packet->unit_id);
-
-          return;
-        }
-        break;
-      case ACTION_SPY_TARGETED_STEAL_TECH:
-      case ACTION_SPY_TARGETED_STEAL_TECH_ESC:
-        if (packet->sub_target[i] == A_NONE
-            || (!valid_advance_by_number(packet->sub_target[i])
-                && packet->sub_target[i] != A_FUTURE)) {
-          /* Target tech is invalid. */
-
-          log_error("handle_unit_orders() can't do %s without a target. "
-                    "Sent in order number %d from %s to unit number %d.",
-                    action_id_rule_name(packet->action[i]), i,
-                    player_name(pplayer), packet->unit_id);
-
-          return;
-        }
-        break;
-      case ACTION_ROAD:
-      case ACTION_BASE:
-      case ACTION_MINE:
-      case ACTION_IRRIGATE:
-        if (packet->sub_target[i] == EXTRA_NONE
-            || (packet->sub_target[i] < 0
-                || packet->sub_target[i] >= game.control.num_extra_types)
-            || extra_by_number(packet->sub_target[i])->ruledit_disabled) {
-          /* Target extra is invalid. */
-
-          log_error("handle_unit_orders() can't do %s without a target. "
-                    "Sent in order number %d from %s to unit number %d.",
-                    action_id_rule_name(packet->action[i]), i,
-                    player_name(pplayer), packet->unit_id);
-
-          return;
-        }
-        break;
-      case ACTION_ESTABLISH_EMBASSY:
-      case ACTION_ESTABLISH_EMBASSY_STAY:
-      case ACTION_SPY_INVESTIGATE_CITY:
-      case ACTION_INV_CITY_SPEND:
-      case ACTION_SPY_POISON:
-      case ACTION_SPY_POISON_ESC:
-      case ACTION_SPY_STEAL_GOLD:
-      case ACTION_SPY_STEAL_GOLD_ESC:
-      case ACTION_SPY_SABOTAGE_CITY:
-      case ACTION_SPY_SABOTAGE_CITY_ESC:
-      case ACTION_SPY_STEAL_TECH:
-      case ACTION_SPY_STEAL_TECH_ESC:
-      case ACTION_SPY_INCITE_CITY:
-      case ACTION_SPY_INCITE_CITY_ESC:
-      case ACTION_TRADE_ROUTE:
-      case ACTION_MARKETPLACE:
-      case ACTION_HELP_WONDER:
-      case ACTION_SPY_BRIBE_UNIT:
-      case ACTION_SPY_ATTACK:
-      case ACTION_SPY_SABOTAGE_UNIT:
-      case ACTION_SPY_SABOTAGE_UNIT_ESC:
-      case ACTION_CAPTURE_UNITS:
-      case ACTION_FOUND_CITY:
-      case ACTION_JOIN_CITY:
-      case ACTION_STEAL_MAPS:
-      case ACTION_STEAL_MAPS_ESC:
-      case ACTION_BOMBARD:
-      case ACTION_SPY_NUKE:
-      case ACTION_SPY_NUKE_ESC:
-      case ACTION_NUKE:
-      case ACTION_DESTROY_CITY:
-      case ACTION_EXPEL_UNIT:
-      case ACTION_RECYCLE_UNIT:
-      case ACTION_DISBAND_UNIT:
-      case ACTION_HOME_CITY:
-      case ACTION_UPGRADE_UNIT:
-      case ACTION_ATTACK:
-      case ACTION_SUICIDE_ATTACK:
-      case ACTION_CONQUER_CITY:
-      case ACTION_PARADROP:
-      case ACTION_AIRLIFT:
-      case ACTION_HEAL_UNIT:
-      case ACTION_TRANSFORM_TERRAIN:
-      case ACTION_CULTIVATE:
-      case ACTION_PLANT:
-      case ACTION_PILLAGE:
-      case ACTION_CLEAN_FALLOUT:
-      case ACTION_CLEAN_POLLUTION:
-      case ACTION_FORTIFY:
-      case ACTION_CONVERT:
-        /* No validation required. */
-        break;
-      /* Invalid action. Should have been caught above. */
-      case ACTION_COUNT:
-        fc_assert_ret_msg(packet->action[i] != ACTION_NONE,
-                          "ACTION_NONE in ORDER_PERFORM_ACTION order. "
-                          "Order number %d from %s to unit number %d.",
-                          i, player_name(pplayer), packet->unit_id);
-      }
-
-      /* Don't validate that the target tile really contains a target or
-       * that the actor player's map think the target tile has one.
-       * The player may target a something from his player map that isn't
-       * there any more, a target he thinks is there even if his player map
-       * doesn't have it or even a target he assumes will be there when the
-       * unit reaches the target tile.
-       *
-       * With that said: The client should probably at least have an
-       * option to only aim city targeted actions at cities. */
-
-      break;
-    case ORDER_FULL_MP:
-      break;
-    case ORDER_LAST:
-      /* An invalid order.  This is handled in execute_orders. */
-      break;
+  if (length) {
+    order_list = create_unit_orders(length, packet->orders, packet->dir,
+                                    packet->activity, packet->sub_target,
+                                    packet->action);
+    if (!order_list) {
+      log_error("received invalid orders from %s for %s (%d).",
+                player_name(pplayer), unit_rule_name(punit), packet->unit_id);
+      return;
     }
   }
 
@@ -5867,14 +5599,8 @@ void handle_unit_orders(struct player *pplayer,
   punit->orders.index = 0;
   punit->orders.repeat = packet->repeat;
   punit->orders.vigilant = packet->vigilant;
-  punit->orders.list
-    = fc_malloc(length * sizeof(*(punit->orders.list)));
-  for (i = 0; i < length; i++) {
-    punit->orders.list[i].order = packet->orders[i];
-    punit->orders.list[i].dir = packet->dir[i];
-    punit->orders.list[i].activity = packet->activity[i];
-    punit->orders.list[i].sub_target = packet->sub_target[i];
-    punit->orders.list[i].action = packet->action[i];
+  if (length) {
+    punit->orders.list = order_list;
   }
 
   if (!packet->repeat) {

--- a/freeciv/freeciv/server/unittools.c
+++ b/freeciv/freeciv/server/unittools.c
@@ -946,8 +946,8 @@ void unit_activity_complete(struct unit *punit)
 {
   const enum unit_activity tile_changing_actions[] =
     { ACTIVITY_PILLAGE, ACTIVITY_GEN_ROAD, ACTIVITY_IRRIGATE, ACTIVITY_MINE,
-      ACTIVITY_BASE, ACTIVITY_TRANSFORM, ACTIVITY_POLLUTION,
-      ACTIVITY_FALLOUT, ACTIVITY_LAST };
+      ACTIVITY_BASE, ACTIVITY_CULTIVATE, ACTIVITY_PLANT, ACTIVITY_TRANSFORM,
+      ACTIVITY_POLLUTION, ACTIVITY_FALLOUT, ACTIVITY_LAST };
 
   bool unit_activity_done = FALSE;
   enum unit_activity activity = punit->activity;
@@ -1082,6 +1082,8 @@ void unit_activity_complete(struct unit *punit)
 
   case ACTIVITY_IRRIGATE:
   case ACTIVITY_MINE:
+  case ACTIVITY_CULTIVATE:
+  case ACTIVITY_PLANT:
   case ACTIVITY_TRANSFORM:
     if (total_activity_done(ptile, activity, punit->activity_target)) {
       struct terrain *old = tile_terrain(ptile);
@@ -1106,6 +1108,8 @@ void unit_activity_complete(struct unit *punit)
     update_tile_knowledge(ptile);
     if (ACTIVITY_IRRIGATE == activity
         || ACTIVITY_MINE == activity
+        || ACTIVITY_CULTIVATE == activity
+        || ACTIVITY_PLANT == activity
         || ACTIVITY_TRANSFORM == activity) {
       /* FIXME: As we might probably do the activity again, because of the
        * terrain change cycles, we need to treat these cases separatly.
@@ -1224,6 +1228,8 @@ static void update_unit_activity(struct unit *punit, time_t now)
   case ACTIVITY_MINE:
   case ACTIVITY_IRRIGATE:
   case ACTIVITY_PILLAGE:
+  case ACTIVITY_CULTIVATE:
+  case ACTIVITY_PLANT:
   case ACTIVITY_TRANSFORM:
   case ACTIVITY_FALLOUT:
   case ACTIVITY_BASE:
@@ -4223,6 +4229,8 @@ static void check_unit_activity(struct unit *punit)
   case ACTIVITY_POLLUTION:
   case ACTIVITY_MINE:
   case ACTIVITY_IRRIGATE:
+  case ACTIVITY_CULTIVATE:
+  case ACTIVITY_PLANT:
   case ACTIVITY_FORTIFIED:
   case ACTIVITY_FORTRESS:
   case ACTIVITY_PILLAGE:

--- a/freeciv/freeciv/server/unittools.c
+++ b/freeciv/freeciv/server/unittools.c
@@ -3627,17 +3627,23 @@ static bool hut_get_limited(struct unit *punit)
 static void unit_enter_hut(struct unit *punit)
 {
   struct player *pplayer = unit_owner(punit);
+  int id = punit->id;
   enum hut_behavior behavior = unit_class_get(punit)->hut_behavior;
   struct tile *ptile = unit_tile(punit);
+  bool hut = FALSE;
 
-  /* FIXME: Should we still run "hut_enter" script when
-   *        hut_behavior is HUT_NOTHING or HUT_FRIGHTEN? */ 
   if (behavior == HUT_NOTHING) {
     return;
   }
 
-  extra_type_by_cause_iterate(EC_HUT, pextra) {
-    if (tile_has_extra(ptile, pextra)) {
+  extra_type_by_rmcause_iterate(ERM_ENTER, pextra) {
+    if (tile_has_extra(ptile, pextra)
+        && are_reqs_active(pplayer, tile_owner(ptile), NULL, NULL, ptile,
+                           NULL, NULL, NULL, NULL, NULL, &pextra->rmreqs,
+                           RPT_CERTAIN)
+       ) {
+      hut = TRUE;
+      /* FIXME: are all enter-removes extras worth counting? */
       pplayer->server.huts++;
 
       destroy_extra(ptile, pextra);
@@ -3648,21 +3654,23 @@ static void unit_enter_hut(struct unit *punit)
       if (behavior == HUT_FRIGHTEN) {
         script_server_signal_emit("hut_frighten", punit,
                                   extra_rule_name(pextra));
-        return;
-      }
-  
-      /* AI with H_LIMITEDHUTS only gets 25 gold (or barbs if unlucky) */
-      if (is_ai(pplayer) && has_handicap(pplayer, H_LIMITEDHUTS)) {
+      } else if (is_ai(pplayer) && has_handicap(pplayer, H_LIMITEDHUTS)) {
+        /* AI with H_LIMITEDHUTS only gets 25 gold (or barbs if unlucky) */
         (void) hut_get_limited(punit);
-        return;
+      } else {
+        script_server_signal_emit("hut_enter", punit, extra_rule_name(pextra));
       }
 
-      /* FIXME: Should have parameter for hut extra type */
-      script_server_signal_emit("hut_enter", punit, extra_rule_name(pextra));
+      /* We need punit for the callbacks, can't continue if the unit died */
+      if (!unit_is_alive(id)) {
+        break;
+      }
     }
-  } extra_type_by_cause_iterate_end;
+  } extra_type_by_rmcause_iterate_end;
 
-  send_player_info_c(pplayer, pplayer->connections); /* eg, gold */
+  if (hut) {
+    send_player_info_c(pplayer, pplayer->connections); /* eg, gold */
+  }
   return;
 }
 
@@ -4729,10 +4737,8 @@ bool unit_move(struct unit *punit, struct tile *pdesttile, int move_cost,
 
   if (unit_lives) {
     /* Is there a hut? */
-    if (tile_has_cause_extra(pdesttile, EC_HUT)) {
-      unit_enter_hut(punit);
-      unit_lives = unit_is_alive(saved_id);
-    }
+    unit_enter_hut(punit);
+    unit_lives = unit_is_alive(saved_id);
   }
 
   conn_list_do_unbuffer(game.est_connections);

--- a/freeciv/freeciv/server/unittools.c
+++ b/freeciv/freeciv/server/unittools.c
@@ -5514,3 +5514,262 @@ bool is_unit_plural(struct unit *punit)
 
   return is_word_plural( utype_name_translation(unit_type_get(punit)) );
 }
+
+/**********************************************************************//**
+  Sanity-check unit order arrays from a packet and create a unit_order array
+  from their contents if valid.
+**************************************************************************/
+struct unit_order *create_unit_orders(int length,
+                                      const enum unit_orders *orders,
+                                      const enum direction8 *dir,
+                                      const enum unit_activity *activity,
+                                      const int *sub_target,
+                                      const action_id *action)
+{
+  int i;
+  struct unit_order *unit_orders;
+
+  for (i = 0; i < length; i++) {
+    if (orders[i] < 0 || orders[i] > ORDER_LAST) {
+      log_error("invalid order %d at index %d", orders[i], i);
+      return NULL;
+    }
+    switch (orders[i]) {
+    case ORDER_MOVE:
+    case ORDER_ACTION_MOVE:
+      if (!map_untrusted_dir_is_valid(dir[i])) {
+        log_error("in order %d, invalid move direction %d.", i, dir[i]);
+	return NULL;
+      }
+      break;
+    case ORDER_ACTIVITY:
+      switch (activity[i]) {
+      case ACTIVITY_FALLOUT:
+      case ACTIVITY_POLLUTION:
+      case ACTIVITY_PILLAGE:
+      case ACTIVITY_MINE:
+      case ACTIVITY_IRRIGATE:
+      case ACTIVITY_PLANT:
+      case ACTIVITY_CULTIVATE:
+      case ACTIVITY_TRANSFORM:
+      case ACTIVITY_CONVERT:
+      case ACTIVITY_UNKNOWN:        // new vigil activity
+	/* Simple activities. */
+	break;
+      case ACTIVITY_FORTIFYING:
+      case ACTIVITY_SENTRY:
+        if (i != length - 1) {
+          /* Only allowed as the last order. */
+          log_error("activity %d is not allowed at index %d.", activity[i],
+                    i);
+          return NULL;
+        }
+        break;
+      case ACTIVITY_BASE:
+        if (!is_extra_caused_by(extra_by_number(sub_target[i]),
+                                EC_BASE)) {
+          log_error("at index %d, %s isn't a base.", i,
+                    extra_rule_name(extra_by_number(sub_target[i])));
+          return NULL;
+        }
+        break;
+      case ACTIVITY_GEN_ROAD:
+        if (!is_extra_caused_by(extra_by_number(sub_target[i]),
+                                EC_ROAD)) {
+          log_error("at index %d, %s isn't a road.", i,
+                    extra_rule_name(extra_by_number(sub_target[i])));
+          return NULL;
+        }
+        break;
+      /* Not supported yet. */
+      case ACTIVITY_EXPLORE:
+      case ACTIVITY_IDLE:
+      /* Not set from the client. */
+      case ACTIVITY_GOTO:
+      case ACTIVITY_FORTIFIED:
+      /* Compatiblity, used in savegames. */
+      case ACTIVITY_OLD_ROAD:
+      case ACTIVITY_OLD_RAILROAD:
+      case ACTIVITY_FORTRESS:
+      case ACTIVITY_AIRBASE:
+      /* Unused. */
+      case ACTIVITY_PATROL_UNUSED:
+      case ACTIVITY_LAST:
+        log_error("at index %d, unsupported activity %d.", i, activity[i]);
+        return NULL;
+      }
+
+      if (sub_target[i] == EXTRA_NONE
+          && unit_activity_needs_target_from_client(activity[i])) {
+        /* The orders system can't do server side target assignment for
+         * this activity. */
+        log_error("activity %d at index %d requires target.", activity[i],
+                  i);
+        return NULL;
+      }
+
+      break;
+    case ORDER_PERFORM_ACTION:
+      if (!action_id_exists(action[i])) {
+        /* Non-existent action. */
+        log_error("at index %d, the action %d doesn't exist.", i, action[i]);
+        return NULL;
+      }
+
+      if (action_id_distance_inside_max(action[i], 2)) {
+        /* Long range actions aren't supported in unit orders. Clients
+         * should order them performed via the unit_do_action packet.
+         *
+         * Reason: A unit order stores an action's target as the tile it is
+         * located on. The tile is stored as a direction (when the target
+         * is at a tile adjacent to the actor unit tile) or as no
+         * direction (when the target is at the same tile as the actor
+         * unit). The order system will pick a suitable target at the
+         * specified tile during order execution. This makes it impossible
+         * to target something that isn't at or next to the actors tile.
+         * Being unable to exploit the full range of an action handicaps
+         * it.
+         *
+         * A patch that allows a distant target in an order should remove
+         * this check and update the comment in the Qt client's
+         * go_act_menu::create(). */
+        log_error("at index %d, the action %s isn't supported in unit "
+                  "orders.", i, action_id_name_translation(action[i]));
+        return NULL;
+      }
+
+      if (!action_id_distance_inside_max(action[i], 1)
+          && map_untrusted_dir_is_valid(dir[i])) {
+        /* Actor must be on the target tile. */
+        log_error("at index %d, cannot do %s on a neighbor tile.", i,
+                  action_id_rule_name(action[i]));
+        return NULL;
+      }
+
+      /* Validate individual actions. */
+      switch ((enum gen_action) action[i]) {
+      case ACTION_SPY_TARGETED_SABOTAGE_CITY:
+      case ACTION_SPY_TARGETED_SABOTAGE_CITY_ESC:
+        /* Sabotage target is production (-1) or a building. */
+        if (!(sub_target[i] - 1 == -1
+              || improvement_by_number(sub_target[i] - 1))) {
+          /* Sabotage target is invalid. */
+          log_error("at index %d, cannot do %s without a target.", i,
+                    action_id_rule_name(action[i]));
+          return NULL;
+        }
+        break;
+      case ACTION_SPY_TARGETED_STEAL_TECH:
+      case ACTION_SPY_TARGETED_STEAL_TECH_ESC:
+        if (sub_target[i] == A_NONE
+            || (!valid_advance_by_number(sub_target[i])
+                && sub_target[i] != A_FUTURE)) {
+          /* Target tech is invalid. */
+          log_error("at index %d, cannot do %s without a target.", i,
+                    action_id_rule_name(action[i]));
+          return NULL;
+        }
+        break;
+      case ACTION_ROAD:
+      case ACTION_BASE:
+      case ACTION_MINE:
+      case ACTION_IRRIGATE:
+        if (sub_target[i] == EXTRA_NONE
+            || (sub_target[i] < 0
+                || sub_target[i] >= game.control.num_extra_types)
+            || extra_by_number(sub_target[i])->ruledit_disabled) {
+          /* Target extra is invalid. */
+          log_error("at index %d, cannot do %s without a target.", i,
+                    action_id_rule_name(action[i]));
+          return NULL;
+        }
+        break;
+      case ACTION_ESTABLISH_EMBASSY:
+      case ACTION_ESTABLISH_EMBASSY_STAY:
+      case ACTION_SPY_INVESTIGATE_CITY:
+      case ACTION_INV_CITY_SPEND:
+      case ACTION_SPY_POISON:
+      case ACTION_SPY_POISON_ESC:
+      case ACTION_SPY_STEAL_GOLD:
+      case ACTION_SPY_STEAL_GOLD_ESC:
+      case ACTION_SPY_SABOTAGE_CITY:
+      case ACTION_SPY_SABOTAGE_CITY_ESC:
+      case ACTION_SPY_STEAL_TECH:
+      case ACTION_SPY_STEAL_TECH_ESC:
+      case ACTION_SPY_INCITE_CITY:
+      case ACTION_SPY_INCITE_CITY_ESC:
+      case ACTION_TRADE_ROUTE:
+      case ACTION_MARKETPLACE:
+      case ACTION_HELP_WONDER:
+      case ACTION_SPY_BRIBE_UNIT:
+      case ACTION_SPY_ATTACK:
+      case ACTION_SPY_SABOTAGE_UNIT:
+      case ACTION_SPY_SABOTAGE_UNIT_ESC:
+      case ACTION_CAPTURE_UNITS:
+      case ACTION_FOUND_CITY:
+      case ACTION_JOIN_CITY:
+      case ACTION_STEAL_MAPS:
+      case ACTION_STEAL_MAPS_ESC:
+      case ACTION_BOMBARD:
+      case ACTION_SPY_NUKE:
+      case ACTION_SPY_NUKE_ESC:
+      case ACTION_NUKE:
+      case ACTION_DESTROY_CITY:
+      case ACTION_EXPEL_UNIT:
+      case ACTION_RECYCLE_UNIT:
+      case ACTION_DISBAND_UNIT:
+      case ACTION_HOME_CITY:
+      case ACTION_UPGRADE_UNIT:
+      case ACTION_ATTACK:
+      case ACTION_SUICIDE_ATTACK:
+      case ACTION_CONQUER_CITY:
+      case ACTION_PARADROP:
+      case ACTION_AIRLIFT:
+      case ACTION_HEAL_UNIT:
+      case ACTION_TRANSFORM_TERRAIN:
+      case ACTION_CULTIVATE:
+      case ACTION_PLANT:
+      case ACTION_PILLAGE:
+      case ACTION_CLEAN_FALLOUT:
+      case ACTION_CLEAN_POLLUTION:
+      case ACTION_FORTIFY:
+      case ACTION_CONVERT:
+        /* No validation required. */
+        break;
+      /* Invalid action. Should have been caught above. */
+      case ACTION_COUNT:
+        fc_assert_ret_val_msg(action[i] != ACTION_NONE, NULL,
+                              "ACTION_NONE in ORDER_PERFORM_ACTION order. "
+                              "Order number %d.", i);
+      }
+
+      /* Don't validate that the target tile really contains a target or
+       * that the actor player's map think the target tile has one.
+       * The player may target a something from his player map that isn't
+       * there any more, a target he thinks is there even if his player map
+       * doesn't have it or even a target he assumes will be there when the
+       * unit reaches the target tile.
+       *
+       * With that said: The client should probably at least have an
+       * option to only aim city targeted actions at cities. */
+
+      break;
+    case ORDER_FULL_MP:
+      break;
+    case ORDER_LAST:
+      /* An invalid order.  This is handled in execute_orders. */
+      break;
+    }
+  }
+
+  unit_orders = fc_malloc(length * sizeof(*(unit_orders)));
+  for (i = 0; i < length; i++) {
+    unit_orders[i].order = orders[i];
+    unit_orders[i].dir = dir[i];
+    unit_orders[i].activity = activity[i];
+    unit_orders[i].sub_target = sub_target[i];
+    unit_orders[i].action = action[i];
+  }
+
+  return unit_orders;
+}

--- a/freeciv/freeciv/server/unittools.h
+++ b/freeciv/freeciv/server/unittools.h
@@ -196,4 +196,11 @@ extern char encoded_unit_emoji[128];
 // In those cases, do it yourself with get_web_unit_icon() and your own separate strings:
 #define UNIT_EMOJI(punit) get_web_unit_icon((const struct unit*)punit, &encoded_unit_emoji[0])
 
+struct unit_order *create_unit_orders(int length,
+                                      const enum unit_orders *orders,
+                                      const enum direction8 *dir,
+                                      const enum unit_activity *activity,
+                                      const int *sub_target,
+                                      const action_id *action);
+
 #endif  /* FC__UNITTOOLS_H */

--- a/freeciv/freeciv/tools/Makefile.am
+++ b/freeciv/freeciv/tools/Makefile.am
@@ -8,7 +8,11 @@ endif
 
 include $(top_srcdir)/bootstrap/Makerules.mk
 
-bin_PROGRAMS = freeciv-ruleup
+bin_PROGRAMS =
+
+if FCRULEUP
+bin_PROGRAMS += freeciv-ruleup
+endif
 
 if FCMANUAL
 bin_PROGRAMS += freeciv-manual

--- a/freeciv/freeciv/tools/ruleutil/rulesave.c
+++ b/freeciv/freeciv/tools/ruleutil/rulesave.c
@@ -1153,6 +1153,9 @@ static bool save_game_ruleset(const char *filename, const char *name)
   save_default_int(sfile, game.info.culture_migration_pml,
                    RS_DEFAULT_CULTURE_MIGRATION_PML,
                    "culture.migration_pml", NULL);
+  save_default_int(sfile, game.info.history_interest_pml,
+                   RS_DEFAULT_HISTORY_INTEREST_PML,
+                   "culture.history_interest_pml", NULL);
 
   save_default_bool(sfile, game.calendar.calendar_skip_0,
                     RS_DEFAULT_CALENDAR_SKIP_0,

--- a/freeciv/freeciv/translations/core/fi.po
+++ b/freeciv/freeciv/translations/core/fi.po
@@ -29,8 +29,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: freeciv 3.0\n"
 "Report-Msgid-Bugs-To: https://www.hostedredmine.com/projects/freeciv\n"
-"POT-Creation-Date: 2019-06-25 20:08+0300\n"
-"PO-Revision-Date: 2019-06-25 20:02+0300\n"
+"POT-Creation-Date: 2019-07-13 23:21+0300\n"
+"PO-Revision-Date: 2019-07-13 23:07+0300\n"
 "Last-Translator: Markus Linnakangas <markus.linnakangas@luukku.com>\n"
 "Language-Team: None <freeciv-i18n@gna.org>\n"
 "Language: fi\n"
@@ -592,8 +592,8 @@ msgstr "ei koskaan"
 #: client/gui-gtk-3.22/helpdlg.c:1255 client/gui-gtk-3.22/helpdlg.c:1267
 #: client/gui-gtk-3.22/helpdlg.c:1278 client/gui-qt/citydlg.cpp:3005
 #: client/gui-qt/helpdlg.cpp:1317 client/gui-qt/helpdlg.cpp:1342
-#: client/gui-qt/helpdlg.cpp:1366 client/helpdata.c:3217 client/text.c:900
-#: client/text.c:1367
+#: client/gui-qt/helpdlg.cpp:1366 client/helpdata.c:3225 client/text.c:900
+#: client/text.c:1369
 #, c-format
 msgid "%d turn"
 msgid_plural "%d turns"
@@ -1102,8 +1102,8 @@ msgstr "Parhaat puolustusyksiköt"
 #: client/gui-gtk-3.0/repodlgs.c:1611 client/gui-gtk-3.22/cityrep.c:1514
 #: client/gui-gtk-3.22/cityrep.c:1533 client/gui-gtk-3.22/cityrep.c:1552
 #: client/gui-gtk-3.22/cityrep.c:1571 client/gui-gtk-3.22/cityrep.c:1591
-#: client/gui-gtk-3.22/menu.c:289 client/gui-gtk-3.22/menu.c:319
-#: client/gui-gtk-3.22/menu.c:401 client/gui-gtk-3.22/repodlgs.c:1611
+#: client/gui-gtk-3.22/menu.c:293 client/gui-gtk-3.22/menu.c:323
+#: client/gui-gtk-3.22/menu.c:405 client/gui-gtk-3.22/repodlgs.c:1611
 #: client/gui-qt/cityrep.cpp:719 client/gui-qt/menu.cpp:1526
 #: client/gui-qt/pages.cpp:722 client/gui-qt/pages.cpp:1275
 #: client/gui-sdl2/helpdlg.c:750 client/gui-sdl2/mapctrl.c:1733
@@ -1197,7 +1197,7 @@ msgstr "Korruptio"
 
 #: client/cityrepdata.c:748 client/gui-gtk-3.0/menu.c:312
 #: client/gui-gtk-3.0/menu.c:426 client/gui-gtk-3.0/repodlgs.c:1084
-#: client/gui-gtk-3.22/menu.c:311 client/gui-gtk-3.22/menu.c:425
+#: client/gui-gtk-3.22/menu.c:315 client/gui-gtk-3.22/menu.c:429
 #: client/gui-gtk-3.22/repodlgs.c:1083 client/gui-qt/menu.cpp:1539
 #: client/gui-qt/pages.cpp:737 client/gui-sdl2/mapctrl.c:1503
 #: client/include/helpdlg_g.h:42 data/helpdata.txt:452
@@ -1288,11 +1288,11 @@ msgstr "Saa"
 
 # *** Depends too much on the context, phenomenom pollution & 'substance' pollution
 # aren't the same. ***
-#: client/cityrepdata.c:768 common/events.c:157 common/unit.c:539
-#: data/civ1/terrain.ruleset:928 data/civ2/terrain.ruleset:1000
-#: data/classic/terrain.ruleset:1213 data/sandbox/terrain.ruleset:1267
-#: data/civ2civ3/terrain.ruleset:1266 data/alien/terrain.ruleset:788
-#: data/multiplayer/terrain.ruleset:1187 server/report.c:173
+#: client/cityrepdata.c:768 common/events.c:157 common/unit.c:541
+#: data/civ1/terrain.ruleset:934 data/civ2/terrain.ruleset:1006
+#: data/classic/terrain.ruleset:1219 data/sandbox/terrain.ruleset:1273
+#: data/civ2civ3/terrain.ruleset:1272 data/alien/terrain.ruleset:794
+#: data/multiplayer/terrain.ruleset:1193 server/report.c:173
 msgid "Pollution"
 msgstr "Saastetta"
 
@@ -1314,7 +1314,7 @@ msgstr "Käskynhaltija"
 
 #: client/cityrepdata.c:772 client/gui-gtk-3.0/cityrep.c:1882
 #: client/gui-gtk-3.0/menu.c:344 client/gui-gtk-3.22/cityrep.c:1880
-#: client/gui-gtk-3.22/menu.c:343 client/gui-sdl2/citydlg.c:3746
+#: client/gui-gtk-3.22/menu.c:347 client/gui-sdl2/citydlg.c:3746
 #: client/gui-sdl2/cma_fe.c:912 client/include/helpdlg_g.h:37
 #: data/helpdata.txt:1780
 msgid "Citizen Governor"
@@ -1861,8 +1861,8 @@ msgstr ""
 
 #: client/editor.c:199 client/gui-gtk-3.0/editprop.c:4392
 #: client/gui-gtk-3.0/menu.c:310 client/gui-gtk-3.0/menu.c:382
-#: client/gui-gtk-3.22/editprop.c:4391 client/gui-gtk-3.22/menu.c:309
-#: client/gui-gtk-3.22/menu.c:381 client/include/helpdlg_g.h:50
+#: client/gui-gtk-3.22/editprop.c:4391 client/gui-gtk-3.22/menu.c:313
+#: client/gui-gtk-3.22/menu.c:385 client/include/helpdlg_g.h:50
 #: data/helpdata.txt:290 tools/civmanual.c:453
 msgid "Terrain"
 msgstr "Maasto"
@@ -1907,10 +1907,10 @@ msgstr ""
 
 #: client/editor.c:211 client/gui-gtk-3.0/citydlg.c:2920
 #: client/gui-gtk-3.22/citydlg.c:2924 client/gui-qt/citydlg.cpp:1313
-#: common/unit.c:564 data/civ1/terrain.ruleset:1048
-#: data/civ2/terrain.ruleset:1183 data/classic/terrain.ruleset:1478
-#: data/sandbox/terrain.ruleset:1668 data/civ2civ3/terrain.ruleset:1631
-#: data/alien/terrain.ruleset:976 data/multiplayer/terrain.ruleset:1452
+#: common/unit.c:570 data/civ1/terrain.ruleset:1054
+#: data/civ2/terrain.ruleset:1189 data/classic/terrain.ruleset:1484
+#: data/sandbox/terrain.ruleset:1673 data/civ2civ3/terrain.ruleset:1637
+#: data/alien/terrain.ruleset:982 data/multiplayer/terrain.ruleset:1458
 msgid "Road"
 msgstr "tie"
 
@@ -1940,7 +1940,7 @@ msgstr ""
 
 #: client/editor.c:219 client/gui-gtk-3.0/editprop.c:672
 #: client/gui-gtk-3.0/menu.c:438 client/gui-gtk-3.0/unitselect.c:95
-#: client/gui-gtk-3.22/editprop.c:672 client/gui-gtk-3.22/menu.c:437
+#: client/gui-gtk-3.22/editprop.c:672 client/gui-gtk-3.22/menu.c:441
 #: client/gui-gtk-3.22/unitselect.c:95 client/gui-qt/menu.cpp:1191
 msgid "Unit"
 msgstr "Yksikkö"
@@ -2087,7 +2087,7 @@ msgstr "%d jäljellä"
 #: client/gui-qt/dialogs.cpp:3041 client/gui-qt/dialogs.cpp:3104
 #: client/gui-qt/repodlgs.cpp:213 client/gui-sdl2/action_dialog.c:2511
 #: client/gui-sdl2/action_dialog.c:2774 client/gui-sdl2/citydlg.c:1146
-#: client/gui-sdl2/repodlgs.c:211 client/text.c:1278 common/unit.c:1910
+#: client/gui-sdl2/repodlgs.c:211 client/text.c:1280 common/unit.c:1942
 #, c-format
 msgid "Treasury contains %d gold."
 msgid_plural "Treasury contains %d gold."
@@ -2275,7 +2275,7 @@ msgstr "Ruudun yksiköt:"
 #: client/gui-gtk-3.0/action_dialog.c:1758
 #: client/gui-gtk-3.0/action_dialog.c:1864 client/gui-gtk-3.0/menu.c:437
 #: client/gui-gtk-3.22/action_dialog.c:1752
-#: client/gui-gtk-3.22/action_dialog.c:1858 client/gui-gtk-3.22/menu.c:436
+#: client/gui-gtk-3.22/action_dialog.c:1858 client/gui-gtk-3.22/menu.c:440
 #: client/gui-qt/cityrep.cpp:546 client/gui-qt/hudwidget.cpp:1407
 #: client/gui-qt/menu.cpp:1148
 msgid "Select"
@@ -2652,9 +2652,9 @@ msgstr "tiede"
 #: client/gui-gtk-3.0/repodlgs.c:1287 client/gui-gtk-3.22/citydlg.c:1357
 #: client/gui-gtk-3.22/editprop.c:4528 client/gui-gtk-3.22/repodlgs.c:1287
 #: client/gui-qt/citydlg.cpp:1878 client/gui-qt/pages.cpp:1281 common/city.c:86
-#: data/civ1/terrain.ruleset:1140 data/civ2/terrain.ruleset:1279
-#: data/classic/terrain.ruleset:1573 data/sandbox/terrain.ruleset:1818
-#: data/civ2civ3/terrain.ruleset:1777 data/multiplayer/terrain.ruleset:1547
+#: data/civ1/terrain.ruleset:1146 data/civ2/terrain.ruleset:1285
+#: data/classic/terrain.ruleset:1579 data/sandbox/terrain.ruleset:1823
+#: data/civ2civ3/terrain.ruleset:1783 data/multiplayer/terrain.ruleset:1553
 msgid "Gold"
 msgstr "kultaa"
 
@@ -2832,22 +2832,22 @@ msgid "Clear request"
 msgstr "Poista pyyntö"
 
 #: client/gui-gtk-3.0/citydlg.c:2907 client/gui-gtk-3.22/citydlg.c:2911
-#: client/gui-qt/citydlg.cpp:1312 data/civ1/terrain.ruleset:904
-#: data/civ2/terrain.ruleset:976 data/classic/terrain.ruleset:1158
-#: data/sandbox/terrain.ruleset:1182 data/civ2civ3/terrain.ruleset:1181
-#: data/alien/terrain.ruleset:768 data/multiplayer/terrain.ruleset:1132
+#: client/gui-qt/citydlg.cpp:1312 data/civ1/terrain.ruleset:910
+#: data/civ2/terrain.ruleset:982 data/classic/terrain.ruleset:1164
+#: data/sandbox/terrain.ruleset:1188 data/civ2civ3/terrain.ruleset:1187
+#: data/alien/terrain.ruleset:774 data/multiplayer/terrain.ruleset:1138
 msgid "Mine"
 msgstr "kaivos"
 
 #: client/gui-gtk-3.0/citydlg.c:2915 client/gui-gtk-3.22/citydlg.c:2919
 #: client/gui-qt/citydlg.cpp:1309 client/gui-qt/citydlg.cpp:1310
-#: common/unit.c:544
+#: common/unit.c:548
 msgid "Irrigate"
 msgstr "Rakenna viljely"
 
 #: client/gui-gtk-3.0/citydlg.c:2926 client/gui-gtk-3.22/citydlg.c:2930
 #: client/gui-qt/citydlg.cpp:1314 client/gui-qt/shortcuts.cpp:132
-#: common/unit.c:558 data/civ2/units.ruleset:25 data/classic/units.ruleset:31
+#: common/unit.c:564 data/civ2/units.ruleset:25 data/classic/units.ruleset:31
 #: data/sandbox/units.ruleset:31 data/civ2civ3/units.ruleset:31
 #: data/multiplayer/units.ruleset:31 tools/civmanual.c:457
 msgid "Transform"
@@ -2855,7 +2855,7 @@ msgstr "Muokkaa"
 
 #: client/gui-gtk-3.0/citydlg.c:2932 client/gui-gtk-3.0/menu.c:506
 #: client/gui-gtk-3.0/menu.c:2502 client/gui-gtk-3.22/citydlg.c:2936
-#: client/gui-gtk-3.22/menu.c:505 client/gui-gtk-3.22/menu.c:2501
+#: client/gui-gtk-3.22/menu.c:509 client/gui-gtk-3.22/menu.c:2514
 #: client/gui-qt/citydlg.cpp:1315 client/gui-qt/menu.cpp:1346
 #: client/gui-qt/menu.cpp:2203 client/gui-sdl2/menu.c:748
 msgid "Clean Pollution"
@@ -3013,8 +3013,8 @@ msgstr "_Näytä"
 
 #: client/gui-gtk-3.0/cityrep.c:1147 client/gui-gtk-3.0/menu.c:294
 #: client/gui-gtk-3.0/menu.c:314 client/gui-gtk-3.0/menu.c:400
-#: client/gui-gtk-3.22/cityrep.c:1146 client/gui-gtk-3.22/menu.c:293
-#: client/gui-gtk-3.22/menu.c:313 client/gui-gtk-3.22/menu.c:399
+#: client/gui-gtk-3.22/cityrep.c:1146 client/gui-gtk-3.22/menu.c:297
+#: client/gui-gtk-3.22/menu.c:317 client/gui-gtk-3.22/menu.c:403
 #: client/gui-qt/diplodlg.cpp:382 client/gui-qt/menu.cpp:1535
 #: client/gui-qt/pages.cpp:725 client/gui-qt/pages.cpp:1269
 #: client/gui-sdl2/diplodlg.c:742 client/include/helpdlg_g.h:43
@@ -3034,7 +3034,7 @@ msgstr "_Tarkasta"
 #: client/gui-gtk-3.0/cityrep.c:1597 client/gui-gtk-3.0/menu.c:252
 #: client/gui-gtk-3.22/cityrep.c:1516 client/gui-gtk-3.22/cityrep.c:1535
 #: client/gui-gtk-3.22/cityrep.c:1554 client/gui-gtk-3.22/cityrep.c:1573
-#: client/gui-gtk-3.22/cityrep.c:1595 client/gui-gtk-3.22/menu.c:251
+#: client/gui-gtk-3.22/cityrep.c:1595 client/gui-gtk-3.22/menu.c:253
 #: client/gui-sdl2/helpdlg.c:335
 msgid "Improvements"
 msgstr "Rakennushankkeet"
@@ -3243,8 +3243,8 @@ msgstr "Valitse mitä haluat turmella:"
 
 #. TRANS: Pillage dialog do button text.
 #: client/gui-gtk-3.0/dialogs.c:374 client/gui-gtk-3.0/menu.c:516
-#: client/gui-gtk-3.22/dialogs.c:368 client/gui-gtk-3.22/menu.c:515
-#: client/gui-qt/menu.cpp:1286 client/gui-sdl2/menu.c:698 common/unit.c:552
+#: client/gui-gtk-3.22/dialogs.c:368 client/gui-gtk-3.22/menu.c:519
+#: client/gui-qt/menu.cpp:1286 client/gui-sdl2/menu.c:698 common/unit.c:558
 msgid "Pillage"
 msgstr "Turmele"
 
@@ -3401,19 +3401,19 @@ msgstr "Läh_etystö"
 
 #: client/gui-gtk-3.0/diplodlg.c:423 client/gui-gtk-3.22/diplodlg.c:423
 #: client/gui-qt/diplodlg.cpp:420 client/gui-sdl2/diplodlg.c:507
-#: common/player.h:145
+#: common/player.h:146
 msgid "?diplomatic_state:Cease-fire"
 msgstr "Tulitauko"
 
 #: client/gui-gtk-3.0/diplodlg.c:429 client/gui-gtk-3.22/diplodlg.c:429
 #: client/gui-qt/diplodlg.cpp:426 client/gui-sdl2/diplodlg.c:521
-#: common/player.h:147
+#: common/player.h:148
 msgid "?diplomatic_state:Peace"
 msgstr "Rauha"
 
 #: client/gui-gtk-3.0/diplodlg.c:435 client/gui-gtk-3.22/diplodlg.c:435
 #: client/gui-qt/diplodlg.cpp:432 client/gui-sdl2/diplodlg.c:537
-#: common/player.h:149
+#: common/player.h:150
 msgid "?diplomatic_state:Alliance"
 msgstr "Liittouma"
 
@@ -3616,13 +3616,13 @@ msgid "(destroyed)"
 msgstr "(tuhoutunut)"
 
 #: client/gui-gtk-3.0/editprop.c:3544 client/gui-gtk-3.0/menu.c:251
-#: client/gui-gtk-3.22/editprop.c:3544 client/gui-gtk-3.22/menu.c:250
+#: client/gui-gtk-3.22/editprop.c:3544 client/gui-gtk-3.22/menu.c:252
 #: client/gui-qt/cityrep.cpp:487 client/gui-qt/menu.cpp:1031
 msgid "?verb:View"
 msgstr "Näytä"
 
 #: client/gui-gtk-3.0/editprop.c:3546 client/gui-gtk-3.0/menu.c:250
-#: client/gui-gtk-3.22/editprop.c:3546 client/gui-gtk-3.22/menu.c:249
+#: client/gui-gtk-3.22/editprop.c:3546 client/gui-gtk-3.22/menu.c:251
 msgid "Edit"
 msgstr "Muuta"
 
@@ -3740,7 +3740,7 @@ msgid "Roads"
 msgstr "tiet"
 
 #: client/gui-gtk-3.0/editprop.c:4420 client/gui-gtk-3.0/menu.c:392
-#: client/gui-gtk-3.22/editprop.c:4419 client/gui-gtk-3.22/menu.c:391
+#: client/gui-gtk-3.22/editprop.c:4419 client/gui-gtk-3.22/menu.c:395
 msgid "Bases"
 msgstr "Tukikohdat"
 
@@ -3765,7 +3765,7 @@ msgstr "Vältä kansakuntia"
 #. TRANS: Nations report title
 #: client/gui-gtk-3.0/editprop.c:4445 client/gui-gtk-3.0/menu.c:292
 #: client/gui-gtk-3.0/plrdlg.c:428 client/gui-gtk-3.22/editprop.c:4444
-#: client/gui-gtk-3.22/menu.c:291 client/gui-gtk-3.22/plrdlg.c:426
+#: client/gui-gtk-3.22/menu.c:295 client/gui-gtk-3.22/plrdlg.c:426
 #: client/gui-qt/pages.cpp:730 client/gui-sdl2/mapctrl.c:1706
 #: client/gui-sdl2/plrdlg.c:675
 msgid "Nations"
@@ -3825,7 +3825,7 @@ msgstr "Tuotantovaranto"
 
 #: client/gui-gtk-3.0/editprop.c:4517 client/gui-gtk-3.0/menu.c:326
 #: client/gui-gtk-3.0/menu.c:521 client/gui-gtk-3.22/editprop.c:4516
-#: client/gui-gtk-3.22/menu.c:325 client/gui-gtk-3.22/menu.c:520
+#: client/gui-gtk-3.22/menu.c:329 client/gui-gtk-3.22/menu.c:524
 #: client/gui-qt/menu.cpp:613 client/include/helpdlg_g.h:52
 #: data/helpdata.txt:1369
 msgid "Government"
@@ -3976,12 +3976,12 @@ msgstr ""
 #: client/gui-gtk-3.0/editprop.c:6531 client/gui-gtk-3.0/pages.c:727
 #: client/gui-gtk-3.22/editprop.c:6531 client/gui-gtk-3.22/pages.c:728
 #: client/gui-qt/pages.cpp:905 client/gui-sdl2/citydlg.c:1978 client/text.c:169
-#: common/unit.c:578
+#: common/unit.c:584
 msgid "Unknown"
 msgstr "Tuntematon"
 
 #: client/gui-gtk-3.0/finddlg.c:72 client/gui-gtk-3.0/menu.c:282
-#: client/gui-gtk-3.22/finddlg.c:72 client/gui-gtk-3.22/menu.c:281
+#: client/gui-gtk-3.22/finddlg.c:72 client/gui-gtk-3.22/menu.c:283
 #: client/gui-sdl2/finddlg.c:149 client/gui-sdl2/mapctrl.c:1718
 msgid "Find City"
 msgstr "Etsi kaupunki"
@@ -4001,7 +4001,7 @@ msgid "Change policies"
 msgstr "Muuta linjauksia"
 
 #: client/gui-gtk-3.0/gamedlgs.c:323 client/gui-gtk-3.0/menu.c:308
-#: client/gui-gtk-3.22/gamedlgs.c:323 client/gui-gtk-3.22/menu.c:307
+#: client/gui-gtk-3.22/gamedlgs.c:323 client/gui-gtk-3.22/menu.c:311
 #: client/include/helpdlg_g.h:57 data/helpdata.txt:1428
 msgid "Policies"
 msgstr "Linjaukset"
@@ -4062,7 +4062,7 @@ msgid "Show _All Cities"
 msgstr "_Näytä kaikki kaupungit"
 
 #: client/gui-gtk-3.0/gotodlg.c:345 client/gui-gtk-3.22/gotodlg.c:346
-#: client/text.c:1106
+#: client/text.c:1108
 msgid "No units selected."
 msgstr "Ei valittua yksikköä."
 
@@ -4155,7 +4155,7 @@ msgid "Shift+Return"
 msgstr "Shift+Enter"
 
 #: client/gui-gtk-3.0/gui_main.c:1441 client/gui-gtk-3.0/menu.c:288
-#: client/gui-gtk-3.22/gui_main.c:1454 client/gui-gtk-3.22/menu.c:287
+#: client/gui-gtk-3.22/gui_main.c:1454 client/gui-gtk-3.22/menu.c:291
 #: client/gui-qt/menu.cpp:1522 client/gui-qt/pages.cpp:716
 msgid "?noun:View"
 msgstr "Näkymä"
@@ -4542,12 +4542,12 @@ msgstr "Asiakasohjelman Lua-konsoli"
 msgid "Load Lua Script"
 msgstr "Lataa Lua-skripti"
 
-#: client/gui-gtk-3.0/mapctrl.c:196 client/gui-gtk-3.22/mapctrl.c:197
+#: client/gui-gtk-3.0/mapctrl.c:196 client/gui-gtk-3.22/mapctrl.c:198
 #: client/gui-qt/mapctrl.cpp:57
 msgid "Build New City"
 msgstr "Perusta uusi kaupunki"
 
-#: client/gui-gtk-3.0/mapctrl.c:197 client/gui-gtk-3.22/mapctrl.c:198
+#: client/gui-gtk-3.0/mapctrl.c:197 client/gui-gtk-3.22/mapctrl.c:199
 #: client/gui-qt/mapctrl.cpp:56 client/gui-sdl2/mapctrl.c:2828
 msgid "What should we call our new city?"
 msgstr "Mikä annetaan uudelle kaupungille nimeksi?"
@@ -4573,12 +4573,12 @@ msgstr ""
 msgid "Shows your current luxury/science/tax rates; click to toggle them."
 msgstr "Näyttää nykyisen luksus/tutkimus/vero -tasosi, napsauta muuttaaksesi."
 
-#: client/gui-gtk-3.0/menu.c:248 client/gui-gtk-3.22/menu.c:247
+#: client/gui-gtk-3.0/menu.c:248 client/gui-gtk-3.22/menu.c:249
 #: client/gui-qt/menu.cpp:990
 msgid "Game"
 msgstr "Peli"
 
-#: client/gui-gtk-3.0/menu.c:249 client/gui-gtk-3.22/menu.c:248
+#: client/gui-gtk-3.0/menu.c:249 client/gui-gtk-3.22/menu.c:250
 #: client/gui-qt/citydlg.cpp:2675 client/gui-qt/menu.cpp:992
 #: client/gui-qt/pages.cpp:197 client/gui-sdl2/mapctrl.c:1769
 #: client/gui-sdl2/optiondlg.c:789 client/gui-sdl2/optiondlg.c:1368
@@ -4586,346 +4586,346 @@ msgstr "Peli"
 msgid "Options"
 msgstr "Valinnat"
 
-#: client/gui-gtk-3.0/menu.c:254 client/gui-gtk-3.22/menu.c:253
+#: client/gui-gtk-3.0/menu.c:254 client/gui-gtk-3.22/menu.c:255
 #: client/gui-qt/menu.cpp:1508
 msgid "Civilization"
 msgstr "Kansakunta"
 
 #: client/gui-gtk-3.0/menu.c:256 client/gui-gtk-3.0/repodlgs.c:576
-#: client/gui-gtk-3.22/cma_fe.c:427 client/gui-gtk-3.22/menu.c:255
+#: client/gui-gtk-3.22/cma_fe.c:427 client/gui-gtk-3.22/menu.c:257
 #: client/gui-gtk-3.22/repodlgs.c:575 client/gui-gtk-3.22/wldlg.c:1229
 #: client/gui-qt/menu.cpp:1571
 msgid "Help"
 msgstr "Ohje"
 
-#: client/gui-gtk-3.0/menu.c:257 client/gui-gtk-3.22/menu.c:256
+#: client/gui-gtk-3.0/menu.c:257 client/gui-gtk-3.22/menu.c:258
 msgid "Clear Chat Log"
 msgstr "Tyhjennä keskustelualue"
 
-#: client/gui-gtk-3.0/menu.c:259 client/gui-gtk-3.22/menu.c:258
+#: client/gui-gtk-3.0/menu.c:259 client/gui-gtk-3.22/menu.c:260
 msgid "Save Chat Log"
 msgstr "Talleta keskusteluviestit"
 
-#: client/gui-gtk-3.0/menu.c:261 client/gui-gtk-3.22/menu.c:260
+#: client/gui-gtk-3.0/menu.c:261 client/gui-gtk-3.22/menu.c:262
 msgid "Local Client"
 msgstr "Paikalliset asetukset"
 
-#: client/gui-gtk-3.0/menu.c:263 client/gui-gtk-3.22/menu.c:262
+#: client/gui-gtk-3.0/menu.c:263 client/gui-gtk-3.22/menu.c:264
 msgid "Message"
 msgstr "Viestiasetukset"
 
-#: client/gui-gtk-3.0/menu.c:265 client/gui-gtk-3.22/menu.c:264
+#: client/gui-gtk-3.0/menu.c:265 client/gui-gtk-3.22/menu.c:266
 msgid "Remote Server"
 msgstr "Etäpalvelimen asetukset"
 
-#: client/gui-gtk-3.0/menu.c:267 client/gui-gtk-3.22/menu.c:266
+#: client/gui-gtk-3.0/menu.c:267 client/gui-gtk-3.22/menu.c:268
 #: client/gui-qt/menu.cpp:1003
 msgid "Save Options Now"
 msgstr "Tallenna asetukset nyt"
 
-#: client/gui-gtk-3.0/menu.c:269 client/gui-gtk-3.22/menu.c:268
+#: client/gui-gtk-3.0/menu.c:269 client/gui-gtk-3.22/menu.c:270
 msgid "Reload Tileset"
 msgstr "Lataa kuvitus uudelleen"
 
 #: client/gui-gtk-3.0/menu.c:271 client/gui-gtk-3.0/pages.c:3459
-#: client/gui-gtk-3.22/menu.c:270 client/gui-gtk-3.22/pages.c:3458
+#: client/gui-gtk-3.22/menu.c:272 client/gui-gtk-3.22/pages.c:3458
 #: client/gui-qt/menu.cpp:1011 client/gui-sdl2/optiondlg.c:852
 msgid "Save Game"
 msgstr "Tallenna peli"
 
-#: client/gui-gtk-3.0/menu.c:273 client/gui-gtk-3.22/menu.c:272
+#: client/gui-gtk-3.0/menu.c:273 client/gui-gtk-3.22/menu.c:274
 #: client/gui-qt/menu.cpp:1016 client/gui-qt/menu.cpp:3495
 msgid "Save Game As..."
 msgstr "Tallenna peli nimellä..."
 
 #: client/gui-gtk-3.0/menu.c:275 client/gui-gtk-3.0/pages.c:3523
-#: client/gui-gtk-3.22/menu.c:274 client/gui-gtk-3.22/pages.c:3522
+#: client/gui-gtk-3.22/menu.c:276 client/gui-gtk-3.22/pages.c:3522
 msgid "Save Map Image"
 msgstr "Tallenna karttakuva"
 
-#: client/gui-gtk-3.0/menu.c:277 client/gui-gtk-3.22/menu.c:276
+#: client/gui-gtk-3.0/menu.c:277 client/gui-gtk-3.22/menu.c:278
 msgid "Save Map Image As..."
 msgstr "Tallenna karttakuva nimellä..."
 
-#: client/gui-gtk-3.0/menu.c:279 client/gui-gtk-3.22/menu.c:278
+#: client/gui-gtk-3.0/menu.c:279 client/gui-gtk-3.22/menu.c:280
 msgid "Leave"
 msgstr "Poistu"
 
-#: client/gui-gtk-3.0/menu.c:280 client/gui-gtk-3.22/menu.c:279
+#: client/gui-gtk-3.0/menu.c:280 client/gui-gtk-3.22/menu.c:281
 #: client/gui-qt/menu.cpp:1026 client/gui-qt/pages.cpp:197
 #: client/gui-sdl2/optiondlg.c:884 client/gui-sdl2/pages.c:279
 msgid "Quit"
 msgstr "Lopeta"
 
-#: client/gui-gtk-3.0/menu.c:284 client/gui-gtk-3.22/menu.c:283
+#: client/gui-gtk-3.0/menu.c:284 client/gui-gtk-3.22/menu.c:285
 #: client/gui-sdl2/optiondlg.c:833
 msgid "Worklists"
 msgstr "Työlistat"
 
-#: client/gui-gtk-3.0/menu.c:286 client/gui-gtk-3.22/menu.c:285
+#: client/gui-gtk-3.0/menu.c:286 client/gui-gtk-3.22/menu.c:289
 msgid "Client Lua Script"
 msgstr "Asiakasohjelman Lua-skripti"
 
 #: client/gui-gtk-3.0/menu.c:296 client/gui-gtk-3.0/menu.c:318
-#: client/gui-gtk-3.22/menu.c:295 client/gui-gtk-3.22/menu.c:317
+#: client/gui-gtk-3.22/menu.c:299 client/gui-gtk-3.22/menu.c:321
 #: client/gui-qt/menu.cpp:1547 client/include/helpdlg_g.h:51
 #: data/helpdata.txt:997 server/report.c:465
 msgid "Wonders of the World"
 msgstr "Maailman ihmeet"
 
-#: client/gui-gtk-3.0/menu.c:298 client/gui-gtk-3.22/menu.c:297
+#: client/gui-gtk-3.0/menu.c:298 client/gui-gtk-3.22/menu.c:301
 #: client/gui-qt/menu.cpp:1551
 msgid "Top Five Cities"
 msgstr "Viisi parasta kaupunkia"
 
 #: client/gui-gtk-3.0/menu.c:300 client/gui-gtk-3.0/messagewin.c:337
-#: client/gui-gtk-3.22/menu.c:299 client/gui-gtk-3.22/messagewin.c:337
+#: client/gui-gtk-3.22/menu.c:303 client/gui-gtk-3.22/messagewin.c:337
 #: client/gui-qt/menu.cpp:997 client/gui-sdl2/messagewin.c:257
 msgid "Messages"
 msgstr "Viestit"
 
-#: client/gui-gtk-3.0/menu.c:302 client/gui-gtk-3.22/menu.c:301
+#: client/gui-gtk-3.0/menu.c:302 client/gui-gtk-3.22/menu.c:305
 #: client/gui-qt/menu.cpp:1555
 msgid "Demographics"
 msgstr "Tilastotietoja"
 
 #. TRANS: "Overview" topic in built-in help
-#: client/gui-gtk-3.0/menu.c:304 client/gui-gtk-3.22/menu.c:303
+#: client/gui-gtk-3.0/menu.c:304 client/gui-gtk-3.22/menu.c:307
 #: client/include/helpdlg_g.h:31 data/helpdata.txt:43
 msgid "?help:Overview"
 msgstr "Yhteenveto"
 
-#: client/gui-gtk-3.0/menu.c:306 client/gui-gtk-3.22/menu.c:305
+#: client/gui-gtk-3.0/menu.c:306 client/gui-gtk-3.22/menu.c:309
 #: client/include/helpdlg_g.h:32 data/helpdata.txt:82
 msgid "Strategy and Tactics"
 msgstr "Strategia ja taktiikka"
 
-#: client/gui-gtk-3.0/menu.c:316 client/gui-gtk-3.22/menu.c:315
+#: client/gui-gtk-3.0/menu.c:316 client/gui-gtk-3.22/menu.c:319
 #: client/include/helpdlg_g.h:44 data/helpdata.txt:972
 msgid "City Improvements"
 msgstr "Rakennushankkeet"
 
 #: client/gui-gtk-3.0/menu.c:322 client/gui-gtk-3.0/menu.c:440
-#: client/gui-gtk-3.22/menu.c:321 client/gui-gtk-3.22/menu.c:439
+#: client/gui-gtk-3.22/menu.c:325 client/gui-gtk-3.22/menu.c:443
 #: client/gui-qt/menu.cpp:1269 client/include/helpdlg_g.h:46
 #: data/helpdata.txt:1095
 msgid "Combat"
 msgstr "Taistelu"
 
-#: client/gui-gtk-3.0/menu.c:324 client/gui-gtk-3.22/menu.c:323
+#: client/gui-gtk-3.0/menu.c:324 client/gui-gtk-3.22/menu.c:327
 #: client/include/helpdlg_g.h:47 data/helpdata.txt:1325
 msgid "Zones of Control"
 msgstr "Valvonta-alueet"
 
-#: client/gui-gtk-3.0/menu.c:328 client/gui-gtk-3.22/menu.c:327
+#: client/gui-gtk-3.0/menu.c:328 client/gui-gtk-3.22/menu.c:331
 #: client/include/helpdlg_g.h:53 data/helpdata.txt:1442
 msgid "Diplomacy"
 msgstr "Diplomatia"
 
-#: client/gui-gtk-3.0/menu.c:330 client/gui-gtk-3.22/menu.c:329
+#: client/gui-gtk-3.0/menu.c:330 client/gui-gtk-3.22/menu.c:333
 #: client/include/helpdlg_g.h:48 data/helpdata.txt:1485
 msgid "Technology"
 msgstr "Teknologia"
 
-#: client/gui-gtk-3.0/menu.c:332 client/gui-gtk-3.22/menu.c:331
+#: client/gui-gtk-3.0/menu.c:332 client/gui-gtk-3.22/menu.c:335
 #: client/include/helpdlg_g.h:54 data/helpdata.txt:1524
 msgid "Space Race"
 msgstr "Avaruuden kilpajuoksu"
 
-#: client/gui-gtk-3.0/menu.c:334 client/gui-gtk-3.22/menu.c:333
+#: client/gui-gtk-3.0/menu.c:334 client/gui-gtk-3.22/menu.c:337
 #: client/include/helpdlg_g.h:39
 msgid "About Current Ruleset"
 msgstr "Käytetty sääntökokoelma"
 
-#: client/gui-gtk-3.0/menu.c:336 client/gui-gtk-3.22/menu.c:335
+#: client/gui-gtk-3.0/menu.c:336 client/gui-gtk-3.22/menu.c:339
 #: client/include/helpdlg_g.h:40
 msgid "About Current Tileset"
 msgstr "Käytetty kuvitus"
 
-#: client/gui-gtk-3.0/menu.c:338 client/gui-gtk-3.22/menu.c:337
+#: client/gui-gtk-3.0/menu.c:338 client/gui-gtk-3.22/menu.c:341
 #: client/include/helpdlg_g.h:41 data/helpdata.txt:1564
 msgid "About Nations"
 msgstr "Tietoja kansakunnista"
 
-#: client/gui-gtk-3.0/menu.c:340 client/gui-gtk-3.22/menu.c:339
+#: client/gui-gtk-3.0/menu.c:340 client/gui-gtk-3.22/menu.c:343
 #: client/include/helpdlg_g.h:34 data/helpdata.txt:1579
 msgid "Connecting"
 msgstr "Yhdistäminen"
 
-#: client/gui-gtk-3.0/menu.c:342 client/gui-gtk-3.22/menu.c:341
+#: client/gui-gtk-3.0/menu.c:342 client/gui-gtk-3.22/menu.c:345
 #: client/include/helpdlg_g.h:38 data/helpdata.txt:1606
 msgid "Controls"
 msgstr "Ohjauskomennot"
 
-#: client/gui-gtk-3.0/menu.c:346 client/gui-gtk-3.22/menu.c:345
+#: client/gui-gtk-3.0/menu.c:346 client/gui-gtk-3.22/menu.c:349
 #: client/include/helpdlg_g.h:35 data/helpdata.txt:1829
 msgid "Chatline"
 msgstr "Keskustelu"
 
-#: client/gui-gtk-3.0/menu.c:348 client/gui-gtk-3.22/menu.c:347
+#: client/gui-gtk-3.0/menu.c:348 client/gui-gtk-3.22/menu.c:351
 #: client/include/helpdlg_g.h:36 data/helpdata.txt:1947
 msgid "Worklist Editor"
 msgstr "Työlistan hallinta"
 
-#: client/gui-gtk-3.0/menu.c:350 client/gui-gtk-3.22/menu.c:349
+#: client/gui-gtk-3.0/menu.c:350 client/gui-gtk-3.22/menu.c:353
 #: client/include/helpdlg_g.h:33 data/helpdata.txt:1971
 msgid "Languages"
 msgstr "Kielet"
 
-#: client/gui-gtk-3.0/menu.c:352 client/gui-gtk-3.22/menu.c:351
+#: client/gui-gtk-3.0/menu.c:352 client/gui-gtk-3.22/menu.c:355
 #: client/include/helpdlg_g.h:55 data/helpdata.txt:2001
 msgid "Copying"
 msgstr "Kopiointi"
 
-#: client/gui-gtk-3.0/menu.c:354 client/gui-gtk-3.22/menu.c:353
+#: client/gui-gtk-3.0/menu.c:354 client/gui-gtk-3.22/menu.c:357
 #: client/include/helpdlg_g.h:56 data/helpdata.txt:2306
 msgid "About Freeciv"
 msgstr "Tietoja Freecivistä"
 
-#: client/gui-gtk-3.0/menu.c:356 client/gui-gtk-3.22/menu.c:355
+#: client/gui-gtk-3.0/menu.c:356 client/gui-gtk-3.22/menu.c:359
 #: client/gui-qt/menu.cpp:1006
 msgid "Save Options on Exit"
 msgstr "Tallenna asetukset lopetettaessa"
 
-#: client/gui-gtk-3.0/menu.c:358 client/gui-gtk-3.22/menu.c:357
+#: client/gui-gtk-3.0/menu.c:358 client/gui-gtk-3.22/menu.c:361
 msgid "Editing Mode"
 msgstr "Muokkaustila"
 
-#: client/gui-gtk-3.0/menu.c:360 client/gui-gtk-3.22/menu.c:359
+#: client/gui-gtk-3.0/menu.c:360 client/gui-gtk-3.22/menu.c:363
 #: client/gui-qt/menu.cpp:1086
 msgid "City Outlines"
 msgstr "Kaupunkien ääriviivat"
 
 # Show food/production/trade on each worked tile
-#: client/gui-gtk-3.0/menu.c:362 client/gui-gtk-3.22/menu.c:361
+#: client/gui-gtk-3.0/menu.c:362 client/gui-gtk-3.22/menu.c:365
 #: client/gui-qt/menu.cpp:1090 client/gui-qt/shortcuts.cpp:65
 msgid "City Output"
 msgstr "Kaupunkiruutujen tuotanto"
 
-#: client/gui-gtk-3.0/menu.c:364 client/gui-gtk-3.22/menu.c:363
+#: client/gui-gtk-3.0/menu.c:364 client/gui-gtk-3.22/menu.c:367
 #: client/gui-qt/menu.cpp:1096 client/gui-qt/shortcuts.cpp:67
 msgid "Map Grid"
 msgstr "Koordinaatisto"
 
-#: client/gui-gtk-3.0/menu.c:366 client/gui-gtk-3.22/menu.c:365
+#: client/gui-gtk-3.0/menu.c:366 client/gui-gtk-3.22/menu.c:369
 #: client/gui-qt/menu.cpp:1102 client/gui-qt/shortcuts.cpp:69
 msgid "National Borders"
 msgstr "Valtioiden rajat"
 
-#: client/gui-gtk-3.0/menu.c:368 client/gui-gtk-3.22/menu.c:367
+#: client/gui-gtk-3.0/menu.c:368 client/gui-gtk-3.22/menu.c:371
 #: client/gui-qt/menu.cpp:1108
 msgid "Native Tiles"
 msgstr "Sallitut ruudut"
 
-#: client/gui-gtk-3.0/menu.c:370 client/gui-gtk-3.22/menu.c:369
+#: client/gui-gtk-3.0/menu.c:370 client/gui-gtk-3.22/menu.c:373
 #: client/gui-qt/menu.cpp:1113
 msgid "City Full Bar"
 msgstr "Täydellinen kaupunki-info"
 
-#: client/gui-gtk-3.0/menu.c:372 client/gui-gtk-3.22/menu.c:371
+#: client/gui-gtk-3.0/menu.c:372 client/gui-gtk-3.22/menu.c:375
 #: client/gui-qt/menu.cpp:1119 client/gui-qt/shortcuts.cpp:99
 #: client/options.c:2712 client/options.c:2933 client/options.c:3154
 #: client/options.c:3205 client/options.c:3300
 msgid "City Names"
 msgstr "Kaupunkien nimet"
 
-#: client/gui-gtk-3.0/menu.c:374 client/gui-gtk-3.22/menu.c:373
+#: client/gui-gtk-3.0/menu.c:374 client/gui-gtk-3.22/menu.c:377
 #: client/gui-qt/menu.cpp:1125
 msgid "City Growth"
 msgstr "Kaupungin kasvu"
 
-#: client/gui-gtk-3.0/menu.c:376 client/gui-gtk-3.22/menu.c:375
+#: client/gui-gtk-3.0/menu.c:376 client/gui-gtk-3.22/menu.c:379
 #: client/gui-qt/menu.cpp:1130 client/gui-qt/shortcuts.cpp:97
 msgid "City Production Levels"
 msgstr "Kaupunkien tuotanto"
 
-#: client/gui-gtk-3.0/menu.c:378 client/gui-gtk-3.22/menu.c:377
+#: client/gui-gtk-3.0/menu.c:378 client/gui-gtk-3.22/menu.c:381
 #: client/gui-qt/menu.cpp:1136
 msgid "City Buy Cost"
 msgstr "Tuotannon ostohinnat"
 
-#: client/gui-gtk-3.0/menu.c:380 client/gui-gtk-3.22/menu.c:379
+#: client/gui-gtk-3.0/menu.c:380 client/gui-gtk-3.22/menu.c:383
 #: client/gui-qt/menu.cpp:1140 client/gui-qt/shortcuts.cpp:95
 msgid "City Traderoutes"
 msgstr "Kaupunkien kauppareitit"
 
-#: client/gui-gtk-3.0/menu.c:384 client/gui-gtk-3.22/menu.c:383
+#: client/gui-gtk-3.0/menu.c:384 client/gui-gtk-3.22/menu.c:387
 msgid "Coastline"
 msgstr "Rantaviiva"
 
-#: client/gui-gtk-3.0/menu.c:386 client/gui-gtk-3.22/menu.c:385
+#: client/gui-gtk-3.0/menu.c:386 client/gui-gtk-3.22/menu.c:389
 msgid "Paths"
 msgstr "Kulkureitit"
 
-#: client/gui-gtk-3.0/menu.c:388 client/gui-gtk-3.22/menu.c:387
-#: data/civ1/terrain.ruleset:871 data/civ2/terrain.ruleset:942
-#: data/classic/terrain.ruleset:1124 data/sandbox/terrain.ruleset:1142
-#: data/civ2civ3/terrain.ruleset:1141 data/multiplayer/terrain.ruleset:1098
+#: client/gui-gtk-3.0/menu.c:388 client/gui-gtk-3.22/menu.c:391
+#: data/civ1/terrain.ruleset:877 data/civ2/terrain.ruleset:948
+#: data/classic/terrain.ruleset:1130 data/sandbox/terrain.ruleset:1148
+#: data/civ2civ3/terrain.ruleset:1147 data/multiplayer/terrain.ruleset:1104
 #: tools/civmanual.c:457
 msgid "Irrigation"
 msgstr "kasteluverkosto"
 
-#: client/gui-gtk-3.0/menu.c:390 client/gui-gtk-3.22/menu.c:389
+#: client/gui-gtk-3.0/menu.c:390 client/gui-gtk-3.22/menu.c:393
 msgid "Mines"
 msgstr "Kaivokset"
 
-#: client/gui-gtk-3.0/menu.c:394 client/gui-gtk-3.22/menu.c:393
-#: data/civ1/terrain.ruleset:1244 data/civ2/terrain.ruleset:1448
-#: data/classic/terrain.ruleset:1742 data/sandbox/terrain.ruleset:1988
-#: data/civ2civ3/terrain.ruleset:1947 data/alien/terrain.ruleset:1170
-#: data/multiplayer/terrain.ruleset:1716 tools/civmanual.c:454
+#: client/gui-gtk-3.0/menu.c:394 client/gui-gtk-3.22/menu.c:397
+#: data/civ1/terrain.ruleset:1250 data/civ2/terrain.ruleset:1454
+#: data/classic/terrain.ruleset:1748 data/sandbox/terrain.ruleset:1993
+#: data/civ2civ3/terrain.ruleset:1953 data/alien/terrain.ruleset:1176
+#: data/multiplayer/terrain.ruleset:1722 tools/civmanual.c:454
 msgid "Resources"
 msgstr "luonnonvaroja"
 
-#: client/gui-gtk-3.0/menu.c:396 client/gui-gtk-3.22/menu.c:395
+#: client/gui-gtk-3.0/menu.c:396 client/gui-gtk-3.22/menu.c:399
 msgid "Huts"
 msgstr "Majat"
 
-#: client/gui-gtk-3.0/menu.c:398 client/gui-gtk-3.22/menu.c:397
+#: client/gui-gtk-3.0/menu.c:398 client/gui-gtk-3.22/menu.c:401
 msgid "Pollution & Fallout"
 msgstr "Saasteet & laskeuma"
 
-#: client/gui-gtk-3.0/menu.c:404 client/gui-gtk-3.22/menu.c:403
+#: client/gui-gtk-3.0/menu.c:404 client/gui-gtk-3.22/menu.c:407
 msgid "Unit Solid Background"
 msgstr "Yksivärinen yksikön tausta"
 
-#: client/gui-gtk-3.0/menu.c:406 client/gui-gtk-3.22/menu.c:405
+#: client/gui-gtk-3.0/menu.c:406 client/gui-gtk-3.22/menu.c:409
 msgid "Unit shields"
 msgstr "Yksiköiden vaakuna"
 
-#: client/gui-gtk-3.0/menu.c:408 client/gui-gtk-3.22/menu.c:407
+#: client/gui-gtk-3.0/menu.c:408 client/gui-gtk-3.22/menu.c:411
 msgid "Focus Unit"
 msgstr "Keskitä yksikköön"
 
-#: client/gui-gtk-3.0/menu.c:410 client/gui-gtk-3.22/menu.c:409
+#: client/gui-gtk-3.0/menu.c:410 client/gui-gtk-3.22/menu.c:413
 msgid "Fog of War"
 msgstr "Näkymättömän alueen hämärrys"
 
-#: client/gui-gtk-3.0/menu.c:412 client/gui-gtk-3.22/menu.c:411
+#: client/gui-gtk-3.0/menu.c:412 client/gui-gtk-3.22/menu.c:415
 #: client/gui-qt/menu.cpp:1037 client/gui-qt/shortcuts.cpp:61
 #: client/options.c:2510 client/options.c:2731 client/options.c:2952
 #: client/options.c:3184 client/options.c:3218
 msgid "Fullscreen"
 msgstr "Kokoruututila"
 
-#: client/gui-gtk-3.0/menu.c:415 client/gui-gtk-3.22/menu.c:414
+#: client/gui-gtk-3.0/menu.c:415 client/gui-gtk-3.22/menu.c:418
 msgid "Recalculate Borders"
 msgstr "Laske rajat uudelleen"
 
-#: client/gui-gtk-3.0/menu.c:417 client/gui-gtk-3.22/menu.c:416
+#: client/gui-gtk-3.0/menu.c:417 client/gui-gtk-3.22/menu.c:420
 msgid "Toggle Fog of War"
 msgstr "Näkymättömän alueen hämärrys päälle/pois"
 
-#: client/gui-gtk-3.0/menu.c:419 client/gui-gtk-3.22/menu.c:418
+#: client/gui-gtk-3.0/menu.c:419 client/gui-gtk-3.22/menu.c:422
 msgid "Game/Scenario Properties"
 msgstr "Pelin/skenaarion ominaisuudet"
 
 #: client/gui-gtk-3.0/menu.c:421 client/gui-gtk-3.0/pages.c:3494
-#: client/gui-gtk-3.22/menu.c:420 client/gui-gtk-3.22/pages.c:3493
+#: client/gui-gtk-3.22/menu.c:424 client/gui-gtk-3.22/pages.c:3493
 msgid "Save Scenario"
 msgstr "Tallenna skenaario"
 
-#: client/gui-gtk-3.0/menu.c:424 client/gui-gtk-3.22/menu.c:423
+#: client/gui-gtk-3.0/menu.c:424 client/gui-gtk-3.22/menu.c:427
 #: client/gui-qt/menu.cpp:1032 client/gui-qt/shortcuts.cpp:59
 msgid "Center View"
 msgstr "Keskitä näkymä"
@@ -4934,7 +4934,7 @@ msgstr "Keskitä näkymä"
 #. TRANS: Research report action
 #. TRANS: Research report title
 #: client/gui-gtk-3.0/menu.c:428 client/gui-gtk-3.0/repodlgs.c:556
-#: client/gui-gtk-3.22/menu.c:427 client/gui-gtk-3.22/repodlgs.c:554
+#: client/gui-gtk-3.22/menu.c:431 client/gui-gtk-3.22/repodlgs.c:554
 #: client/gui-qt/menu.cpp:1543 client/gui-qt/pages.cpp:734
 #: client/gui-sdl2/mapctrl.c:1518 client/gui-sdl2/mapview.c:348
 #: client/gui-sdl2/mapview.c:356 client/gui-sdl2/mapview.c:364
@@ -4942,102 +4942,102 @@ msgstr "Keskitä näkymä"
 msgid "Research"
 msgstr "Tutkimus"
 
-#: client/gui-gtk-3.0/menu.c:430 client/gui-gtk-3.22/menu.c:429
+#: client/gui-gtk-3.0/menu.c:430 client/gui-gtk-3.22/menu.c:433
 #: client/gui-qt/menu.cpp:1514
 msgid "Policies..."
 msgstr "Linjaukset..."
 
-#: client/gui-gtk-3.0/menu.c:432 client/gui-gtk-3.22/menu.c:431
+#: client/gui-gtk-3.0/menu.c:432 client/gui-gtk-3.22/menu.c:435
 #: client/gui-qt/menu.cpp:1559
 msgid "Spaceship"
 msgstr "Avaruusalus"
 
-#: client/gui-gtk-3.0/menu.c:434 client/gui-gtk-3.22/menu.c:433
+#: client/gui-gtk-3.0/menu.c:434 client/gui-gtk-3.22/menu.c:437
 #: client/gui-qt/menu.cpp:1563 common/events.c:150
 msgid "Achievements"
 msgstr "Saavutukset"
 
-#: client/gui-gtk-3.0/menu.c:439 client/gui-gtk-3.22/menu.c:438
+#: client/gui-gtk-3.0/menu.c:439 client/gui-gtk-3.22/menu.c:442
 #: client/gui-qt/menu.cpp:1298
 msgid "Work"
 msgstr "Työt"
 
-#: client/gui-gtk-3.0/menu.c:441 client/gui-gtk-3.22/menu.c:440
+#: client/gui-gtk-3.0/menu.c:441 client/gui-gtk-3.22/menu.c:444
 #: client/gui-qt/menu.cpp:1283
 msgid "Build Base"
 msgstr "Rakenna tukikohta"
 
-#: client/gui-gtk-3.0/menu.c:442 client/gui-gtk-3.22/menu.c:441
+#: client/gui-gtk-3.0/menu.c:442 client/gui-gtk-3.22/menu.c:445
 #: client/gui-qt/menu.cpp:1315
 msgid "Build Path"
 msgstr "Rakenna kulkureitti"
 
-#: client/gui-gtk-3.0/menu.c:443 client/gui-gtk-3.22/menu.c:442
+#: client/gui-gtk-3.0/menu.c:443 client/gui-gtk-3.22/menu.c:446
 #: client/gui-qt/menu.cpp:1149
 msgid "Single Unit (Unselect Others)"
 msgstr "Vain yksi yksikkö"
 
-#: client/gui-gtk-3.0/menu.c:445 client/gui-gtk-3.22/menu.c:444
+#: client/gui-gtk-3.0/menu.c:445 client/gui-gtk-3.22/menu.c:448
 #: client/gui-qt/menu.cpp:1153
 msgid "All On Tile"
 msgstr "Kaikki ruudusta"
 
-#: client/gui-gtk-3.0/menu.c:447 client/gui-gtk-3.22/menu.c:446
+#: client/gui-gtk-3.0/menu.c:447 client/gui-gtk-3.22/menu.c:450
 #: client/gui-qt/menu.cpp:1158
 msgid "Same Type on Tile"
 msgstr "Saman tyyppiset ruudusta"
 
-#: client/gui-gtk-3.0/menu.c:449 client/gui-gtk-3.22/menu.c:448
+#: client/gui-gtk-3.0/menu.c:449 client/gui-gtk-3.22/menu.c:452
 #: client/gui-qt/menu.cpp:1162
 msgid "Same Type on Continent"
 msgstr "Saman tyyppiset mantereelta"
 
-#: client/gui-gtk-3.0/menu.c:451 client/gui-gtk-3.22/menu.c:450
+#: client/gui-gtk-3.0/menu.c:451 client/gui-gtk-3.22/menu.c:454
 #: client/gui-qt/menu.cpp:1167
 msgid "Same Type Everywhere"
 msgstr "Saman tyyppiset kaikkialta"
 
-#: client/gui-gtk-3.0/menu.c:453 client/gui-gtk-3.22/menu.c:452
+#: client/gui-gtk-3.0/menu.c:453 client/gui-gtk-3.22/menu.c:456
 msgid "Unit Selection Dialog"
 msgstr "Avaa yksiköiden valitsemisikkuna"
 
 #: client/gui-gtk-3.0/menu.c:455 client/gui-gtk-3.22/action_dialog.c:2271
-#: client/gui-gtk-3.22/menu.c:454 client/gui-qt/menu.cpp:1173
+#: client/gui-gtk-3.22/menu.c:458 client/gui-qt/menu.cpp:1173
 #: client/gui-qt/shortcuts.cpp:130 client/gui-sdl2/action_dialog.c:1981
 #: client/gui-sdl2/menu.c:417
 msgid "Wait"
 msgstr "Odota"
 
-#: client/gui-gtk-3.0/menu.c:457 client/gui-gtk-3.22/menu.c:456
+#: client/gui-gtk-3.0/menu.c:457 client/gui-gtk-3.22/menu.c:460
 #: client/gui-qt/menu.cpp:1178
 msgid "Done"
 msgstr "Valmis"
 
-#: client/gui-gtk-3.0/menu.c:459 client/gui-gtk-3.22/menu.c:458
+#: client/gui-gtk-3.0/menu.c:459 client/gui-gtk-3.22/menu.c:462
 msgid "Go to"
 msgstr "Mene"
 
-#: client/gui-gtk-3.0/menu.c:461 client/gui-gtk-3.22/menu.c:460
+#: client/gui-gtk-3.0/menu.c:461 client/gui-gtk-3.22/menu.c:464
 #: client/gui-qt/menu.cpp:744
 msgid "Go to and..."
 msgstr "Siirry ja..."
 
-#: client/gui-gtk-3.0/menu.c:462 client/gui-gtk-3.22/menu.c:461
+#: client/gui-gtk-3.0/menu.c:462 client/gui-gtk-3.22/menu.c:465
 msgid "Go to/Airlift to City"
 msgstr "Mene/Lennätä kaupunkiin"
 
-#: client/gui-gtk-3.0/menu.c:464 client/gui-gtk-3.22/menu.c:463
+#: client/gui-gtk-3.0/menu.c:464 client/gui-gtk-3.22/menu.c:467
 #: client/gui-sdl2/menu.c:495
 msgid "Return to Nearest City"
 msgstr "Palaa lähimpään kaupunkiin"
 
-#: client/gui-gtk-3.0/menu.c:466 client/gui-gtk-3.22/menu.c:465
+#: client/gui-gtk-3.0/menu.c:466 client/gui-gtk-3.22/menu.c:469
 #: client/gui-qt/menu.cpp:1211 client/gui-qt/shortcuts.cpp:105
 #: client/gui-sdl2/menu.c:608
 msgid "Auto Explore"
 msgstr "Kartoita automaattisesti"
 
-#: client/gui-gtk-3.0/menu.c:468 client/gui-gtk-3.22/menu.c:467
+#: client/gui-gtk-3.0/menu.c:468 client/gui-gtk-3.22/menu.c:471
 #: client/gui-qt/menu.cpp:1216 client/gui-qt/shortcuts.cpp:107
 #: client/gui-sdl2/menu.c:544
 msgid "Patrol"
@@ -5045,82 +5045,82 @@ msgstr "Partioi"
 
 # *** The three first ones are states, this and a few next are imperative. ***
 #: client/gui-gtk-3.0/menu.c:470 client/gui-gtk-3.0/unitselect.c:484
-#: client/gui-gtk-3.22/menu.c:469 client/gui-gtk-3.22/unitselect.c:484
+#: client/gui-gtk-3.22/menu.c:473 client/gui-gtk-3.22/unitselect.c:484
 #: client/gui-qt/menu.cpp:1223 client/gui-qt/shortcuts.cpp:124
-#: common/unit.c:550
+#: common/unit.c:556
 msgid "Sentry"
 msgstr "Vartioi"
 
-#: client/gui-gtk-3.0/menu.c:472 client/gui-gtk-3.22/menu.c:471
+#: client/gui-gtk-3.0/menu.c:472 client/gui-gtk-3.22/menu.c:475
 #: client/gui-qt/menu.cpp:1228 client/gui-qt/shortcuts.cpp:109
 #: client/gui-sdl2/menu.c:635
 msgid "Unsentry All On Tile"
 msgstr "Herätä kaikki vartioivat yksiköt ruudusta"
 
 #: client/gui-gtk-3.0/menu.c:474 client/gui-gtk-3.0/transportdlg.c:116
-#: client/gui-gtk-3.22/menu.c:473 client/gui-gtk-3.22/transportdlg.c:116
+#: client/gui-gtk-3.22/menu.c:477 client/gui-gtk-3.22/transportdlg.c:116
 #: client/gui-qt/citydlg.cpp:818 client/gui-qt/menu.cpp:1234
 #: client/gui-qt/pages.cpp:536 client/gui-qt/shortcuts.cpp:136
 msgid "Load"
 msgstr "Lastaa"
 
-#: client/gui-gtk-3.0/menu.c:476 client/gui-gtk-3.22/menu.c:475
+#: client/gui-gtk-3.0/menu.c:476 client/gui-gtk-3.22/menu.c:479
 #: client/gui-qt/citydlg.cpp:825 client/gui-qt/menu.cpp:1239
 #: client/gui-qt/shortcuts.cpp:138
 msgid "Unload"
 msgstr "Pura lasti"
 
-#: client/gui-gtk-3.0/menu.c:478 client/gui-gtk-3.22/menu.c:477
+#: client/gui-gtk-3.0/menu.c:478 client/gui-gtk-3.22/menu.c:481
 #: client/gui-qt/citydlg.cpp:832 client/gui-qt/menu.cpp:1244
 #: client/gui-sdl2/menu.c:648
 msgid "Unload All From Transporter"
 msgstr "Pura kuljetusalus"
 
-#: client/gui-gtk-3.0/menu.c:480 client/gui-gtk-3.22/menu.c:479
+#: client/gui-gtk-3.0/menu.c:480 client/gui-gtk-3.22/menu.c:483
 #: client/gui-qt/shortcuts.cpp:114
 msgid "Set Home City"
 msgstr "Tee tästä uusi kotikaupunki"
 
 #: client/gui-gtk-3.0/menu.c:482 client/gui-gtk-3.0/menu.c:2396
-#: client/gui-gtk-3.22/menu.c:481 client/gui-gtk-3.22/menu.c:2395
+#: client/gui-gtk-3.22/menu.c:485 client/gui-gtk-3.22/menu.c:2408
 #: client/gui-qt/menu.cpp:1254 client/gui-qt/shortcuts.cpp:112
 #: client/gui-sdl2/dialogs.c:736
 msgid "Upgrade"
 msgstr "Ajanmukaista"
 
 #: client/gui-gtk-3.0/menu.c:484 client/gui-gtk-3.0/menu.c:2416
-#: client/gui-gtk-3.22/menu.c:483 client/gui-gtk-3.22/menu.c:2415
-#: client/gui-qt/menu.cpp:1259 common/unit.c:566
+#: client/gui-gtk-3.22/menu.c:487 client/gui-gtk-3.22/menu.c:2428
+#: client/gui-qt/menu.cpp:1259 common/unit.c:572
 msgid "Convert"
 msgstr "Muunna yksikkö"
 
-#: client/gui-gtk-3.0/menu.c:486 client/gui-gtk-3.22/menu.c:485
+#: client/gui-gtk-3.0/menu.c:486 client/gui-gtk-3.22/menu.c:489
 #: client/gui-qt/menu.cpp:1263 client/gui-qt/repodlgs.cpp:1220
 #: client/gui-sdl2/dialogs.c:932
 msgid "Disband"
 msgstr "Lakkauta"
 
-#: client/gui-gtk-3.0/menu.c:488 client/gui-gtk-3.22/menu.c:487
+#: client/gui-gtk-3.0/menu.c:488 client/gui-gtk-3.22/menu.c:491
 #: client/gui-qt/shortcuts.cpp:122
 msgid "Build City"
 msgstr "Perusta kaupunki"
 
-#: client/gui-gtk-3.0/menu.c:490 client/gui-gtk-3.22/menu.c:489
+#: client/gui-gtk-3.0/menu.c:490 client/gui-gtk-3.22/menu.c:493
 #: client/gui-qt/menu.cpp:1304 client/gui-qt/menu.cpp:2242
 #: client/gui-sdl2/menu.c:620 client/gui-sdl2/menu.c:1319
 msgid "Auto Settler"
 msgstr "Automatisoi uudisraivaaja"
 
 #: client/gui-gtk-3.0/menu.c:492 client/gui-gtk-3.0/menu.c:2374
-#: client/gui-gtk-3.22/menu.c:491 client/gui-gtk-3.22/menu.c:2373
+#: client/gui-gtk-3.22/menu.c:495 client/gui-gtk-3.22/menu.c:2386
 #: client/gui-qt/menu.cpp:1310 client/gui-qt/shortcuts.cpp:120
 msgid "Build Road"
 msgstr "Rakenna tie"
 
 #: client/gui-gtk-3.0/menu.c:494 client/gui-gtk-3.0/menu.c:2446
 #: client/gui-gtk-3.0/menu.c:2449 client/gui-gtk-3.0/menu.c:2489
-#: client/gui-gtk-3.22/menu.c:493 client/gui-gtk-3.22/menu.c:2445
-#: client/gui-gtk-3.22/menu.c:2448 client/gui-gtk-3.22/menu.c:2488
+#: client/gui-gtk-3.22/menu.c:497 client/gui-gtk-3.22/menu.c:2458
+#: client/gui-gtk-3.22/menu.c:2461 client/gui-gtk-3.22/menu.c:2501
 #: client/gui-qt/menu.cpp:1317 client/gui-qt/menu.cpp:2110
 #: client/gui-qt/menu.cpp:2113 client/gui-qt/shortcuts.cpp:118
 #: client/gui-sdl2/menu.c:823 client/gui-sdl2/menu.c:1177
@@ -5129,92 +5129,92 @@ msgstr "Rakenna kasteluverkosto"
 
 #: client/gui-gtk-3.0/menu.c:496 client/gui-gtk-3.0/menu.c:2474
 #: client/gui-gtk-3.0/menu.c:2477 client/gui-gtk-3.0/menu.c:2490
-#: client/gui-gtk-3.22/menu.c:495 client/gui-gtk-3.22/menu.c:2473
-#: client/gui-gtk-3.22/menu.c:2476 client/gui-gtk-3.22/menu.c:2489
+#: client/gui-gtk-3.22/menu.c:499 client/gui-gtk-3.22/menu.c:2486
+#: client/gui-gtk-3.22/menu.c:2489 client/gui-gtk-3.22/menu.c:2502
 #: client/gui-qt/menu.cpp:1322 client/gui-qt/menu.cpp:2070
 #: client/gui-qt/menu.cpp:2073 client/gui-qt/shortcuts.cpp:116
 #: client/gui-sdl2/menu.c:809 client/gui-sdl2/menu.c:1212
 msgid "Build Mine"
 msgstr "Louhi kaivos"
 
-#: client/gui-gtk-3.0/menu.c:498 client/gui-gtk-3.22/menu.c:497
+#: client/gui-gtk-3.0/menu.c:498 client/gui-gtk-3.22/menu.c:501
 #: client/gui-qt/menu.cpp:1328
 msgid "Connect With Road"
 msgstr "Mene tietä rakentaen"
 
-#: client/gui-gtk-3.0/menu.c:500 client/gui-gtk-3.22/menu.c:499
+#: client/gui-gtk-3.0/menu.c:500 client/gui-gtk-3.22/menu.c:503
 msgid "Connect With Rail"
 msgstr "Mene rautatietä rakentaen"
 
-#: client/gui-gtk-3.0/menu.c:502 client/gui-gtk-3.22/menu.c:501
+#: client/gui-gtk-3.0/menu.c:502 client/gui-gtk-3.22/menu.c:505
 #: client/gui-qt/menu.cpp:1336 client/gui-sdl2/menu.c:556
 msgid "Connect With Irrigation"
 msgstr "Mene kasteluverkostoa rakentaen"
 
 #: client/gui-gtk-3.0/menu.c:504 client/gui-gtk-3.0/menu.c:2486
-#: client/gui-gtk-3.0/menu.c:2491 client/gui-gtk-3.22/menu.c:503
-#: client/gui-gtk-3.22/menu.c:2485 client/gui-gtk-3.22/menu.c:2490
+#: client/gui-gtk-3.0/menu.c:2491 client/gui-gtk-3.22/menu.c:507
+#: client/gui-gtk-3.22/menu.c:2498 client/gui-gtk-3.22/menu.c:2503
 #: client/gui-qt/menu.cpp:1341 client/gui-qt/menu.cpp:2136
 msgid "Transform Terrain"
 msgstr "Muokkaa maastoa"
 
-#: client/gui-gtk-3.0/menu.c:508 client/gui-gtk-3.22/menu.c:507
+#: client/gui-gtk-3.0/menu.c:508 client/gui-gtk-3.22/menu.c:511
 #: client/gui-qt/menu.cpp:1351 client/gui-sdl2/menu.c:723
 msgid "Clean Nuclear Fallout"
 msgstr "Puhdista ydinlaskeumaa"
 
-#: client/gui-gtk-3.0/menu.c:510 client/gui-gtk-3.22/menu.c:509
+#: client/gui-gtk-3.0/menu.c:510 client/gui-gtk-3.22/menu.c:513
 #: client/gui-qt/shortcuts.cpp:126
 msgid "Fortify"
 msgstr "Linnoittaudu"
 
-#: client/gui-gtk-3.0/menu.c:512 client/gui-gtk-3.22/menu.c:511
+#: client/gui-gtk-3.0/menu.c:512 client/gui-gtk-3.22/menu.c:515
 #: client/gui-sdl2/menu.c:784
 msgid "Build Fortress"
 msgstr "Rakenna linnoitus"
 
-#: client/gui-gtk-3.0/menu.c:514 client/gui-gtk-3.22/menu.c:513
+#: client/gui-gtk-3.0/menu.c:514 client/gui-gtk-3.22/menu.c:517
 #: client/gui-sdl2/menu.c:760
 msgid "Build Airbase"
 msgstr "Rakenna lentotukikohta"
 
 #. TRANS: Menu item to bring up the action selection dialog.
 #. TRANS: Button to bring up the action selection dialog.
-#: client/gui-gtk-3.0/menu.c:518 client/gui-gtk-3.22/menu.c:517
+#: client/gui-gtk-3.0/menu.c:518 client/gui-gtk-3.22/menu.c:521
 #: client/gui-qt/menu.cpp:1291 client/gui-qt/shortcuts.cpp:110
 #: client/gui-sdl2/menu.c:444
 msgid "Do..."
 msgstr "Toimi..."
 
-#: client/gui-gtk-3.0/menu.c:523 client/gui-gtk-3.22/menu.c:522
+#: client/gui-gtk-3.0/menu.c:523 client/gui-gtk-3.22/menu.c:526
 msgid "Tax Rates"
 msgstr "Verotus"
 
-#: client/gui-gtk-3.0/menu.c:525 client/gui-gtk-3.22/menu.c:524
+#: client/gui-gtk-3.0/menu.c:525 client/gui-gtk-3.22/menu.c:528
 #: client/gui-sdl2/mapctrl.c:1532 client/gui-sdl2/mapview.c:328
 #: client/gui-sdl2/mapview.c:331
 msgid "Revolution"
 msgstr "Vallankumous"
 
 #: client/gui-gtk-3.0/menu.c:553 client/gui-gtk-3.0/pages.c:140
-#: client/gui-gtk-3.22/menu.c:552 client/gui-gtk-3.22/pages.c:140
+#: client/gui-gtk-3.22/menu.c:556 client/gui-gtk-3.22/pages.c:140
 #: client/gui-qt/fc_client.cpp:827 client/gui-qt/menu.cpp:993
 msgid "Set local options"
 msgstr "Muokkaa paikallisia asetuksia"
 
 #: client/gui-gtk-3.0/menu.c:569 client/gui-gtk-3.0/pages.c:1562
-#: client/gui-gtk-3.22/menu.c:568 client/gui-gtk-3.22/pages.c:1563
+#: client/gui-gtk-3.22/menu.c:572 client/gui-gtk-3.22/pages.c:1563
 msgid "Game Settings"
 msgstr "Pelin asetukset"
 
-#: client/gui-gtk-3.0/menu.c:645 client/gui-gtk-3.22/menu.c:644
+#: client/gui-gtk-3.0/menu.c:645 client/gui-gtk-3.22/menu.c:648
 #: client/gui-qt/menu.cpp:3511
 msgid "Leaving a local game will end it!"
 msgstr "Jos lähdet paikallispelistä, peli päättyy!"
 
 #. TRANS: Connect with some road type (Road/Railroad)
 #: client/gui-gtk-3.0/menu.c:2118 client/gui-gtk-3.0/menu.c:2125
-#: client/gui-gtk-3.22/menu.c:2117 client/gui-gtk-3.22/menu.c:2124
+#: client/gui-gtk-3.22/menu.c:2130 client/gui-gtk-3.22/menu.c:2137
 #, c-format
 msgid "Connect With %s"
 msgstr "Mene %stä rakentaen"
@@ -5226,38 +5226,38 @@ msgstr "Mene %stä rakentaen"
 #. TRANS: Build irrigation of specific type
 #. TRANS: Build mine of specific type
 #: client/gui-gtk-3.0/menu.c:2369 client/gui-gtk-3.0/menu.c:2443
-#: client/gui-gtk-3.0/menu.c:2471 client/gui-gtk-3.22/menu.c:2368
-#: client/gui-gtk-3.22/menu.c:2442 client/gui-gtk-3.22/menu.c:2470
+#: client/gui-gtk-3.0/menu.c:2471 client/gui-gtk-3.22/menu.c:2381
+#: client/gui-gtk-3.22/menu.c:2455 client/gui-gtk-3.22/menu.c:2483
 #: client/gui-qt/menu.cpp:2170
 #, c-format
 msgid "Build %s"
 msgstr "Rakenna %s"
 
 #. TRANS: %s is a unit type.
-#: client/gui-gtk-3.0/menu.c:2383 client/gui-gtk-3.22/menu.c:2382
+#: client/gui-gtk-3.0/menu.c:2383 client/gui-gtk-3.22/menu.c:2395
 #, c-format
 msgid "Upgrade to %s"
 msgstr "Ajanmukaista yksiköksi %s"
 
 #. TRANS: %s is a unit type.
-#: client/gui-gtk-3.0/menu.c:2404 client/gui-gtk-3.22/menu.c:2403
+#: client/gui-gtk-3.0/menu.c:2404 client/gui-gtk-3.22/menu.c:2416
 #, c-format
 msgid "Convert to %s"
 msgstr "Muunna yksiköksi %s"
 
 #: client/gui-gtk-3.0/menu.c:2425 client/gui-gtk-3.0/menu.c:2454
-#: client/gui-gtk-3.22/menu.c:2424 client/gui-gtk-3.22/menu.c:2453
+#: client/gui-gtk-3.22/menu.c:2437 client/gui-gtk-3.22/menu.c:2466
 #, c-format
 msgid "Change to %s"
 msgstr "Tee tästä %s"
 
-#: client/gui-gtk-3.0/menu.c:2482 client/gui-gtk-3.22/menu.c:2481
+#: client/gui-gtk-3.0/menu.c:2482 client/gui-gtk-3.22/menu.c:2494
 #, c-format
 msgid "Transform to %s"
 msgstr "Muokkaa tästä %s"
 
 #. TRANS: %s is a government name
-#: client/gui-gtk-3.0/menu.c:2593 client/gui-gtk-3.22/menu.c:2590
+#: client/gui-gtk-3.0/menu.c:2593 client/gui-gtk-3.22/menu.c:2603
 #, c-format
 msgid "%s..."
 msgstr "%s..."
@@ -6185,11 +6185,11 @@ msgstr "luo"
 #: client/gui-gtk-3.22/dialogs.c:212 client/gui-gtk-3.22/dialogs.c:217
 #: client/gui-gtk-3.22/dialogs.c:254 client/gui-gtk-3.22/editprop.c:4912
 #: client/gui-gtk-3.22/gamedlgs.c:326 client/gui-gtk-3.22/helpdlg.c:462
-#: client/gui-gtk-3.22/inteldlg.c:185 client/gui-gtk-3.22/luaconsole.c:242
-#: client/gui-gtk-3.22/messagewin.c:379 client/gui-gtk-3.22/plrdlg.c:428
-#: client/gui-gtk-3.22/repodlgs.c:556 client/gui-gtk-3.22/repodlgs.c:1154
-#: client/gui-gtk-3.22/repodlgs.c:1676 client/gui-gtk-3.22/spaceshipdlg.c:230
-#: client/gui-gtk-3.22/unitselect.c:281
+#: client/gui-gtk-3.22/infradlg.c:94 client/gui-gtk-3.22/inteldlg.c:185
+#: client/gui-gtk-3.22/luaconsole.c:242 client/gui-gtk-3.22/messagewin.c:379
+#: client/gui-gtk-3.22/plrdlg.c:428 client/gui-gtk-3.22/repodlgs.c:556
+#: client/gui-gtk-3.22/repodlgs.c:1154 client/gui-gtk-3.22/repodlgs.c:1676
+#: client/gui-gtk-3.22/spaceshipdlg.c:230 client/gui-gtk-3.22/unitselect.c:281
 #: client/gui-gtk-3.22/unitselextradlg.c:129
 #: client/gui-gtk-3.22/unitselunitdlg.c:93 client/gui-gtk-3.22/wldlg.c:226
 #: client/gui-gtk-3.22/wldlg.c:401 client/gui-qt/helpdlg.cpp:167
@@ -6392,9 +6392,47 @@ msgstr "Palaa"
 msgid "Forward"
 msgstr "Eteenpäin"
 
+#: client/gui-gtk-3.22/infradlg.c:93
+#, fuzzy
+#| msgid "Basic Infrastructure"
+msgid "Place infrastructure"
+msgstr "Perusinfrastruktuuri"
+
+#: client/gui-gtk-3.22/infradlg.c:105
+msgid "First click a tile."
+msgstr ""
+
+#: client/gui-gtk-3.22/infradlg.c:111
+#, fuzzy
+#| msgid " point"
+#| msgid_plural " points"
+msgid "- infrapoints"
+msgstr " piste"
+
+#: client/gui-gtk-3.22/infradlg.c:140
+#, fuzzy, c-format
+#| msgid " point"
+#| msgid_plural " points"
+msgid "%d infrapoints"
+msgstr " piste"
+
+#: client/gui-gtk-3.22/infradlg.c:184
+#, fuzzy
+#| msgid "No visible unit on this tile."
+msgid "No infra possible. Select another tile."
+msgstr "Ei yksikköä näkyvissä tässä ruudussa."
+
+#: client/gui-gtk-3.22/infradlg.c:187
+msgid "Select infra for the tile, or another tile."
+msgstr ""
+
 #: client/gui-gtk-3.22/luaconsole.c:318 client/gui-gtk-3.22/pages.c:455
 msgid "Open"
 msgstr "Avaa"
+
+#: client/gui-gtk-3.22/menu.c:287
+msgid "Infra dialog"
+msgstr ""
 
 #: client/gui-gtk-3.22/optiondlg.c:361 client/gui-gtk-3.22/pages.c:455
 #: client/gui-gtk-3.22/pages.c:584 client/gui-qt/citydlg.cpp:1846
@@ -6458,7 +6496,7 @@ msgid "Governor %1"
 msgstr "Kuvernööri %1"
 
 #. TRANS: Activity name, verb in English
-#: client/gui-qt/citydlg.cpp:1311 common/unit.c:542
+#: client/gui-qt/citydlg.cpp:1311 common/unit.c:544 common/unit.c:546
 msgid "Plant"
 msgstr "Istuta"
 
@@ -7048,11 +7086,11 @@ msgstr "Yksikön toiminta"
 msgid "Any activity"
 msgstr "Mikä hyvänsä toiminta"
 
-#: client/gui-qt/hudwidget.cpp:1346 common/unit.c:548
+#: client/gui-qt/hudwidget.cpp:1346 common/unit.c:554
 msgid "Fortified"
 msgstr "Linnoittautunut"
 
-#: client/gui-qt/hudwidget.cpp:1347 common/unit.c:537
+#: client/gui-qt/hudwidget.cpp:1347 common/unit.c:539
 msgid "Idle"
 msgstr "Toimeton"
 
@@ -8787,7 +8825,7 @@ msgid "Barracks"
 msgstr "Kasarmi"
 
 #: client/gui-sdl2/mapview.c:665 client/gui-sdl2/mapview.c:671
-#: client/gui-sdl2/mapview.c:677 client/helpdata.c:4429 client/helpdata.c:4437
+#: client/gui-sdl2/mapview.c:677 client/helpdata.c:4459 client/helpdata.c:4467
 msgid "?blistmore:, "
 msgstr ", "
 
@@ -9015,7 +9053,7 @@ msgstr "liikkuu"
 msgid "disconnected"
 msgstr "yhteys katkesi"
 
-#: client/gui-sdl2/repodlgs.c:374 common/fc_types.h:803
+#: client/gui-sdl2/repodlgs.c:374 common/fc_types.h:809
 msgid "active"
 msgstr "toiminnassa"
 
@@ -9341,17 +9379,17 @@ msgstr "-------------------------------------------------"
 msgid "Terrain       Irrigation       Mining           Transform\n"
 msgstr "Maasto        Kastelu          Kaivos           Muunnos\n"
 
-#: client/helpdata.c:432
+#: client/helpdata.c:435
 msgid "Time taken for the following activities is independent of terrain:\n"
 msgstr "Seuraaviin töihin menevä aika ei riipu maastotyypistä:\n"
 
 #. TRANS: Header for fixed-width terrain alteration table.
 #. * TRANS: Translators cannot change column widths :(
-#: client/helpdata.c:438
+#: client/helpdata.c:441
 msgid "Activity            Time\n"
 msgstr "Työ                 Aika\n"
 
-#: client/helpdata.c:443
+#: client/helpdata.c:446
 #, c-format
 msgid ""
 "\n"
@@ -9360,7 +9398,7 @@ msgstr ""
 "\n"
 "saasteiden siivous %3d"
 
-#: client/helpdata.c:446
+#: client/helpdata.c:449
 #, c-format
 msgid ""
 "\n"
@@ -9369,7 +9407,7 @@ msgstr ""
 "\n"
 "laskeuman siivous  %3d"
 
-#: client/helpdata.c:449
+#: client/helpdata.c:452
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -9378,96 +9416,96 @@ msgstr ""
 "\n"
 "turmelu            %3d"
 
-#: client/helpdata.c:476
+#: client/helpdata.c:479
 msgid "In this ruleset, the following veteran levels are defined:"
 msgstr "Tässä sääntökokoelmassa käytetään seuraavia kokemustasoja:"
 
-#: client/helpdata.c:477
+#: client/helpdata.c:480
 msgid "This ruleset has no default veteran levels defined."
 msgstr "Tässä sääntökokoelmassa ei ole määritelty oletuskokemustasoja."
 
 #. TRANS: First %s is version string, e.g.,
 #. * "Freeciv version 2.3.0-beta1 (beta version)" (translated).
 #. * Second %s is client_string, e.g., "gui-gtk-2.0".
-#: client/helpdata.c:485
+#: client/helpdata.c:488
 #, c-format
 msgid "This is %s, %s client."
 msgstr "Tämä on %s, käyttöliittymä %s."
 
 #. TRANS: First %s is a government name.
-#: client/helpdata.c:599
+#: client/helpdata.c:602
 #, c-format
 msgid "?gov:Allows %s (with %s but no %s)."
 msgstr "%s mahdollistuu (lisäksi tarvitaan %s, mutta ei saa olla %s)."
 
 #. TRANS: First %s is a government name.
-#: client/helpdata.c:601
+#: client/helpdata.c:604
 #, c-format
 msgid "?gov:Allows %s (with %s)."
 msgstr "%s mahdollistuu (lisäksi tarvitaan %s)."
 
 #. TRANS: First %s is a government name.
-#: client/helpdata.c:603
+#: client/helpdata.c:606
 #, c-format
 msgid "?gov:Allows %s (absent %s)."
 msgstr "%s mahdollistuu (%s puuttuu)."
 
 #. TRANS: %s is a government name.
-#: client/helpdata.c:605
+#: client/helpdata.c:608
 #, c-format
 msgid "?gov:Allows %s."
 msgstr "%s mahdollistuu."
 
 #. TRANS: %s is a government name.
-#: client/helpdata.c:607
+#: client/helpdata.c:610
 #, c-format
 msgid "?gov:Prevents %s."
 msgstr "%s estyy."
 
 #. TRANS: First %s is a building name.
-#: client/helpdata.c:617
+#: client/helpdata.c:620
 #, c-format
 msgid "?improvement:Allows %s (with %s but no %s)."
 msgstr "%s mahdollistuu (lisäksi tarvitaan %s, mutta ei saa olla %s)."
 
 #. TRANS: First %s is a building name.
-#: client/helpdata.c:619
+#: client/helpdata.c:622
 #, c-format
 msgid "?improvement:Allows %s (with %s)."
 msgstr "%s mahdollistuu (lisäksi tarvitaan %s)."
 
 #. TRANS: First %s is a building name.
-#: client/helpdata.c:621
+#: client/helpdata.c:624
 #, c-format
 msgid "?improvement:Allows %s (absent %s)."
 msgstr "%s mahdollistuu (%s puuttuu)."
 
 #. TRANS: %s is a building name.
-#: client/helpdata.c:623
+#: client/helpdata.c:626
 #, c-format
 msgid "?improvement:Allows %s."
 msgstr "%s mahdollistuu."
 
 #. TRANS: %s is a building name.
-#: client/helpdata.c:625
+#: client/helpdata.c:628
 #, c-format
 msgid "?improvement:Prevents %s."
 msgstr "%s estyy."
 
-#: client/helpdata.c:920
+#: client/helpdata.c:923
 msgid "Current ruleset contains no summary."
 msgstr "Tämänhetkisestä sääntökokoelmasta puuttuu yhteenveto."
 
-#: client/helpdata.c:994
+#: client/helpdata.c:997
 msgid "Current tileset contains no summary."
 msgstr "Tämänhetkisestä kuvituksesta puuttuu yhteenveto."
 
-#: client/helpdata.c:1186
+#: client/helpdata.c:1189
 #, c-format
 msgid "Sorry, no help topic for %s.\n"
 msgstr "%s: Valitettavasti tälle ei ole ohjetta.\n"
 
-#: client/helpdata.c:1190
+#: client/helpdata.c:1193
 #, c-format
 msgid ""
 "Sorry, no help topic for %s.\n"
@@ -9478,18 +9516,18 @@ msgstr ""
 "Tämä sivu on luotu automaattisesti.\n"
 "\n"
 
-#: client/helpdata.c:1283
+#: client/helpdata.c:1286
 #, c-format
 msgid "* The discovery of %s will make %s obsolete.\n"
 msgstr "· Kun %s keksitään, %s vanhentuu.\n"
 
 #. TRANS: both %s are improvement names
-#: client/helpdata.c:1290
+#: client/helpdata.c:1293
 #, c-format
 msgid "* The presence of %s in the city will make %s obsolete.\n"
 msgstr "· Kun kaupungissa on %s, %s vanhentuu.\n"
 
-#: client/helpdata.c:1299
+#: client/helpdata.c:1302
 msgid ""
 "* A 'small wonder': at most one of your cities may possess this "
 "improvement.\n"
@@ -9497,30 +9535,31 @@ msgstr "'Pieni ihme': vain yhdessä kaupungeistasi voi olla tämä parannus.\n"
 
 #. TRANS: 'Allows all players with knowledge of atomic
 #. * power to build nuclear units.'
-#: client/helpdata.c:1312
+#: client/helpdata.c:1315
 #, c-format
 msgid "* Allows all players with knowledge of %s to build %s units.\n"
 msgstr "· Sallii pelaajien joilla on %s tuottaa %s yksiköitä.\n"
 
 #. TRANS: bullet point; note trailing space
-#: client/helpdata.c:1320 client/helpdata.c:1947 client/helpdata.c:2819
-#: client/helpdata.c:2925 client/helpdata.c:2975 client/helpdata.c:3050
-#: client/helpdata.c:3354 client/helpdata.c:3576 client/helpdata.c:3785
+#: client/helpdata.c:1323 client/helpdata.c:1955 client/helpdata.c:2827
+#: client/helpdata.c:2933 client/helpdata.c:2983 client/helpdata.c:3058
+#: client/helpdata.c:3367 client/helpdata.c:3471 client/helpdata.c:3606
+#: client/helpdata.c:3815
 msgid "?bullet:* "
 msgstr "· "
 
-#: client/helpdata.c:1325
+#: client/helpdata.c:1328
 #, c-format
 msgid "* Allows %s (with %s).\n"
 msgstr "· %s mahdollistuu (lisäksi tarvitaan %s).\n"
 
-#: client/helpdata.c:1329
+#: client/helpdata.c:1332
 #, c-format
 msgid "* Allows %s.\n"
 msgstr "· Mahdollistaa: %s.\n"
 
 #. TRANS: Help build Wonder
-#: client/helpdata.c:1388
+#: client/helpdata.c:1391
 #, c-format
 msgid ""
 "* Makes it possible to target the city building it with the action '%s'.\n"
@@ -9528,13 +9567,13 @@ msgstr ""
 "· Tekee mahdolliseksi tehdä toiminto %s sitä rakentavalle kaupungille.\n"
 
 #. TRANS: Help build Wonder
-#: client/helpdata.c:1397
+#: client/helpdata.c:1400
 #, c-format
 msgid "* Makes it possible to target its city with the action '%s'.\n"
 msgstr "· Tekee mahdolliseksi tehdä toiminto '%s' kaupungille.\n"
 
 #. TRANS: Help build Wonder
-#: client/helpdata.c:1406
+#: client/helpdata.c:1409
 #, c-format
 msgid ""
 "* Makes it possible to target its city and its trade partners with the "
@@ -9544,7 +9583,7 @@ msgstr ""
 "kauppakumppaneille.\n"
 
 #. TRANS: Help build Wonder
-#: client/helpdata.c:1415
+#: client/helpdata.c:1418
 #, c-format
 msgid ""
 "* Makes it possible to target all cities with its owner on its continent "
@@ -9554,7 +9593,7 @@ msgstr ""
 "kaupunkeihin samalla mantereella.\n"
 
 #. TRANS: Help build Wonder
-#: client/helpdata.c:1424
+#: client/helpdata.c:1427
 #, c-format
 msgid ""
 "* Makes it possible to target all cities with its owner with the action "
@@ -9564,7 +9603,7 @@ msgstr ""
 "kaupunkeihin.\n"
 
 #. TRANS: Help build Wonder
-#: client/helpdata.c:1433
+#: client/helpdata.c:1436
 #, c-format
 msgid ""
 "* Makes it possible to target all cities on the same team with the action "
@@ -9574,7 +9613,7 @@ msgstr ""
 "kaupunkeihin.\n"
 
 #. TRANS: Help build Wonder
-#: client/helpdata.c:1442
+#: client/helpdata.c:1445
 #, c-format
 msgid ""
 "* Makes it possible to target all cities owned by or allied to its owner "
@@ -9584,26 +9623,26 @@ msgstr ""
 "liittolaistensa kaupunkeihin.\n"
 
 #. TRANS: Help build Wonder
-#: client/helpdata.c:1451
+#: client/helpdata.c:1454
 #, c-format
 msgid "* Makes it possible to target all cities with the action '%s'.\n"
 msgstr "· Tekee mahdolliseksi kohdistaa toiminto %s kaikkiin kaupunkeihin.\n"
 
 #. TRANS: Incite City
-#: client/helpdata.c:1524
+#: client/helpdata.c:1527
 #, c-format
 msgid "* Makes it impossible to do the action '%s' to the city building it.\n"
 msgstr ""
 "· Tekee mahdottomaksi tehdä toimintoa %s sitä rakentavalle kaupungille.\n"
 
 #. TRANS: Incite City
-#: client/helpdata.c:1531
+#: client/helpdata.c:1534
 #, c-format
 msgid "* Makes it impossible to do the action '%s' to its city.\n"
 msgstr "· Tekee mahdottomaksi tehdä toimintoa %s kaupungille.\n"
 
 #. TRANS: Incite City
-#: client/helpdata.c:1538
+#: client/helpdata.c:1541
 #, c-format
 msgid ""
 "* Makes it impossible to do the action '%s' to its city or to its city's "
@@ -9613,7 +9652,7 @@ msgstr ""
 "kauppakumppaneille.\n"
 
 #. TRANS: Incite City
-#: client/helpdata.c:1545
+#: client/helpdata.c:1548
 #, c-format
 msgid ""
 "* Makes it impossible to do the action '%s' to any city with its owner on "
@@ -9623,7 +9662,7 @@ msgstr ""
 "samalla mantereella.\n"
 
 #. TRANS: Incite City
-#: client/helpdata.c:1552
+#: client/helpdata.c:1555
 #, fuzzy, c-format
 #| msgid "* Makes it impossible to do the action '%s' to your %s.\n"
 msgid ""
@@ -9631,7 +9670,7 @@ msgid ""
 msgstr "· Tekee mahdottomaksi yksikkösi %2$s tehdä toimintoa %1$s.\n"
 
 #. TRANS: Incite City
-#: client/helpdata.c:1559
+#: client/helpdata.c:1562
 #, fuzzy, c-format
 #| msgid "* Makes it impossible to do the action '%s' to your %s.\n"
 msgid ""
@@ -9639,7 +9678,7 @@ msgid ""
 msgstr "· Tekee mahdottomaksi yksikkösi %2$s tehdä toimintoa %1$s.\n"
 
 #. TRANS: Incite City
-#: client/helpdata.c:1566
+#: client/helpdata.c:1569
 #, fuzzy, c-format
 #| msgid "* Makes it impossible to do the action '%s' to your %s.\n"
 msgid ""
@@ -9648,25 +9687,25 @@ msgid ""
 msgstr "· Tekee mahdottomaksi yksikkösi %2$s tehdä toimintoa %1$s.\n"
 
 #. TRANS: Incite City
-#: client/helpdata.c:1573
+#: client/helpdata.c:1576
 #, fuzzy, c-format
 #| msgid "* Makes it impossible to do the action '%s' to your %s.\n"
 msgid "* Makes it impossible to do the action '%s' to any city in the game.\n"
 msgstr "· Tekee mahdottomaksi yksikkösi %2$s tehdä toimintoa %1$s.\n"
 
-#: client/helpdata.c:1596
+#: client/helpdata.c:1599
 msgid "* All players start with this improvement in their first city.\n"
 msgstr ""
 "· Kaikki pelaajat aloittavat tämä parannus ensimmäisessä kaupungissaan.\n"
 
 #. TRANS: %s is a nation plural
-#: client/helpdata.c:1619
+#: client/helpdata.c:1622
 #, c-format
 msgid "* The %s start with this improvement in their first city.\n"
 msgstr "· %s aloittavat tämä paranus ensimmäisessä kaupungissaan.\n"
 
 #. TRANS: don't translate 'savepalace'
-#: client/helpdata.c:1629
+#: client/helpdata.c:1632
 msgid ""
 "* If you lose the city containing this improvement, it will be rebuilt for "
 "free in another of your cities (if the 'savepalace' server setting is "
@@ -9676,145 +9715,152 @@ msgstr ""
 "ilmaiseksi johonkin toiseen kaupungeistasi (jos palvelimen asetus "
 "'savepalace' on käytössä).\n"
 
-#: client/helpdata.c:1714
+#: client/helpdata.c:1717
 #, c-format
 msgid "* Belongs to %s unit class."
 msgstr "· Kuuluu %s yksiköihin."
 
-#: client/helpdata.c:1725
+#: client/helpdata.c:1728
 msgid "  * Can occupy empty enemy cities.\n"
 msgstr "  · Voi ottaa hallintaan tyhjiä viholliskaupunkeja.\n"
 
-#: client/helpdata.c:1728
+#: client/helpdata.c:1731
 msgid "  * Speed is not affected by terrain.\n"
 msgstr "  · Maasto ei vaikuta nopeuteen.\n"
 
-#: client/helpdata.c:1731
+#: client/helpdata.c:1734
 msgid "  * Does not get defense bonuses from terrain.\n"
 msgstr "  · Ei saa puolustautumisetuja maastosta.\n"
 
-#: client/helpdata.c:1734
+#: client/helpdata.c:1737
 msgid "  * Not subject to zones of control.\n"
 msgstr "  · Ei piittaa valvonta-alueista.\n"
 
-#: client/helpdata.c:1736
+#: client/helpdata.c:1739
 msgid "  * Subject to zones of control.\n"
 msgstr "  · Valvonta-alueiden rajoittama.\n"
 
-#: client/helpdata.c:1739
+#: client/helpdata.c:1742
 msgid "  * Slowed down while damaged.\n"
 msgstr "  · Hidastuu vaurioituneena.\n"
 
-#: client/helpdata.c:1746
+#: client/helpdata.c:1749
 #, no-c-format
 msgid "  * Gets a 50% defensive bonus while in cities.\n"
 msgstr "  · Saa 50% puolustusedun kaupungissa ollessaan.\n"
 
-#: client/helpdata.c:1749
+#: client/helpdata.c:1752
 #, no-c-format
 msgid "  * May fortify, granting a 50% defensive bonus when not in a city.\n"
 msgstr ""
 "  · Voi linnoittautua ja saada täten 50% puolustusedun kaupungin "
 "ulkopuolella.\n"
 
-#: client/helpdata.c:1753
+#: client/helpdata.c:1756
 msgid "  * May fortify to stay put.\n"
 msgstr "  · Voi linnoittautua pysyäkseen paikoillaan.\n"
 
-#: client/helpdata.c:1758
+#: client/helpdata.c:1761
 msgid "  * Is unreachable. Most units cannot attack this one.\n"
 msgstr ""
 "  · On tavoittamattomissa. Useimmat yksiköt eivät voi hyökätä tämän yksikön "
 "kimppuun.\n"
 
-#: client/helpdata.c:1762
+#: client/helpdata.c:1764
+#, fuzzy
+#| msgid "  * Doesn't prevent enemy cities from working the tile it's on.\n"
+msgid ""
+"    * Doesn't prevent enemy units from attacking other units on its tile.\n"
+msgstr "  · Ei estä viholliskaupunkeja työstämästä ruutua.\n"
+
+#: client/helpdata.c:1770
 msgid "  * Can pillage tile improvements.\n"
 msgstr "  · Voi turmella infrastruktuuria.\n"
 
-#: client/helpdata.c:1767 client/helpdata.c:2282
+#: client/helpdata.c:1775 client/helpdata.c:2290
 msgid "  * Doesn't prevent enemy cities from working the tile it's on.\n"
 msgstr "  · Ei estä viholliskaupunkeja työstämästä ruutua.\n"
 
-#: client/helpdata.c:1771
+#: client/helpdata.c:1779
 msgid "  * Can attack units on non-native tiles.\n"
 msgstr ""
 "  · Voi hyökätä sellaisia viereisiä ruutuja vastaan, joiden maastoon ei "
 "voisi normaalisti liikkua.\n"
 
-#: client/helpdata.c:1778
+#: client/helpdata.c:1786
 msgid "?bullet:  * "
 msgstr "  · "
 
 #. TRANS: percentage ... or-list of unit types
-#: client/helpdata.c:1811 client/helpdata.c:1833
+#: client/helpdata.c:1819 client/helpdata.c:1841
 #, fuzzy, c-format
 #| msgid "* %dx defense bonus if attacked by %s.\n"
 msgid "* %d%% defense bonus if attacked by %s.\n"
 msgstr "· %d-kertainen puolustusbonus jos hyökkääjä on %s.\n"
 
 #. TRANS: defense divider ... or-list of unit types
-#: client/helpdata.c:1818
+#: client/helpdata.c:1826
 #, c-format
 msgid "* Reduces target's defense to 1 / %d when attacking %s.\n"
 msgstr ""
 "· kun hyökkäyksen kohteena %2$s, sen puolustusarvo on 1 / %1$d normaalista.\n"
 
 #. TRANS: or-list of unit types
-#: client/helpdata.c:1826
+#: client/helpdata.c:1834
 #, c-format
 msgid "* Reduces target's fire power to 1 when attacking %s.\n"
 msgstr "· kun hyökkäyksen kohteena %s, sen tulivoima on vain 1.\n"
 
 #. TRANS: defense divider ... or-list of unit types
-#: client/helpdata.c:1840
+#: client/helpdata.c:1848
 #, fuzzy, c-format
 #| msgid "* Reduces target's defense to 1 / %d when attacking %s.\n"
 msgid "* Reduces target's defense to 1 / %.2f when attacking %s.\n"
 msgstr ""
 "· kun hyökkäyksen kohteena %2$s, sen puolustusarvo on 1 / %1$d normaalista.\n"
 
-#: client/helpdata.c:1853
+#: client/helpdata.c:1861
 #, c-format
 msgid "* Can only be built if there is %s in the city.\n"
 msgstr "· Voidaan rakentaa vain kun kaupungissa on %s.\n"
 
-#: client/helpdata.c:1859
+#: client/helpdata.c:1867
 #, c-format
 msgid "* Can only be built with %s as government.\n"
 msgstr "· Voidaan rakentaa vain valtiomuodossa %s.\n"
 
-#: client/helpdata.c:1864
+#: client/helpdata.c:1872
 msgid "* Can escape once stack defender is lost.\n"
 msgstr "· Voi paeta ruudun puolustajan hävittyä taistelun.\n"
 
-#: client/helpdata.c:1867
+#: client/helpdata.c:1875
 msgid "* Can pursue escaping units and kill them.\n"
 msgstr "· Voi jahdata pakenevia.\n"
 
-#: client/helpdata.c:1871
+#: client/helpdata.c:1879
 msgid "* May not be built in cities.\n"
 msgstr "· Ei voida koota kaupungeissa.\n"
 
-#: client/helpdata.c:1874
+#: client/helpdata.c:1882
 msgid "* Only barbarians may build this.\n"
 msgstr "· Vain barbaarit voivat koota tämän.\n"
 
-#: client/helpdata.c:1877
+#: client/helpdata.c:1885
 msgid "* Can only be built in games where new cities are allowed.\n"
 msgstr ""
 ". Voidaan rakentaa vain mikäli uusien kaupunkien perustaminen on pelissä "
 "sallittua.\n"
 
-#: client/helpdata.c:1880
+#: client/helpdata.c:1888
 msgid "  - New cities are not allowed in the current game.\n"
 msgstr "  - Nykyisessä pelissä kaupunkien perustaminen ei ole sallittua.\n"
 
-#: client/helpdata.c:1883
+#: client/helpdata.c:1891
 msgid "  - New cities are allowed in the current game.\n"
 msgstr "  - Nykyisessä pelissä kaupunkien perustaminen on sallittua.\n"
 
 #. TRANS: %s is a nation plural
-#: client/helpdata.c:1904
+#: client/helpdata.c:1912
 #, c-format
 msgid "* The %s start the game with %d of these units.\n"
 msgid_plural "* The %s start the game with %d of these units.\n"
@@ -9822,24 +9868,24 @@ msgstr[0] "· %s aloittavat pelin %d tällainen yksikkö hallinnassaan.\n"
 msgstr[1] "· %s aloittavat pelin %d tätä yksikköä hallinnassaan.\n"
 
 #. TRANS: %s is a list of unit types separated by "or".
-#: client/helpdata.c:1926
+#: client/helpdata.c:1934
 #, c-format
 msgid "* May be obtained by conversion of %s.\n"
 msgstr "· Voidaan saada muuntamalla yksiköistä %s.\n"
 
-#: client/helpdata.c:1932
+#: client/helpdata.c:1940
 msgid "* Never has a home city.\n"
 msgstr "· Aina kotikaupungiton.\n"
 
-#: client/helpdata.c:1935
+#: client/helpdata.c:1943
 msgid "* Losing this unit will lose you the game!\n"
 msgstr "· Jos tämä yksikkö on menetetään, häviät pelin!\n"
 
-#: client/helpdata.c:1939
+#: client/helpdata.c:1947
 msgid "* Each player may only have one of this type of unit.\n"
 msgstr "· Kullakin pelaajalla voi olla vain yksi tämäntyyppinen yksikkö.\n"
 
-#: client/helpdata.c:1955
+#: client/helpdata.c:1963
 #, c-format
 msgid "* Costs %d population to build.\n"
 msgid_plural "* Costs %d population to build.\n"
@@ -9847,14 +9893,14 @@ msgstr[0] "· Tuottaminen pienentää kaupungin väkilukua %d pisteen.\n"
 msgstr[1] "· Tuottaminen pienentää kaupungin väkilukua %d pistettä.\n"
 
 #. TRANS: %s is a list of unit classes separated by "or".
-#: client/helpdata.c:1973
+#: client/helpdata.c:1981
 #, c-format
 msgid "* Can carry and refuel %d %s unit.\n"
 msgid_plural "* Can carry and refuel up to %d %s units.\n"
 msgstr[0] "· Voi kantaa ja tankata %d %s yksikön.\n"
 msgstr[1] "· Voi kantaa ja tankata %d %s yksikköä.\n"
 
-#: client/helpdata.c:2001
+#: client/helpdata.c:2009
 msgid ""
 "  * Some cargo cannot be loaded except in a city or a base native to this "
 "transport.\n"
@@ -9862,7 +9908,7 @@ msgstr ""
 "  · Joitakin yksiköitä voidaan lastata vain kaupungissa ja sopivassa "
 "tukikohdassa.\n"
 
-#: client/helpdata.c:2006
+#: client/helpdata.c:2014
 msgid ""
 "  * Cargo cannot be loaded except in a city or a base native to this "
 "transport.\n"
@@ -9870,7 +9916,7 @@ msgstr ""
 "  · Toisia yksiköitä voidaan lastata vain kaupungissa ja sopivassa "
 "tukikohdassa.\n"
 
-#: client/helpdata.c:2014
+#: client/helpdata.c:2022
 msgid ""
 "  * Some cargo cannot be unloaded except in a city or a base native to this "
 "transport.\n"
@@ -9878,7 +9924,7 @@ msgstr ""
 "  · Joitakin yksiköitä ei voida purkaa kyydistä kuin kaupungissa tai "
 "sopivassa tukikohdassa.\n"
 
-#: client/helpdata.c:2019
+#: client/helpdata.c:2027
 msgid ""
 "  * Cargo cannot be unloaded except in a city or a base native to this "
 "transport.\n"
@@ -9886,13 +9932,13 @@ msgstr ""
 "  · Toisia yksiköitä ei voida purkaa kyydistä kuin kaupungissa tai sopivassa "
 "tukikohdassa.\n"
 
-#: client/helpdata.c:2026
+#: client/helpdata.c:2034
 msgid "* Must stay next to safe coast.\n"
 msgstr "· Joutuu pysyttelemään turvallisen rannikon lähellä.\n"
 
 #. TRANS: %s is a list of unit classes separated
 #. * by "or".
-#: client/helpdata.c:2084
+#: client/helpdata.c:2092
 #, c-format
 msgid "* May load onto and unload from %s transports even when underway.\n"
 msgstr ""
@@ -9901,69 +9947,73 @@ msgstr ""
 
 #. TRANS: %s is a list of unit classes separated
 #. * by "or".
-#: client/helpdata.c:2091
+#: client/helpdata.c:2099
 #, c-format
 msgid "* May load onto %s transports even when underway.\n"
 msgstr "· Voidaan lastata %s yksiköiden kyytiin missä hyvänsä.\n"
 
 #. TRANS: %s is a list of unit classes separated
 #. * by "or".
-#: client/helpdata.c:2111
+#: client/helpdata.c:2119
 #, c-format
 msgid "* May unload from %s transports even when underway.\n"
 msgstr "· Voidaan purkaa %s yksiköiden kyydistä missä hyvänsä.\n"
 
 #. TRANS: %s is list of extra types separated by ',' and 'and'
-#: client/helpdata.c:2130 client/helpdata.c:2144 client/helpdata.c:2163
-#: client/helpdata.c:2184
+#: client/helpdata.c:2138 client/helpdata.c:2152 client/helpdata.c:2171
+#: client/helpdata.c:2192
 #, c-format
 msgid "* Can build %s on tiles.\n"
 msgstr "· Voi rakentaa ruutuihin parannuksen %s.\n"
 
-#: client/helpdata.c:2150
-msgid "* Can convert terrain to another type by mining.\n"
+#: client/helpdata.c:2158
+#, fuzzy
+#| msgid "* Can convert terrain to another type by mining.\n"
+msgid "* Can convert terrain to another type by planting.\n"
 msgstr "· Voi muokata maastotyypin toiseksi kaivoksenlouhinta-käskyllä.\n"
 
-#: client/helpdata.c:2169
-msgid "* Can convert terrain to another type by irrigation.\n"
-msgstr "· Voi muokata maastotyypin toiseksi kastelukanavien kaivuu käskyllä.\n"
+#: client/helpdata.c:2177
+#, fuzzy
+#| msgid "* Can convert terrain to another type by mining.\n"
+msgid "* Can convert terrain to another type by cultivating.\n"
+msgstr "· Voi muokata maastotyypin toiseksi kaivoksenlouhinta-käskyllä.\n"
 
-#: client/helpdata.c:2173
+#: client/helpdata.c:2181
 msgid "* Can transform terrain to another type.\n"
 msgstr "· Voi muokata maastotyypin toiseksi.\n"
 
 #. TRANS: list of extras separated by "and"
-#: client/helpdata.c:2199 client/helpdata.c:2213
+#: client/helpdata.c:2207 client/helpdata.c:2221
 #, c-format
 msgid "* Can clean %s from tiles.\n"
 msgstr "· Voi puhdistaa lisän \"%s\" ruuduista.\n"
 
-#: client/helpdata.c:2222
+#: client/helpdata.c:2230
 msgid "* Strong in diplomatic battles.\n"
 msgstr "· Vahva diplomaattien välisissä taisteluissa.\n"
 
-#: client/helpdata.c:2226
+#: client/helpdata.c:2234
 msgid "* Defends cities against diplomatic actions.\n"
 msgstr "· Puolustaa kaupunkeja diplomaatteja vastaan.\n"
 
-#: client/helpdata.c:2229
+#: client/helpdata.c:2237
 msgid "* Will never lose a diplomat-versus-diplomat fight.\n"
 msgstr "· Ei koskaan häviä diplomaattien välisiä taisteluja.\n"
 
-#: client/helpdata.c:2233
+#: client/helpdata.c:2241
 msgid "* Will always survive a spy mission.\n"
 msgstr "· Selviää aina vakoilutehtävästä.\n"
 
-#: client/helpdata.c:2237
+#: client/helpdata.c:2245
 msgid "* Is invisible except when next to an enemy unit or city.\n"
 msgstr ""
 "· On näkymätön paitsi aivan vihollisen yksikön tai kaupungin vieressä.\n"
 
-#: client/helpdata.c:2241
+#: client/helpdata.c:2249
 msgid "* Can only attack units on native tiles.\n"
 msgstr "· Voi hyökätä vain suotuisassa maastossa olevia yksiköitä vastaan.\n"
 
-#: client/helpdata.c:2247
+#: client/helpdata.c:2255
 msgid ""
 "* Won't lose all movement when moving from non-native terrain to native "
 "terrain.\n"
@@ -9971,52 +10021,52 @@ msgstr ""
 "· Ei menetä kaikkia liikepisteitään liikkuessaan ei-suotuisesta maastosta, "
 "jossa on ollut esimerkiksi kuljetusaluksen kyydissä, suotuisaan maastoon.\n"
 
-#: client/helpdata.c:2252
+#: client/helpdata.c:2260
 msgid "* Gets double firepower when attacking cities.\n"
 msgstr "· Saa kaksinkertaisen tulivoiman kaupunkeja vastaan.\n"
 
 #. TRANS: "MP" = movement points. %s may have a
 #. * fractional part.
-#: client/helpdata.c:2258
+#: client/helpdata.c:2266
 #, c-format
 msgid "* Ignores terrain effects (moving costs at most %s MP per tile).\n"
 msgstr ""
 "· On kotonaan maastossa kuin maastossa (liikkuminen maksaa korkeintaan %s "
 "LP).\n"
 
-#: client/helpdata.c:2263
+#: client/helpdata.c:2271
 msgid "* Never imposes a zone of control.\n"
 msgstr "· Ei luo valvonta-alueita ympärilleen.\n"
 
-#: client/helpdata.c:2265
+#: client/helpdata.c:2273
 msgid "* May impose a zone of control on its adjacent tiles.\n"
 msgstr "· Luo valvonta-alueen ympäröiviin ruutuihin.\n"
 
-#: client/helpdata.c:2269
+#: client/helpdata.c:2277
 msgid "* Not subject to zones of control imposed by other units.\n"
 msgstr "· Ei piittaa muiden luomista valvonta-alueista.\n"
 
-#: client/helpdata.c:2274
+#: client/helpdata.c:2282
 msgid "* A non-military unit:\n"
 msgstr "· Siviiliyksikkö:\n"
 
-#: client/helpdata.c:2276
+#: client/helpdata.c:2284
 msgid "  * Cannot attack.\n"
 msgstr "  · Ei voi hyökätä.\n"
 
-#: client/helpdata.c:2278
+#: client/helpdata.c:2286
 msgid "  * Doesn't impose martial law.\n"
 msgstr "  · Ei voi pakottaa kansalaisia rauhallisiksi.\n"
 
-#: client/helpdata.c:2280
+#: client/helpdata.c:2288
 msgid "  * Can enter foreign territory regardless of peace treaty.\n"
 msgstr "  · Voi liikkua vieraalla maalla rauhansopimuksesta riippumatta.\n"
 
-#: client/helpdata.c:2286
+#: client/helpdata.c:2294
 msgid "* A field unit: one unhappiness applies even when non-aggressive.\n"
 msgstr "· Taisteluyksikkö: aiheuttaa tyytymättömyyttä puolustusasemissakin.\n"
 
-#: client/helpdata.c:2292
+#: client/helpdata.c:2300
 msgid ""
 "* An enemy unit considering to auto attack this unit will choose to do so "
 "even if it has better odds when defending against it than when attacking "
@@ -10026,7 +10076,7 @@ msgstr ""
 "olisikin paremmat voittomahdollisuudet puolustautuessaan tätä yksikköä "
 "vastaan.\n"
 
-#: client/helpdata.c:2301
+#: client/helpdata.c:2309
 msgid ""
 "* Under certain conditions the shield upkeep of this unit can be converted "
 "to gold upkeep.\n"
@@ -10034,12 +10084,12 @@ msgstr ""
 "· Tietyin edellytyksin yksikön ylläpitokustannukset voidaan maksaa kultana "
 "tuotannon sijaan.\n"
 
-#: client/helpdata.c:2309
+#: client/helpdata.c:2317
 #, c-format
 msgid "* Can attack against %s units, which are usually not reachable.\n"
 msgstr "· Voi hyökätä ylensä tavoittamattomissa olevia %s yksikköjä vastaan.\n"
 
-#: client/helpdata.c:2330
+#: client/helpdata.c:2338
 #, fuzzy
 #| msgid "* Unit has to be in a city or a base after %d turn.\n"
 #| msgid_plural "* Unit has to be in a city or a base after %d turns.\n"
@@ -10048,7 +10098,7 @@ msgid ""
 msgstr "· Yksikön tulee olla kaupungissa tai tukikohdassa %d vuoron jälkeen.\n"
 
 #. TRANS: Never called for 'turns = 1' case
-#: client/helpdata.c:2337
+#: client/helpdata.c:2345
 #, fuzzy, c-format
 #| msgid "* Unit has to be in a city or a base after %d turn.\n"
 #| msgid_plural "* Unit has to be in a city or a base after %d turns.\n"
@@ -10061,7 +10111,7 @@ msgstr[0] ""
 msgstr[1] ""
 "· Yksikön tulee olla kaupungissa tai tukikohdassa %d vuoron jälkeen.\n"
 
-#: client/helpdata.c:2346
+#: client/helpdata.c:2354
 #, c-format
 msgid "* Unit has to be in a city or a base after %d turn.\n"
 msgid_plural "* Unit has to be in a city or a base after %d turns.\n"
@@ -10071,7 +10121,7 @@ msgstr[1] ""
 "· Yksikön tulee olla kaupungissa tai tukikohdassa %d vuoron jälkeen.\n"
 
 #. TRANS: %s is a list of unit types separated by "or"
-#: client/helpdata.c:2359
+#: client/helpdata.c:2367
 #, c-format
 msgid ""
 "* Unit has to be next to safe coast, in a city, a base, or on a %s after %d "
@@ -10087,7 +10137,7 @@ msgstr[1] ""
 "tukikohdassa (%s riittää myös) %d vuoron jälkeen.\n"
 
 #. TRANS: %s is a list of unit types separated by "or"
-#: client/helpdata.c:2368
+#: client/helpdata.c:2376
 #, c-format
 msgid "* Unit has to be in a city, a base, or on a %s after %d turn.\n"
 msgid_plural "* Unit has to be in a city, a base, or on a %s after %d turns.\n"
@@ -10099,26 +10149,26 @@ msgstr[1] ""
 "vuoron jälkeen.\n"
 
 #. TRANS: %s is the action's ruleset defined ui name
-#: client/helpdata.c:2394
+#: client/helpdata.c:2402
 #, fuzzy, c-format
 #| msgid "* Can do the action '%s' to some %s.\n"
 msgid "* Can do the action '%s'.\n"
 msgstr "· Voi tehdä toiminnon '%s' tyypin %s kohteelle.\n"
 
 #. TRANS: describes the target of an action.
-#: client/helpdata.c:2405
+#: client/helpdata.c:2413
 msgid "domestic "
 msgstr "kotimainen "
 
 #. TRANS: describes the target of an action.
-#: client/helpdata.c:2409
+#: client/helpdata.c:2417
 msgid "foreign "
 msgstr "ulkomainen "
 
 #. TRANS: The first %s may be an adjective (that
 #. * includes a space). The next is the name of its
 #. * target kind.
-#: client/helpdata.c:2419
+#: client/helpdata.c:2427
 #, fuzzy, c-format
 #| msgid "?output:Applies only to %s.\n"
 msgid "  * is done to %s%s.\n"
@@ -10126,7 +10176,7 @@ msgstr "Pätee vain kun kyseessä on %s.\n"
 
 #. TRANS: said about an action. %s is a unit type
 #. * name.
-#: client/helpdata.c:2429
+#: client/helpdata.c:2437
 #, fuzzy, c-format
 #| msgid "%s rules the %s."
 msgid "  * uses up the %s.\n"
@@ -10134,7 +10184,7 @@ msgstr "%s sai johtaakseen %s."
 
 #. TRANS: The %s is a kind of battle defined in
 #. * actions.h. Example: "diplomatic battle".
-#: client/helpdata.c:2437
+#: client/helpdata.c:2445
 #, fuzzy, c-format
 #| msgid "* Counts as 'mounted' against certain defenders.\n"
 msgid "  * can lead to a %s against a defender.\n"
@@ -10142,13 +10192,13 @@ msgstr "· Lasketaan ratsuyksiköksi tiettyjä puolustajia vastaan.\n"
 
 #. TRANS: distance between an actor unit and its
 #. * target when performing a specific action.
-#: client/helpdata.c:2458
+#: client/helpdata.c:2466
 msgid "  * target must be at the same tile.\n"
 msgstr "  · Kohteen täytyy olla samassa ruudussa.\n"
 
 #. TRANS: distance between an actor unit and its
 #. * target when performing a specific action.
-#: client/helpdata.c:2463
+#: client/helpdata.c:2471
 #, c-format
 msgid "  * target must be exactly %d tile away.\n"
 msgid_plural "  * target must be exactly %d tiles away.\n"
@@ -10157,13 +10207,13 @@ msgstr[1] "  · Kohteen täytyy olla täsmälleen %d ruudun päässä.\n"
 
 #. TRANS: distance between an actor unit and its
 #. * target when performing a specific action.
-#: client/helpdata.c:2475
+#: client/helpdata.c:2483
 msgid "  * target can be anywhere.\n"
 msgstr "  · Kohde voi olla missä hyvänsä.\n"
 
 #. TRANS: distance between an actor unit and its
 #. * target when performing a specific action.
-#: client/helpdata.c:2480
+#: client/helpdata.c:2488
 #, c-format
 msgid "  * target must be at least %d tile away.\n"
 msgid_plural "  * target must be at least %d tiles away.\n"
@@ -10172,7 +10222,7 @@ msgstr[1] "  · Kohteen täytyy olla vähintään %d ruudun päässä.\n"
 
 #. TRANS: distance between an actor unit and its
 #. * target when performing a specific action.
-#: client/helpdata.c:2491
+#: client/helpdata.c:2499
 #, fuzzy, c-format
 #| msgid "* Can clean %s from tiles.\n"
 msgid "  * target can be max %d tile away.\n"
@@ -10182,7 +10232,7 @@ msgstr[1] "· Voi puhdistaa lisän \"%s\" ruuduista.\n"
 
 #. TRANS: distance between an actor unit and its
 #. * target when performing a specific action.
-#: client/helpdata.c:2501
+#: client/helpdata.c:2509
 #, c-format
 msgid "  * target must be between %d and %d tile away.\n"
 msgid_plural "  * target must be between %d and %d tiles away.\n"
@@ -10193,18 +10243,18 @@ msgstr[1] ""
 
 #. TRANS: the %d is the number of shields the unit can
 #. * contribute.
-#: client/helpdata.c:2514
+#: client/helpdata.c:2522
 #, c-format
 msgid "  * adds %d production.\n"
 msgstr "  · Lisää tuontantoa %d.\n"
 
 #. TRANS: is talking about an action.
-#: client/helpdata.c:2521
+#: client/helpdata.c:2529
 msgid "  * is disabled in the current game.\n"
 msgstr "  · Ei ole sallittu nykyisessä pelissä.\n"
 
 #. TRANS: the %d is initial population.
-#: client/helpdata.c:2525
+#: client/helpdata.c:2533
 #, c-format
 msgid "  * initial population: %d.\n"
 msgid_plural "  * initial population: %d.\n"
@@ -10212,7 +10262,7 @@ msgstr[0] "  · Aloituskoko on %d.\n"
 msgstr[1] "  · Aloituskoko on %d.\n"
 
 #. TRANS: the %d is population.
-#: client/helpdata.c:2533
+#: client/helpdata.c:2541
 #, c-format
 msgid "  * max target size: %d.\n"
 msgid_plural "  * max target size: %d.\n"
@@ -10220,7 +10270,7 @@ msgstr[0] "  · Kohteen suurin mahdollinen koko: %d.\n"
 msgstr[1] "  · Kohteen suurin mahdollinen koko: %d.\n"
 
 #. TRANS: the %d is the population added.
-#: client/helpdata.c:2539
+#: client/helpdata.c:2547
 #, fuzzy, c-format
 #| msgid "* Costs %d population to build.\n"
 #| msgid_plural "* Costs %d population to build.\n"
@@ -10230,13 +10280,13 @@ msgstr[0] "· Tuottaminen pienentää kaupungin väkilukua %d pisteen.\n"
 msgstr[1] "· Tuottaminen pienentää kaupungin väkilukua %d pistettä.\n"
 
 #. TRANS: %d is bombard rate.
-#: client/helpdata.c:2547
+#: client/helpdata.c:2555
 #, c-format
 msgid "  * %d per turn.\n"
 msgstr "  * %d vuorossa.\n"
 
 #. TRANS: talking about bombard
-#: client/helpdata.c:2551
+#: client/helpdata.c:2559
 #, fuzzy
 #| msgid ""
 #| "* Does bombard attacks (%d per turn). These attacks will only damage "
@@ -10251,7 +10301,7 @@ msgstr ""
 "kaikkia yksiköitä ruudussa. Ne ovat hyökkääjän kannalta riskittömiä.\n"
 
 #. TRANS: %s is a unit type.
-#: client/helpdata.c:2559
+#: client/helpdata.c:2567
 #, c-format
 msgid ""
 "  * upgraded to %s or, when possible, to the unit type it upgrades to.\n"
@@ -10259,7 +10309,7 @@ msgstr ""
 "  · ajanmukaistuu yksiköksi %s, mahdollisuuksien mukaan "
 "ajanmukaistusketjussa ylemmäksikin.\n"
 
-#: client/helpdata.c:2567
+#: client/helpdata.c:2575
 msgid ""
 "  * weaker when tired. If performed with less than a single move point left "
 "the attack power is reduced accordingly.\n"
@@ -10267,14 +10317,14 @@ msgstr ""
 "  · väsyneenä heikompi. Jos yksikkö hyökää kun sillä on vähemmän kuin yksi "
 "kokonainen liikepiste, hyökkäysvoima on vähentynyt vastaavassa suhteessa.\n"
 
-#: client/helpdata.c:2574
+#: client/helpdata.c:2582
 #, fuzzy
 #| msgid "* Making an attack ends this unit's turn.\n"
 msgid "  * ends this unit's turn.\n"
 msgstr "· Hyökkäys päättää tämän yksikön vuoron.\n"
 
 #. TRANS: %s is a unit type. "MP" = movement points.
-#: client/helpdata.c:2580
+#: client/helpdata.c:2588
 #, fuzzy, c-format
 #| msgid "* May be converted into %s (takes %d MP).\n"
 #| msgid_plural "* May be converted into %s (takes %d MP).\n"
@@ -10284,54 +10334,54 @@ msgstr[0] "· Voidaan muuntaa yksiköksi %s (kuluttaa %d LP).\n"
 msgstr[1] "· Voidaan muuntaa yksiköksi %s (kuluttaa %d LP).\n"
 
 #. TRANS: %s is an action that can block another.
-#: client/helpdata.c:2604
+#: client/helpdata.c:2612
 #, c-format
 msgid "'%s'"
 msgstr "'%s'"
 
 #. TRANS: %s is a list of actions separated by "or".
-#: client/helpdata.c:2616
+#: client/helpdata.c:2624
 #, c-format
 msgid "  * can't be done if %s is legal.\n"
 msgstr "  · ei voida tehdä mikäli toimenpide %s on mahdollinen.\n"
 
-#: client/helpdata.c:2660
+#: client/helpdata.c:2668
 #, c-format
 msgid "* Doing the action '%s' to this unit is impossible.\n"
 msgstr "· Yksikölle ei voi tehdä toimenpidettä '%s'.\n"
 
-#: client/helpdata.c:2668
+#: client/helpdata.c:2676
 msgid "* Will never achieve veteran status.\n"
 msgstr "· Ei ylennetä koskaan.\n"
 
-#: client/helpdata.c:2682
+#: client/helpdata.c:2690
 msgid "* May acquire veteran status.\n"
 msgstr "· Voi saada ylennyksiä.\n"
 
-#: client/helpdata.c:2687
+#: client/helpdata.c:2695
 msgid "  * Veterans have increased strength in combat.\n"
 msgstr "  · Ylennetyt yksiköt ovat vahvempia taistelussa.\n"
 
-#: client/helpdata.c:2693
+#: client/helpdata.c:2701
 msgid "  * Veterans have improved chances in diplomatic contests.\n"
 msgstr ""
 "  · Ylentäminen parantaa mahdollisuuksia onnistua diplomaattisissa "
 "tehtävissä.\n"
 
-#: client/helpdata.c:2697
+#: client/helpdata.c:2705
 msgid "  * Veterans are more likely to survive missions.\n"
 msgstr "  · Yleneminen parantaa mahdollisuutta selvitä tehtävistä hengissä.\n"
 
 # Property of improvement
-#: client/helpdata.c:2702
+#: client/helpdata.c:2710
 msgid "  * Veterans work faster.\n"
 msgstr "  · Ylennettynä tekevät työtä nopeammin.\n"
 
-#: client/helpdata.c:2713
+#: client/helpdata.c:2721
 msgid "This type of unit has its own veteran levels:"
 msgstr "Tällä yksikkötyypillä on omat ylennystasonsa:"
 
-#: client/helpdata.c:2752
+#: client/helpdata.c:2760
 msgid ""
 "Belongs to the default tech class.\n"
 "\n"
@@ -10339,7 +10389,7 @@ msgstr ""
 "Kuuluu teknologioiden oletusluokkaan.\n"
 "\n"
 
-#: client/helpdata.c:2754
+#: client/helpdata.c:2762
 #, c-format
 msgid ""
 "Belongs to tech class %s.\n"
@@ -10348,7 +10398,7 @@ msgstr ""
 "Kuuluu teknologialuokkaan %s.\n"
 "\n"
 
-#: client/helpdata.c:2767
+#: client/helpdata.c:2775
 #, c-format
 msgid "Starting now, researching %s would need %d bulb."
 msgid_plural "Starting now, researching %s would need %d bulbs."
@@ -10357,7 +10407,7 @@ msgstr[1] "Jos %s otettaisiin kohteeksi nyt, tarvitsisimme %d lamppua."
 
 #. TRANS: appended to another sentence. Preserve the
 #. * leading space.
-#: client/helpdata.c:2779
+#: client/helpdata.c:2787
 #, c-format
 msgid " The whole project will require %d bulb to complete."
 msgid_plural " The whole project will require %d bulbs to complete."
@@ -10365,7 +10415,7 @@ msgstr[0] " Koko projekti vaatii %d lampun."
 msgstr[1] " Koko projekti vaatii %d lamppua."
 
 #. TRANS: last %s is a sentence pluralized separately.
-#: client/helpdata.c:2785
+#: client/helpdata.c:2793
 #, c-format
 msgid "To research %s you need to research %d other technology first.%s"
 msgid_plural ""
@@ -10374,38 +10424,38 @@ msgstr[0] "Jotta %s saavutettaisiin, %d muu teknologia pitää tutkia ensin.%s"
 msgstr[1] ""
 "Jotta %s saavutettaisiin, %d muuta teknologiaa pitää tutkia ensin.%s"
 
-#: client/helpdata.c:2794
+#: client/helpdata.c:2802
 msgid "You cannot research this technology."
 msgstr "Et voi tutkia tätä teknologiaa."
 
-#: client/helpdata.c:2799
+#: client/helpdata.c:2807
 msgid " This number may vary depending on what other players research.\n"
 msgstr ""
 " Lamppujen määrä voi vaihdella riippuen siitä mitä muut pelaajat tutkivat.\n"
 
-#: client/helpdata.c:2810
+#: client/helpdata.c:2818
 msgid "Requirements to research:\n"
 msgstr "Tutkimisvaatimukset:\n"
 
-#: client/helpdata.c:2829
+#: client/helpdata.c:2837
 msgid "* All players start the game with knowledge of this technology.\n"
 msgstr "· Kaikki pelaajat osaavat tämän teknologian jo pelin alkaessa.\n"
 
 #. TRANS: %s is a nation plural
-#: client/helpdata.c:2851
+#: client/helpdata.c:2859
 #, c-format
 msgid "* The %s start the game with knowledge of this technology.\n"
 msgstr "· %s osaavat tämän teknologian jo pelin alkaessa.\n"
 
 #. TRANS: 'and'-separated list of techs
-#: client/helpdata.c:2905
+#: client/helpdata.c:2913
 #, c-format
 msgid "* Only those who know %s can acquire this technology (by any means).\n"
 msgstr ""
 "· Vain pelaajat jotka osaavat teknologian %s voivat saavuttaa tämän "
 "teknologian millään keinolla.\n"
 
-#: client/helpdata.c:2914
+#: client/helpdata.c:2922
 #, fuzzy, c-format
 #| msgid "* The first player to research %s gets an immediate advance.\n"
 msgid "* The first player to learn %s gets an immediate advance.\n"
@@ -10413,7 +10463,7 @@ msgstr ""
 "· Ensimmäinen pelaaja joka saavuttaa teknologian %s saa välittömästi "
 "ylimääräisen teknologian.\n"
 
-#: client/helpdata.c:2937
+#: client/helpdata.c:2945
 msgid ""
 "* To preserve this technology for our nation some bulbs are needed each "
 "turn.\n"
@@ -10421,29 +10471,29 @@ msgstr ""
 "· Tämän teknologian säilyttämiseksi tutkimuksen on tuotettava lamppuja joka "
 "vuoro.\n"
 
-#: client/helpdata.c:2978
+#: client/helpdata.c:2986
 msgid "* You cannot build cities on this terrain."
 msgstr "· Tälle maastotyypille ei voi rakentaa kaupunkeja."
 
-#: client/helpdata.c:2986
+#: client/helpdata.c:2994
 msgid "* Paths cannot be built on this terrain."
 msgstr "· Tälle maastotyypille ei voi rakentaa kulkureittejä."
 
-#: client/helpdata.c:2997
+#: client/helpdata.c:3005
 msgid "* Bases cannot be built on this terrain."
 msgstr "· Tälle maastotyypille ei voi rakentaa tukikohtia."
 
-#: client/helpdata.c:3006
+#: client/helpdata.c:3014
 msgid "* The coastline of this terrain is unsafe."
 msgstr "· Tämä maastotyypin rannikko on turvaton."
 
 #. TRANS: %s is a list of unit classes separated by "and".
-#: client/helpdata.c:3023 client/helpdata.c:3494
+#: client/helpdata.c:3031 client/helpdata.c:3524
 #, c-format
 msgid "* Can be traveled by %s units.\n"
 msgstr "· Tällä maastotyypillä voivat kulkea %s yksiköt.\n"
 
-#: client/helpdata.c:3030
+#: client/helpdata.c:3038
 msgid ""
 "* Units on this terrain neither impose zones of control nor are restricted "
 "by them.\n"
@@ -10451,7 +10501,7 @@ msgstr ""
 "· Tällä maastolla olevat yksiköt eivät luo valvonta-alueita eivätkä myöskään "
 "välitä niistä.\n"
 
-#: client/helpdata.c:3034
+#: client/helpdata.c:3042
 msgid ""
 "* Units on this terrain may impose a zone of control, or be restricted by "
 "one.\n"
@@ -10459,115 +10509,133 @@ msgstr ""
 "· Tällä maastotyypillä olevat yksiköt voivat luoda valvonta-alueita ja olla "
 "niiden rajoittamia.\n"
 
-#: client/helpdata.c:3039
+#: client/helpdata.c:3047
 msgid "* No units can fortify on this terrain.\n"
 msgstr "· Tällä maastotyypillä ei voi linnoittautua.\n"
 
-#: client/helpdata.c:3042
+#: client/helpdata.c:3050
 msgid "* Units able to fortify may do so on this terrain.\n"
 msgstr "· Tälle maastotyypille voi linnoittautua.\n"
 
-#: client/helpdata.c:3222
+#: client/helpdata.c:3230
 #, c-format
 msgid ", +%d food"
 msgid_plural ", +%d food"
 msgstr[0] ", +%d ruokaa"
 msgstr[1] ", +%d ruokaa"
 
-#: client/helpdata.c:3226
+#: client/helpdata.c:3234
 #, c-format
 msgid ", +%d shield"
 msgid_plural ", +%d shields"
 msgstr[0] ", +%d tuotantoa"
 msgstr[1] ", +%d tuotantoa"
 
-#: client/helpdata.c:3230
+#: client/helpdata.c:3238
 #, c-format
 msgid ", +%d trade"
 msgid_plural ", +%d trade"
 msgstr[0] ", +%d kauppaa"
 msgstr[1] ", +%d kauppaa"
 
-#: client/helpdata.c:3288
+#: client/helpdata.c:3296
 msgid "Build by issuing an \"irrigate\" order.\n"
 msgstr "Rakenna määräämällä kasteluverkoston rakennuskäsky.\n"
 
-#: client/helpdata.c:3292
+#: client/helpdata.c:3300
 msgid "Build by issuing a \"mine\" order.\n"
 msgstr "Rakenna määräämällä kaivoksen louhiminen.\n"
 
-#: client/helpdata.c:3296
+#: client/helpdata.c:3304
 msgid "Build by issuing a \"road\" order.\n"
 msgstr "Rakenna määräämällä tien rakentaminen.\n"
 
-#: client/helpdata.c:3302
+#: client/helpdata.c:3310
 msgid "Build by issuing a \"build base\" order.\n"
 msgstr "Rakenna määräämällä tukikohdan rakentaminen.\n"
 
 #. TRANS: %s is a gui_type base string from a ruleset
-#: client/helpdata.c:3319
+#: client/helpdata.c:3327
 #, c-format
 msgid "Build by issuing a \"%s\" order.\n"
 msgstr "Rakennataan komennolla \"%s\".\n"
 
-#: client/helpdata.c:3326
+#: client/helpdata.c:3334
 msgid "May randomly appear around polluting city.\n"
 msgstr "Voi sattumanvaraisesti ilmestyä saastuttavan kaupungin ympäristöön.\n"
 
-#: client/helpdata.c:3331
+#: client/helpdata.c:3339
 msgid "May randomly appear around nuclear blast.\n"
 msgstr "Voi sattumanvaraisesti ilmestyä ydinräjähdyksen ympäristöön.\n"
 
-#: client/helpdata.c:3337
+#: client/helpdata.c:3345
 msgid "Placed by map generator.\n"
 msgstr "Karttageneraattori sijoittaa.\n"
 
-#: client/helpdata.c:3342
+#: client/helpdata.c:3350
+#, fuzzy
+#| msgid "* Can be traveled by %s units.\n"
+msgid "Can be explored by certain units.\n"
+msgstr "· Tällä maastotyypillä voivat kulkea %s yksiköt.\n"
+
+#: client/helpdata.c:3355
 msgid "May appear spontaneously.\n"
 msgstr "Voi ilmestyä itsestään.\n"
 
-#: client/helpdata.c:3358
+#: client/helpdata.c:3371
 msgid "Requirements to build:\n"
 msgstr "Rakentamisvaatimukset:\n"
 
-#: client/helpdata.c:3393
+#: client/helpdata.c:3378
+#, fuzzy, c-format
+#| msgid "Cost:"
+msgid "Cost: %d\n"
+msgstr "Hinta:"
+
+#: client/helpdata.c:3410
 msgid "Can be pillaged by units (time is terrain-dependent).\n"
 msgstr "Yksiköt voivat turmella (aika riippuu maastotyypistä).\n"
 
-#: client/helpdata.c:3396
+#: client/helpdata.c:3413
 #, c-format
 msgid "Can be pillaged by units (takes %d turn).\n"
 msgid_plural "Can be pillaged by units (takes %d turns).\n"
 msgstr[0] "Yksiköt voivat tuhota (%d vuorossa).\n"
 msgstr[1] "Yksiköt voivat tuhota (%d vuorossa).\n"
 
-#: client/helpdata.c:3440
+#: client/helpdata.c:3457
 msgid "Can be cleaned by units (time is terrain-dependent).\n"
 msgstr "Yksiköt voivat siivota pois (aika riippuu maastotyypistä).\n"
 
-#: client/helpdata.c:3443
+#: client/helpdata.c:3460
 #, c-format
 msgid "Can be cleaned by units (takes %d turn).\n"
 msgid_plural "Can be cleaned by units (takes %d turns).\n"
 msgstr[0] "Yksiköt voivat siivota pois (%d vuorossa).\n"
 msgstr[1] "Yksiköt voivat siivota pois (%d vuorossa).\n"
 
-#: client/helpdata.c:3469
+#: client/helpdata.c:3474
+#, fuzzy
+#| msgid "Requirements to research:\n"
+msgid "Requirements to remove:\n"
+msgstr "Tutkimisvaatimukset:\n"
+
+#: client/helpdata.c:3499
 #, c-format
 msgid "* Visible only if %s known.\n"
 msgstr "· Näkyvä vain jos %s tunnetaan.\n"
 
-#: client/helpdata.c:3476
+#: client/helpdata.c:3506
 msgid "* Units inside are hidden from non-allied players.\n"
 msgstr "· Sisällä olevat yksiköt ovat vain liittolaisten näkyvissä.\n"
 
 #. TRANS: %s is a list of unit classes separated by "and".
-#: client/helpdata.c:3498
+#: client/helpdata.c:3528
 #, c-format
 msgid "* Native to %s units.\n"
 msgstr "· Sopii %s yksiköille.\n"
 
-#: client/helpdata.c:3505
+#: client/helpdata.c:3535
 msgid ""
 "  * Such units can move onto this tile even if it would not normally be "
 "suitable terrain.\n"
@@ -10575,7 +10643,7 @@ msgstr ""
 "  · Niiden tyyppiset yksiköt voivat liikkua tähän ruutuun vaikka maasto ei "
 "normaalisti sopisi niille.\n"
 
-#: client/helpdata.c:3512
+#: client/helpdata.c:3542
 msgid ""
 "  * Such units situated here are not considered aggressive if this tile is "
 "within 3 tiles of a friendly city.\n"
@@ -10584,7 +10652,7 @@ msgstr ""
 "kunhan ruutu on korkeintaan 3 ruudun päässä ystävällismielisestä "
 "kaupungista.\n"
 
-#: client/helpdata.c:3517
+#: client/helpdata.c:3547
 msgid ""
 "  * Can be captured by such units if at war with the nation that currently "
 "owns it.\n"
@@ -10592,39 +10660,39 @@ msgstr ""
 "  · Voidaan valloittaa vastaavilla yksiköillä, jos sodassa ruudun "
 "tämänhetkisen omistajan kanssa.\n"
 
-#: client/helpdata.c:3523
+#: client/helpdata.c:3553
 #, c-format
 msgid "  * Such units get a %d%% defense bonus on this tile.\n"
 msgstr ""
 "  · Vastaavat yksiköt saavat %d%% puolustusedun maastossa tässä ruudussa.\n"
 
-#: client/helpdata.c:3532
+#: client/helpdata.c:3562
 msgid "* Allows infinite movement.\n"
 msgstr "· Mahdollistaa rajattoman liikkumisen.\n"
 
 #. TRANS: "MP" = movement points. Second %s may have a
 #. * fractional part.
-#: client/helpdata.c:3537
+#: client/helpdata.c:3567
 #, c-format
 msgid "* Movement cost along %s is %s MP.\n"
 msgstr "· %s pitkin liikkuminen kuluttaa %s LP.\n"
 
-#: client/helpdata.c:3546
+#: client/helpdata.c:3576
 msgid ""
 "* Defeat of one unit does not cause death of all other units on this tile.\n"
 msgstr ""
 "· Puolustavan yksikön tappio ei aiheuta muiden ruudussa olevien yksiköiden "
 "tuhoutumista.\n"
 
-#: client/helpdata.c:3552
+#: client/helpdata.c:3582
 msgid "* Extends national borders of the building nation.\n"
 msgstr "· Laajentaa rakentavan kansakunnan rajoja.\n"
 
-#: client/helpdata.c:3556
+#: client/helpdata.c:3586
 msgid "* Grants permanent vision of an area around the tile to its owner.\n"
 msgstr "· Omistaja näkee pysyvästi ympäröivät ruudut.\n"
 
-#: client/helpdata.c:3561
+#: client/helpdata.c:3591
 #, fuzzy
 #| msgid ""
 #| "* Allows the owner to see normally invisible units in an area around the "
@@ -10636,7 +10704,7 @@ msgstr ""
 "· Omistaja näkee myös tavallisesti näkymättömät yksiköt ruudun "
 "ympäristössä.\n"
 
-#: client/helpdata.c:3566
+#: client/helpdata.c:3596
 #, fuzzy
 #| msgid ""
 #| "* Allows the owner to see normally invisible units in an area around the "
@@ -10648,7 +10716,7 @@ msgstr ""
 "· Omistaja näkee myös tavallisesti näkymättömät yksiköt ruudun "
 "ympäristössä.\n"
 
-#: client/helpdata.c:3607
+#: client/helpdata.c:3637
 msgid ""
 "\n"
 "Time to build and output bonus depends on terrain:\n"
@@ -10660,7 +10728,7 @@ msgstr ""
 
 #. TRANS: Header for fixed-width road properties table.
 #. * TRANS: Translators cannot change column widths :(
-#: client/helpdata.c:3611
+#: client/helpdata.c:3641
 msgid ""
 "Terrain       Time     Bonus F/P/T\n"
 "----------------------------------\n"
@@ -10668,7 +10736,7 @@ msgstr ""
 "Maastotyyppi  Aika     Bonus R/T/K\n"
 "----------------------------------\n"
 
-#: client/helpdata.c:3615
+#: client/helpdata.c:3645
 msgid ""
 "\n"
 "Time to build depends on terrain:\n"
@@ -10680,7 +10748,7 @@ msgstr ""
 
 #. TRANS: Header for fixed-width extra properties table.
 #. * TRANS: Translators cannot change column widths :(
-#: client/helpdata.c:3619
+#: client/helpdata.c:3649
 msgid ""
 "Terrain       Time\n"
 "------------------\n"
@@ -10690,7 +10758,7 @@ msgstr ""
 
 #. TRANS: Header for fixed-width road properties table.
 #. * TRANS: Translators cannot change column widths :(
-#: client/helpdata.c:3626
+#: client/helpdata.c:3656
 msgid ""
 "\n"
 "Yields an output bonus with some terrains:\n"
@@ -10700,7 +10768,7 @@ msgstr ""
 "Antaa bonuksen joillakin maastotyypeillä:\n"
 "\n"
 
-#: client/helpdata.c:3628
+#: client/helpdata.c:3658
 msgid ""
 "Terrain       Bonus F/P/T\n"
 "-------------------------\n"
@@ -10708,24 +10776,24 @@ msgstr ""
 "Maastotyyppi  Bonus R/T/K\n"
 "-------------------------\n"
 
-#: client/helpdata.c:3688
+#: client/helpdata.c:3718
 msgid ""
 "There's no bonuses paid when traderoute is established.\n"
 "\n"
 msgstr "Uuden kauppareitin perustamisen yhteydessä ei makseta bonusta.\n"
 
-#: client/helpdata.c:3691
+#: client/helpdata.c:3721
 #, c-format
 msgid "When traderoute is established, %d%% of the normal bonus is paid.\n"
 msgstr ""
 "Perustettaessa uusi kauppareitti, maksetaan %d%% normaalista bonuksesta.\n"
 
-#: client/helpdata.c:3694
+#: client/helpdata.c:3724
 #, c-format
 msgid "Sending city enjoys %d%% income from the route.\n"
 msgstr "Kauppareitin alkupää saa reitistä %d%% tuoton.\n"
 
-#: client/helpdata.c:3696
+#: client/helpdata.c:3726
 #, c-format
 msgid ""
 "Receiving city enjoys %d%% income from the route.\n"
@@ -10734,16 +10802,16 @@ msgstr ""
 "Kauppareitin loppupää saa reitistä  %d%% tuoton.\n"
 "\n"
 
-#: client/helpdata.c:3782
+#: client/helpdata.c:3812
 msgid "Features:\n"
 msgstr "Ominaisuuksia:\n"
 
 #. TRANS: Empty output type list, should never happen.
-#: client/helpdata.c:3905 client/helpdata.c:3906
+#: client/helpdata.c:3935 client/helpdata.c:3936
 msgid "?outputlist: Nothing "
 msgstr " Ei mitään "
 
-#: client/helpdata.c:3918
+#: client/helpdata.c:3948
 #, c-format
 msgid ""
 "* Military units away from home and field units will each cause %d citizen "
@@ -10758,7 +10826,7 @@ msgstr[1] ""
 "· Poissa kotoa olevat sotilasyksiköt ja taisteluyksiköt tekevät %d asukasta "
 "tyytymättömäksi.\n"
 
-#: client/helpdata.c:3931
+#: client/helpdata.c:3961
 #, c-format
 msgid ""
 "* Unhappiness from foreign citizens due to war with their home state is %d%% "
@@ -10767,7 +10835,7 @@ msgstr ""
 "· Sodan aikana viholliskansallisuuden asukkaiden kaupungeille aiheuttama "
 "tyytymättömyys on %d%% tavallisesta.\n"
 
-#: client/helpdata.c:3937
+#: client/helpdata.c:3967
 msgid ""
 "* No unhappiness from foreign citizens even when at war with their home "
 "state.\n"
@@ -10777,7 +10845,7 @@ msgstr ""
 
 #. TRANS: not pluralised as gettext doesn't support
 #. * fractional numbers, which this might be
-#: client/helpdata.c:3944
+#: client/helpdata.c:3974
 #, c-format
 msgid ""
 "* Each foreign citizen causes %.2g unhappiness in their city while you are "
@@ -10786,7 +10854,7 @@ msgstr ""
 "· Kukin viholliskansalaisuuden kansalainen kaupungissa aiheuttaa %.2g "
 "tyytymättömyyttä sodan aikana.\n"
 
-#: client/helpdata.c:3954
+#: client/helpdata.c:3984
 #, c-format
 msgid "* Each of your cities will avoid %d unhappiness caused by units.\n"
 msgid_plural ""
@@ -10798,7 +10866,7 @@ msgstr[1] ""
 "· Kukin kaupungeistasi välttää %d asukkaan yksiköistä aiheutuvan "
 "tyytymättömyyden.\n"
 
-#: client/helpdata.c:3965
+#: client/helpdata.c:3995
 #, c-format
 msgid ""
 "* Each of your cities will avoid %d unhappiness, not including that caused "
@@ -10813,7 +10881,7 @@ msgstr[1] ""
 "· Kukin kaupungeistasi välttää %d asukkaan tyytymättömyyden. Yksiköiden "
 "aiheuttamaa tyytymättömyyttä tämä ei pysty poistamaan.\n"
 
-#: client/helpdata.c:3976
+#: client/helpdata.c:4006
 #, c-format
 msgid ""
 "* Each of your cities will avoid %d unhappiness, including that caused by "
@@ -10830,23 +10898,23 @@ msgstr[1] ""
 
 #. TRANS: %s is the output type, like 'shield'
 #. * or 'gold'.
-#: client/helpdata.c:3991
+#: client/helpdata.c:4021
 #, c-format
 msgid "* You pay no %s upkeep for your units.\n"
 msgstr "· Yksikköjesi ylläpito ei maksa yhtään %s.\n"
 
-#: client/helpdata.c:3995
+#: client/helpdata.c:4025
 msgid "* You pay no upkeep for your units.\n"
 msgstr "· Yksikköjesi ylläpito ei maksa mitään.\n"
 
 #. TRANS: %s is the output type, like 'shield'
 #. * or 'gold'.
-#: client/helpdata.c:4003
+#: client/helpdata.c:4033
 #, c-format
 msgid "* You pay %.2g times normal %s upkeep for your units.\n"
 msgstr "· Maksat %.2g-kertaisesti %s yksikköjesi ylläpidosta.\n"
 
-#: client/helpdata.c:4008
+#: client/helpdata.c:4038
 #, c-format
 msgid "* You pay %.2g times normal upkeep for your units.\n"
 msgstr "· Maksat %.2g-kertaisesti yksikköjesi ylläpidosta.\n"
@@ -10855,7 +10923,7 @@ msgstr "· Maksat %.2g-kertaisesti yksikköjesi ylläpidosta.\n"
 #. * 'gold'; pluralised in %d but there is currently
 #. * no way to control the singular/plural name of the
 #. * output type; sorry
-#: client/helpdata.c:4023
+#: client/helpdata.c:4053
 #, c-format
 msgid "* Each of your cities will avoid paying %d %s upkeep for your units.\n"
 msgid_plural ""
@@ -10869,7 +10937,7 @@ msgstr[1] ""
 
 #. TRANS: Amount is subtracted from upkeep cost
 #. * for each upkeep type.
-#: client/helpdata.c:4032
+#: client/helpdata.c:4062
 #, c-format
 msgid "* Each of your cities will avoid paying %d upkeep for your units.\n"
 msgid_plural ""
@@ -10881,14 +10949,14 @@ msgstr[1] ""
 "· Kukin kaupungeistasi välttyy maksamasta %d yksikköä joukkojesi "
 "ylläpitokuluja.\n"
 
-#: client/helpdata.c:4043
+#: client/helpdata.c:4073
 #, c-format
 msgid "* If you lose your capital, the base chance of civil war is %d%%.\n"
 msgstr ""
 "· Jos menetät pääkaupunkisi, sisällissodan lähtökohtainen todennäköisyys on "
 "%d%%.\n"
 
-#: client/helpdata.c:4051
+#: client/helpdata.c:4081
 #, c-format
 msgid ""
 "* You can have %d city before an additional unhappy citizen appears in each "
@@ -10903,7 +10971,7 @@ msgstr[1] ""
 "· Ensimmäinen kansakunnan koon takia tyytymätön asukas ilmestyy jokaiseen "
 "kaupunkiin kun sinulla on %d kaupunkia.\n"
 
-#: client/helpdata.c:4063
+#: client/helpdata.c:4093
 #, c-format
 msgid ""
 "* After the first unhappy citizen due to civilization size, for each %d "
@@ -10918,17 +10986,17 @@ msgstr[1] ""
 "· Ensimmäisen kansakunnan koon takia tyytymättömän asukkaan jälkeen %d "
 "lisäkaupunkia aiheuttaa aina uuden tyytymättömän asukkaan.\n"
 
-#: client/helpdata.c:4077
+#: client/helpdata.c:4107
 #, c-format
 msgid ""
 "* The maximum rate you can set for science, gold, or luxuries is %d%%.\n"
 msgstr "· Tieteen, veron tai luksuksen maksimiosuus on %d%%.\n"
 
-#: client/helpdata.c:4082
+#: client/helpdata.c:4112
 msgid "* Has unlimited science/gold/luxuries rates.\n"
 msgstr "· Tieteen/veron/luksuksen osuuksia ei ole rajoitettu.\n"
 
-#: client/helpdata.c:4089
+#: client/helpdata.c:4119
 #, c-format
 msgid ""
 "* Your units may impose martial law. Each military unit inside a city will "
@@ -10943,7 +11011,7 @@ msgstr[1] ""
 "· Yksikkösi voivat osallistua sotatilan valvomiseen. Kukin kaupunkiin "
 "sijoitettu sotilasyksikkö pakottaa %d tyytymätöntä asukkasta tyytyväiseksi.\n"
 
-#: client/helpdata.c:4102
+#: client/helpdata.c:4132
 #, c-format
 msgid "* A maximum of %d unit in each city can enforce martial law.\n"
 msgid_plural "* A maximum of %d units in each city can enforce martial law.\n"
@@ -10954,18 +11022,18 @@ msgstr[1] ""
 "· Korkeintaan %d yksikköä voi osallistua sotatilan valvomiseen kussakin "
 "kaupungissa.\n"
 
-#: client/helpdata.c:4113
+#: client/helpdata.c:4143
 msgid "* You may grow your cities by means of celebrations."
 msgstr "· Juhliminen kasvattaa kaupunkejasi."
 
 #. TRANS: Preserve leading space. %d should always be
 #. * 2 or greater.
-#: client/helpdata.c:4119
+#: client/helpdata.c:4149
 #, c-format
 msgid " (Cities below size %d cannot grow in this way.)"
 msgstr " (Kokoa %d pienemmät kaupungit eivät voi kasvaa juhlimalla.)"
 
-#: client/helpdata.c:4128
+#: client/helpdata.c:4158
 #, c-format
 msgid ""
 "* If a city is in disorder for more than %d turn in a row, government will "
@@ -10980,15 +11048,15 @@ msgstr[1] ""
 "· Hallintosi vajoaa anarkiaan jos yksikin kaupunki on rauhaton pidempään "
 "kuin %d vuoroa peräkkäin.\n"
 
-#: client/helpdata.c:4139
+#: client/helpdata.c:4169
 msgid "* Has a senate that may prevent declaration of war.\n"
 msgstr "· Valtiomuotoon kuuluva edustajisto voi estää sodanjulistuksen.\n"
 
-#: client/helpdata.c:4145
+#: client/helpdata.c:4175
 msgid "* Allows partisans when cities are taken by the enemy.\n"
 msgstr "· Mahdollistaa sissisodan kun vihollinen valtaa kaupungin.\n"
 
-#: client/helpdata.c:4152
+#: client/helpdata.c:4182
 msgid ""
 "* Buildings that normally confer bonuses against unhappiness will instead "
 "give gold.\n"
@@ -10997,42 +11065,42 @@ msgstr ""
 "sijaan kultaa.\n"
 
 #. TRANS: %s is list of unit types separated by 'or'
-#: client/helpdata.c:4168
+#: client/helpdata.c:4198
 #, c-format
 msgid "* Pays no upkeep for %s.\n"
 msgstr "· %s eivät aiheuta ylläpitokustannuksia.\n"
 
-#: client/helpdata.c:4176
+#: client/helpdata.c:4206
 msgid "* Has no unhappy citizens.\n"
 msgstr "· Tyytymättömiä asukkaita ei ole.\n"
 
 #. TRANS: %s is a unit class
-#: client/helpdata.c:4201
+#: client/helpdata.c:4231
 #, c-format
 msgid "?unitclass:* New %s units will be veteran.\n"
 msgstr "· Uudet %s-yksiköt aloittavat konkareina.\n"
 
 #. TRANS: %s is a (translatable) unit type flag
-#: client/helpdata.c:4207
+#: client/helpdata.c:4237
 #, c-format
 msgid "?unitflag:* New %s units will be veteran.\n"
 msgstr "· Uudet %s-yksiköt aloittavat konkareina.\n"
 
 #. TRANS: "* New Partisan units will have the rank
 #. * of elite."
-#: client/helpdata.c:4219
+#: client/helpdata.c:4249
 #, c-format
 msgid "?unittype:* New %s units will have the rank of %s.\n"
 msgstr "· Uudet %s-yksiköt aloittavat kokemustasolla %s.\n"
 
-#: client/helpdata.c:4228
+#: client/helpdata.c:4258
 msgid "* New units will be veteran.\n"
 msgstr "· Uudet yksiköt aloittavat konkareina.\n"
 
 #. TRANS: %s is list of output types, with 'or';
 #. * pluralised in %d but of course the output types
 #. * can't be pluralised; sorry
-#: client/helpdata.c:4238
+#: client/helpdata.c:4268
 #, c-format
 msgid ""
 "* Each worked tile that gives more than %d %s will suffer a -1 penalty, "
@@ -11049,13 +11117,13 @@ msgstr[1] ""
 
 #. TRANS: Preserve leading space. %d should always be
 #. * 2 or greater.
-#: client/helpdata.c:4249 client/helpdata.c:4269
+#: client/helpdata.c:4279 client/helpdata.c:4299
 #, c-format
 msgid " (Cities below size %d will not celebrate.)"
 msgstr " (Kokoa %d pienemmät kaupungit eivät juhli.)"
 
 #. TRANS: %s is list of output types, with 'or'
-#: client/helpdata.c:4258
+#: client/helpdata.c:4288
 #, c-format
 msgid ""
 "* Each worked tile with at least 1 %s will yield %d more of it while the "
@@ -11071,7 +11139,7 @@ msgstr[1] ""
 "lisää kaupungin juhliessa."
 
 #. TRANS: %s is list of output types, with 'or'
-#: client/helpdata.c:4277
+#: client/helpdata.c:4307
 #, c-format
 msgid "* Each worked tile with at least 1 %s will yield %d more of it.\n"
 msgid_plural ""
@@ -11084,103 +11152,103 @@ msgstr[1] ""
 "pistettä lisää.\n"
 
 #. TRANS: %s is list of output types, with 'and'
-#: client/helpdata.c:4288
+#: client/helpdata.c:4318
 #, c-format
 msgid "* %s production is increased %d%%.\n"
 msgstr "· %spisteiden tuotto lisääntyy %d%%.\n"
 
 #. TRANS: %s is list of output types, with 'and'
-#: client/helpdata.c:4296
+#: client/helpdata.c:4326
 #, c-format
 msgid "* %s production will suffer massive losses.\n"
 msgstr "· %spisteiden tuotto menee enimmäkseen hukkaan.\n"
 
 #. TRANS: %s is list of output types, with 'and'
-#: client/helpdata.c:4301
+#: client/helpdata.c:4331
 #, c-format
 msgid "* %s production will suffer some losses.\n"
 msgstr "· %spisteiden tuotto menee osittain hukkaan.\n"
 
 #. TRANS: %s is list of output types, with 'and'
-#: client/helpdata.c:4306
+#: client/helpdata.c:4336
 #, c-format
 msgid "* %s production will suffer a small amount of losses.\n"
 msgstr "· %spisteiden tuotto menee vähäisessä määrin hukkaan.\n"
 
-#: client/helpdata.c:4315
+#: client/helpdata.c:4345
 msgid "* Increases the chance of plague within your cities.\n"
 msgstr "· Lisää ruton vaaraa kaupungeissasi.\n"
 
-#: client/helpdata.c:4318
+#: client/helpdata.c:4348
 msgid "* Decreases the chance of plague within your cities.\n"
 msgstr "· Vähentää ruton vaaraa kaupungeissasi.\n"
 
 # gna bug #17706
 #. TRANS: %s is list of output types, with 'and'
-#: client/helpdata.c:4334
+#: client/helpdata.c:4364
 #, c-format
 msgid "* %s losses will increase quickly with distance from capital.\n"
 msgstr ""
 "· Etäisyyden pääkaupungista kasvaessa %spisteiden hukka kasvaa nopeasti.\n"
 
 #. TRANS: %s is list of output types, with 'and'
-#: client/helpdata.c:4340
+#: client/helpdata.c:4370
 #, c-format
 msgid "* %s losses will increase with distance from capital.\n"
 msgstr "· Etäisyyden pääkaupungista kasvaessa %spisteiden hukka kasvaa.\n"
 
 #. TRANS: %s is list of output types, with 'and'
-#: client/helpdata.c:4346
+#: client/helpdata.c:4376
 #, c-format
 msgid "* %s losses will increase slowly with distance from capital.\n"
 msgstr ""
 "· Etäisyyden pääkaupungista kasvaessa %spisteiden hukka kasvaa hitaasti.\n"
 
-#: client/helpdata.c:4355
+#: client/helpdata.c:4385
 msgid "* Increases the chance of migration into your cities.\n"
 msgstr ""
 "· Lisää todennäköisyyttä ihmisten muuttaa kaupunkeihisi toisista "
 "kaupungeista.\n"
 
-#: client/helpdata.c:4358
+#: client/helpdata.c:4388
 msgid "* Decreases the chance of migration into your cities.\n"
 msgstr ""
 "· Vähentää todennäköisyyttä ihmisten muuttaa kaupunkeihisi toisista "
 "kaupungeista.\n"
 
-#: client/helpdata.c:4366
+#: client/helpdata.c:4396
 msgid "* All tiles inside your borders are monitored.\n"
 msgstr "· Kaikkia omien rajojen sisällä olevia ruutuja tarkkaillaan.\n"
 
-#: client/helpdata.c:4384
+#: client/helpdata.c:4414
 #, c-format
 msgid "* Allows you to build %s.\n"
 msgstr "· Mahdollistaa %s-yksikköjen rakentamisen.\n"
 
-#: client/helpdata.c:4398
+#: client/helpdata.c:4428
 #, c-format
 msgid "* Makes it impossible to do the action '%s' to your %s.\n"
 msgstr "· Tekee mahdottomaksi yksikkösi %2$s tehdä toimintoa %1$s.\n"
 
 #. TRANS: "2 Food" or ", 1 Shield"
-#: client/helpdata.c:4428
+#: client/helpdata.c:4458
 #, c-format
 msgid "%s%d %s"
 msgstr "%s%d %s"
 
 #. TRANS: "2 Unhappy" or ", 1 Unhappy"
-#: client/helpdata.c:4436
+#: client/helpdata.c:4466
 #, c-format
 msgid "%s%d Unhappy"
 msgstr "%s%d tyytymätöntä"
 
-#: client/helpdata.c:4480
+#: client/helpdata.c:4510
 #, c-format
 msgid "Initial government is %s.\n"
 msgstr "Aloitusvaltiomuotona on %s.\n"
 
 #. TRANS: %s is an and-separated list of techs
-#: client/helpdata.c:4500
+#: client/helpdata.c:4530
 #, c-format
 msgid ""
 "Starts with knowledge of %s in addition to the standard starting "
@@ -11190,7 +11258,7 @@ msgstr ""
 "lisäksi.\n"
 
 #. TRANS: %s is an and-separated list of techs
-#: client/helpdata.c:4505
+#: client/helpdata.c:4535
 #, c-format
 msgid "Starts with knowledge of %s.\n"
 msgstr "Aloittaa osaten valmiiksi teknologian %s.\n"
@@ -11198,7 +11266,7 @@ msgstr "Aloittaa osaten valmiiksi teknologian %s.\n"
 #. TRANS: a unit type followed by a count. For instance,
 #. * "Fighter (2)" means two Fighters. Count is never 1.
 #. * Used in a list.
-#: client/helpdata.c:4544
+#: client/helpdata.c:4574
 #, c-format
 msgid "%s (%d)"
 msgstr "%s (%d)"
@@ -11206,7 +11274,7 @@ msgstr "%s (%d)"
 #. TRANS: %s is an and-separated list of unit types
 #. * possibly with counts. Plurality is in total number of
 #. * units represented.
-#: client/helpdata.c:4566
+#: client/helpdata.c:4596
 #, c-format
 msgid "Starts with the following additional unit: %s.\n"
 msgid_plural "Starts with the following additional units: %s.\n"
@@ -11214,7 +11282,7 @@ msgstr[0] "Aloittaa seuraavalla ylimääräisellä yksiköllä: %s.\n"
 msgstr[1] "Aloittaa seuraavilla ylimääräisillä yksiköillä: %s.\n"
 
 #. TRANS: %s is an and-separated list of improvements
-#: client/helpdata.c:4590
+#: client/helpdata.c:4620
 #, c-format
 msgid ""
 "First city will get %s for free in addition to the standard improvements.\n"
@@ -11223,7 +11291,7 @@ msgstr ""
 "%s.\n"
 
 #. TRANS: %s is an and-separated list of improvements
-#: client/helpdata.c:4595
+#: client/helpdata.c:4625
 #, c-format
 msgid "First city will get %s for free.\n"
 msgstr "Ensimmäinen kaupunki saa ilmaiseksi hankkeen %s.\n"
@@ -12981,11 +13049,11 @@ msgstr ""
 msgid "They won't be saved when scenario is saved from the editor."
 msgstr "Niitä ei talleta mikäli skenaario talletetaan editorista."
 
-#: client/packhand.c:2347
+#: client/packhand.c:2352
 msgid "AI mode is now ON."
 msgstr "AI-tila on nyt PÄÄLLÄ."
 
-#: client/packhand.c:2353
+#: client/packhand.c:2358
 msgid "AI mode is now OFF."
 msgstr "AI-tila on nyt POIS PÄÄLTÄ."
 
@@ -13291,7 +13359,7 @@ msgstr "koti %s | %s kansalaista"
 
 #. TRANS: Nationality of the people comprising a unit, if
 #. * different from owner.
-#: client/text.c:358 client/text.c:536 client/text.c:1140
+#: client/text.c:358 client/text.c:536 client/text.c:1142
 #, c-format
 msgid "%s people"
 msgstr "%s kansalaista"
@@ -13401,7 +13469,7 @@ msgid "Progress: none"
 msgstr "Tutkimuksen nopeus: ei tutkimusta"
 
 #. TRANS: <perturn> bulbs/turn
-#: client/text.c:793 client/text.c:1380
+#: client/text.c:793 client/text.c:1382
 #, c-format
 msgid "%d bulb/turn"
 msgid_plural "%d bulbs/turn"
@@ -13503,7 +13571,7 @@ msgstr "(Napsauttamalla lisätietoa)"
 msgid "%s People"
 msgstr "%s kansalaista"
 
-#: client/text.c:979 server/gamehand.c:862
+#: client/text.c:979 server/gamehand.c:863
 #, c-format
 msgid "Year: %s"
 msgstr "Vuosi: %s"
@@ -13544,30 +13612,36 @@ msgstr "Lamppuja vuoroa kohden: %d – %d = %d"
 msgid "Bulbs per turn: %d"
 msgstr "Lamppuja vuoroa kohden: %d"
 
-#: client/text.c:1015
+#: client/text.c:1009
+#, fuzzy, c-format
+#| msgid "%4d : Total culture"
+msgid "Total culture: %d"
+msgstr "%4d : Kulttuuria yhteensä"
+
+#: client/text.c:1017
 #, c-format
 msgid "Global warming chance: %d%% (%+d%%/turn)"
 msgstr "Ilmaston lämpenemisen todennäköisyys: %d%% (%+d%%/vuoro)"
 
-#: client/text.c:1018 client/text.c:1408
+#: client/text.c:1020 client/text.c:1410
 msgid "Global warming deactivated."
 msgstr "Ilmastonmuutos ei ole käytössä."
 
-#: client/text.c:1024
+#: client/text.c:1026
 #, c-format
 msgid "Nuclear winter chance: %d%% (%+d%%/turn)"
 msgstr "Ydintalven mahdollisuus: %d%% (%+d%%/vuoro)"
 
-#: client/text.c:1027 client/text.c:1432
+#: client/text.c:1029 client/text.c:1434
 msgid "Nuclear winter deactivated."
 msgstr "Ydintalvi ei ole käytössä."
 
-#: client/text.c:1031
+#: client/text.c:1033
 #, c-format
 msgid "Government: %s"
 msgstr "Valtiomuoto: %s"
 
-#: client/text.c:1055
+#: client/text.c:1057
 #, c-format
 msgid "%d unit"
 msgid_plural "%d units"
@@ -13575,54 +13649,54 @@ msgstr[0] "%d yksikkö"
 msgstr[1] "%d yksikköä"
 
 #. TRANS: Impossible to reach goto target tile
-#: client/text.c:1091
+#: client/text.c:1093
 msgid "?goto:Unreachable"
 msgstr "Saavuttamaton"
 
-#: client/text.c:1093
+#: client/text.c:1095
 #, c-format
 msgid "Turns to target: %d"
 msgstr "Vuoroja kohteeseen: %d"
 
-#: client/text.c:1095
+#: client/text.c:1097
 #, c-format
 msgid "Turns to target: %d to %d"
 msgstr "Vuoroja kohteeseen: %d – %d"
 
-#: client/text.c:1101
+#: client/text.c:1103
 #, c-format
 msgid "%d unit selected"
 msgid_plural "%d units selected"
 msgstr[0] "%d yksikkö valittu"
 msgstr[1] "%d yksikköä valittu"
 
-#: client/text.c:1202
+#: client/text.c:1204
 #, c-format
 msgid "Others: %d civil; %d military"
 msgstr "Muut: %d siviiliä; %d sotayksikköä"
 
-#: client/text.c:1204
+#: client/text.c:1206
 #, c-format
 msgid "Others: %d civilian"
 msgstr "Muut: %d siviiliä"
 
-#: client/text.c:1206
+#: client/text.c:1208
 #, c-format
 msgid "Others: %d military"
 msgstr "Muut: %d sotayksikköä"
 
-#: client/text.c:1245
+#: client/text.c:1247
 msgid "No units to upgrade!"
 msgstr "Yhtään ajanmukaistettavaa yksikköä ei ole."
 
-#: client/text.c:1269
+#: client/text.c:1271
 msgid "None of these units may be upgraded."
 msgstr "Yhtään yksikköä ei voitu ajanmukaistaa."
 
 #. TRANS: this whole string is a sentence fragment that is only ever
 #. * used by including it in another string (search comments for this
 #. * string to find it)
-#: client/text.c:1285
+#: client/text.c:1287
 #, c-format
 msgid "Upgrade %d unit"
 msgid_plural "Upgrade %d units"
@@ -13633,7 +13707,7 @@ msgstr[1] "Ajanmukaista %d yksikköä"
 #. * sentence fragment "Upgrade %d unit(s)"; the second is pre-pluralised
 #. * "Treasury contains %d gold." So the whole thing reads
 #. * "Upgrade 13 units for 1000 gold?\nTreasury contains 2000 gold."
-#: client/text.c:1293
+#: client/text.c:1295
 #, c-format
 msgid ""
 "%s for %d gold?\n"
@@ -13648,116 +13722,116 @@ msgstr[1] ""
 "%s hinnalla %d kultaa?\n"
 "%s"
 
-#: client/text.c:1310
+#: client/text.c:1312
 msgid "No units to disband!"
 msgstr "Lakkautettavia yksikköjä ei ole!"
 
-#: client/text.c:1315
+#: client/text.c:1317
 #, c-format
 msgid "%s refuses to disband!"
 msgstr "%s vastustaa lakkauttamistaan!"
 
 #. TRANS: %s is a unit type
-#: client/text.c:1320
+#: client/text.c:1322
 #, c-format
 msgid "Disband %s?"
 msgstr "Lakkauta %s?"
 
-#: client/text.c:1332
+#: client/text.c:1334
 msgid "None of these units may be disbanded."
 msgstr "Yhtään näistä yksiköistä ei voi lakkauttaa."
 
 #. TRANS: %d is never 0 or 1
-#: client/text.c:1336
+#: client/text.c:1338
 #, c-format
 msgid "Disband %d unit?"
 msgid_plural "Disband %d units?"
 msgstr[0] "Lakkauta %d yksikkö?"
 msgstr[1] "Lakkauta %d yksikköä?"
 
-#: client/text.c:1353
+#: client/text.c:1355
 msgid "Shows your progress in researching the current technology."
 msgstr "Näyttää edistyksesi uusimman tutkimuskohteen kanssa."
 
-#: client/text.c:1360
+#: client/text.c:1362
 #, fuzzy
 #| msgid "no research target."
 msgid "No research target."
 msgstr "ei tutkimuskohdetta."
 
-#: client/text.c:1369
+#: client/text.c:1371
 #, c-format
 msgid "%d turn to loss"
 msgid_plural "%d turns to loss"
 msgstr[0] "%d vuoro menetykseen"
 msgstr[1] "%d vuoroa menetykseen"
 
-#: client/text.c:1373
+#: client/text.c:1375
 msgid "Decreasing"
 msgstr "Laskee"
 
-#: client/text.c:1375
+#: client/text.c:1377
 msgid "No progress"
 msgstr "Ei edistystä"
 
 #. TRANS: <tech>: <amount>/<total bulbs>
-#: client/text.c:1383
+#: client/text.c:1385
 #, c-format
 msgid "%s: %d/%d (%s, %s)."
 msgstr "%s: %d/%d (%s, %s)."
 
-#: client/text.c:1412
+#: client/text.c:1414
 msgid "Shows the progress of global warming:"
 msgstr "Näyttää maailmanlaajuisen lämpenemisen etenemisen:"
 
-#: client/text.c:1413
+#: client/text.c:1415
 #, c-format
 msgid "Pollution rate: %d%%"
 msgstr "Saastumisaste: %d%%"
 
-#: client/text.c:1414
+#: client/text.c:1416
 #, c-format
 msgid "Chance of catastrophic warming each turn: %d%%"
 msgstr "Katastrofaalisen lämpenemisen todennäköisyys joka vuoro: %d%%"
 
-#: client/text.c:1436
+#: client/text.c:1438
 msgid "Shows the progress of nuclear winter:"
 msgstr "Näyttää ydintalven etenemisen:"
 
-#: client/text.c:1437
+#: client/text.c:1439
 #, c-format
 msgid "Fallout rate: %d%%"
 msgstr "Laskeuman määrä: %d%%"
 
-#: client/text.c:1438
+#: client/text.c:1440
 #, c-format
 msgid "Chance of catastrophic winter each turn: %d%%"
 msgstr "Katastrofitalven mahdollisuus vuorossa: %d%%"
 
-#: client/text.c:1455
+#: client/text.c:1457
 msgid "Shows your current government:"
 msgstr "Näyttää nykyisen valtiomuotosi:"
 
 #. TRANS: spaceship text; should have constant width.
-#: client/text.c:1481
+#: client/text.c:1483
 #, c-format
 msgid "Population:      %5d"
 msgstr "Väkiluku:        %5d"
 
 #. TRANS: spaceship text; should have constant width.
-#: client/text.c:1484
+#: client/text.c:1486
 #, c-format
 msgid "Support:         %5d %%"
 msgstr "Ylläpito:        %5d %%"
 
 #. TRANS: spaceship text; should have constant width.
-#: client/text.c:1488
+#: client/text.c:1490
 #, c-format
 msgid "Energy:          %5d %%"
 msgstr "Energia:         %5d %%"
 
 #. TRANS: spaceship text; should have constant width.
-#: client/text.c:1492
+#: client/text.c:1494
 #, c-format
 msgid "Mass:            %5d ton"
 msgid_plural "Mass:            %5d tons"
@@ -13765,127 +13839,127 @@ msgstr[0] "Massa:            %5d t"
 msgstr[1] "Massa:            %5d t"
 
 #. TRANS: spaceship text; should have constant width.
-#: client/text.c:1498
+#: client/text.c:1500
 #, c-format
 msgid "Travel time:     %5.1f years"
 msgstr "Matka-aika:     %5.1f vuotta"
 
 #. TRANS: spaceship text; should have constant width.
-#: client/text.c:1502
+#: client/text.c:1504
 msgid "Travel time:        N/A     "
 msgstr "Matka-aika:     ei tiedossa"
 
 #. TRANS: spaceship text; should have constant width.
-#: client/text.c:1506
+#: client/text.c:1508
 #, c-format
 msgid "Success prob.:   %5d %%"
 msgstr "Onnistumis-tn.:  %5d %%"
 
 #. TRANS: spaceship text; should have constant width.
-#: client/text.c:1510
+#: client/text.c:1512
 #, c-format
 msgid "Year of arrival: %8s"
 msgstr "Saapumisvuosi:   %8s"
 
-#: client/text.c:1533
+#: client/text.c:1535
 msgid "?timeout:wait"
 msgstr "odota"
 
-#: client/text.c:1535
+#: client/text.c:1537
 msgid "?timeout:eta"
 msgstr "arvio"
 
-#: client/text.c:1539
+#: client/text.c:1541
 msgid "?timeout:off"
 msgstr "∞"
 
-#: client/text.c:1564
+#: client/text.c:1566
 #, c-format
 msgid "?seconds:%02ds"
 msgstr "%02ds"
 
-#: client/text.c:1566
+#: client/text.c:1568
 #, c-format
 msgid "?mins/secs:%02dm %02ds"
 msgstr "%02dmin %02ds"
 
-#: client/text.c:1568
+#: client/text.c:1570
 #, c-format
 msgid "?hrs/mns:%02dh %02dm"
 msgstr "%02dh %02dmin"
 
-#: client/text.c:1570
+#: client/text.c:1572
 #, c-format
 msgid "?dys/hrs:%02dd %02dh"
 msgstr "%02dpv %02dh"
 
-#: client/text.c:1573
+#: client/text.c:1575
 msgid "?duration:overflow"
 msgstr "ylivuoto"
 
-#: client/text.c:1596
+#: client/text.c:1598
 #, c-format
 msgid "%6d.%02d ms"
 msgstr "%6d.%02d ms"
 
 #. TRANS: <nation adjective> <government name>.
 #. * E.g. "Polish Republic".
-#: client/text.c:1646
+#: client/text.c:1648
 #, c-format
 msgid "?nationgovernment:%s %s"
 msgstr "%s %s"
 
 #. TRANS: Just appending 2 strings, using the correct localized
 #. * syntax.
-#: client/text.c:1652
+#: client/text.c:1654
 #, c-format
 msgid "%s - %s"
 msgstr "%s – %s"
 
 #. TRANS: "Observer - 1985 AD"
-#: client/text.c:1657
+#: client/text.c:1659
 #, c-format
 msgid "Observer - %s"
 msgstr "Tarkkailija – %s"
 
-#: client/text.c:1676
+#: client/text.c:1678
 #, c-format
 msgid "Buildings: %s."
 msgstr "Rakennukset: %s."
 
-#: client/text.c:1679
+#: client/text.c:1681
 msgid "Buildings: None."
 msgstr "Rakennukset: Ei mitään."
 
-#: client/text.c:1699
+#: client/text.c:1701
 msgid "Nationality: "
 msgstr "Kansallisuus: "
 
-#: client/text.c:1712
+#: client/text.c:1714
 #, c-format
 msgid "%d enemy nationalist"
 msgid_plural "%d enemy nationalists"
 msgstr[0] "%d vihollisen kansalainen"
 msgstr[1] "%d vihollisen kansalaista"
 
-#: client/text.c:1718
+#: client/text.c:1720
 msgid "None."
 msgstr "Ei yhtään."
 
-#: client/text.c:1721
+#: client/text.c:1723
 msgid "Disabled."
 msgstr "Ei käytössä."
 
-#: client/text.c:1742
+#: client/text.c:1744
 #, c-format
 msgid "Wonders: %s."
 msgstr "Ihmeet: %s."
 
-#: client/text.c:1745
+#: client/text.c:1747
 msgid "Wonders: None."
 msgstr "Ihmeet: Ei yhtään."
 
-#: client/text.c:1773
+#: client/text.c:1775
 #, c-format
 msgid "Cities: %d total, but no penalty for empire size."
 msgid_plural "Cities: %d total, but no penalty for empire size."
@@ -13893,7 +13967,7 @@ msgstr[0] "Kaupungit: %d kaikkiaan, ei haittaa valtakunnan koosta."
 msgstr[1] "Kaupungit: %d kaikkiaan, ei haittaa valtakunnan koosta."
 
 #. TRANS: %d is number of citizens
-#: client/text.c:1779 client/text.c:1853
+#: client/text.c:1781 client/text.c:1855
 #, c-format
 msgid "%d content per city."
 msgid_plural "%d content per city."
@@ -13901,7 +13975,7 @@ msgstr[0] "%d rauhallinen joka kaupungissa."
 msgstr[1] "%d rauhallista joka kaupungissa."
 
 #. TRANS: sentence fragment, will have text appended
-#: client/text.c:1819
+#: client/text.c:1821
 #, c-format
 msgid "Cities: %d total:"
 msgid_plural "Cities: %d total:"
@@ -13910,7 +13984,7 @@ msgstr[1] "Kaupunkeja: %d"
 
 #. TRANS: appended to "Cities: %d total:"; preserve leading
 #. * space. Pluralized in "nearest threshold of %d cities".
-#: client/text.c:1826
+#: client/text.c:1828
 #, c-format
 msgid " %d over nearest threshold of %d city."
 msgid_plural " %d over nearest threshold of %d cities."
@@ -13918,21 +13992,21 @@ msgstr[0] " %d yli %d kaupunkimäärän kynnyksen."
 msgstr[1] " %d yli %d kaupunkimäärän kynnyksen."
 
 #. TRANS: Number of content [citizen(s)] ...
-#: client/text.c:1831
+#: client/text.c:1833
 #, c-format
 msgid "%d content before penalty."
 msgid_plural "%d content before penalty."
 msgstr[0] "%d rauhallinen ennen vähennyksiä."
 msgstr[1] "%d rauhallista ennen vähennyksiä."
 
-#: client/text.c:1835
+#: client/text.c:1837
 #, c-format
 msgid "%d additional unhappy citizen."
 msgid_plural "%d additional unhappy citizens."
 msgstr[0] "%d tyytymätön lisää."
 msgstr[1] "%d tyytymätöntä lisää."
 
-#: client/text.c:1840
+#: client/text.c:1842
 #, c-format
 msgid "%d angry citizen."
 msgid_plural "%d angry citizens."
@@ -13941,14 +14015,14 @@ msgstr[1] "%d vihaista asukasta."
 
 #. TRANS: appended to "Cities: %d total:"; preserve leading
 #. * space.
-#: client/text.c:1848
+#: client/text.c:1850
 #, c-format
 msgid " not more than %d, so no empire size penalty."
 msgid_plural " not more than %d, so no empire size penalty."
 msgstr[0] " ei enempää kuin %d, joten valtakunnan koko ei aiheuta ongelmia."
 msgstr[1] " ei enempää kuin %d, joten valtakunnan koko ei aiheuta ongelmia."
 
-#: client/text.c:1859
+#: client/text.c:1861
 #, c-format
 msgid "With %d more city, another citizen will become unhappy."
 msgid_plural "With %d more cities, another citizen will become unhappy."
@@ -13959,7 +14033,7 @@ msgstr[1] ""
 "Kun valtakuntasi kasvaa %d kaupungilla, tyytymättömyys lisääntyy taas "
 "yhdellä asukkaalla."
 
-#: client/text.c:1870
+#: client/text.c:1872
 #, c-format
 msgid "With %d more city, another citizen will become angry."
 msgid_plural "With %d more cities, another citizen will become angry."
@@ -13968,22 +14042,22 @@ msgstr[0] ""
 msgstr[1] ""
 "Kun valtakuntasi kasvaa %d kaupungilla, yksi asukas enemmän tulee vihaiseksi."
 
-#: client/text.c:1880
+#: client/text.c:1882
 msgid "More cities will not cause more unhappy citizens."
 msgstr "Kaupunkimäärän kasvu ei lisää tyytymättömien asukkaiden määrää."
 
-#: client/text.c:1901
+#: client/text.c:1903
 msgid "Unlimited martial law in effect."
 msgstr "Rajoittamaton sotatila on voimassa."
 
-#: client/text.c:1903
+#: client/text.c:1905
 #, c-format
 msgid "%d military unit may impose martial law."
 msgid_plural "Up to %d military units may impose martial law."
 msgstr[0] "%d sotilasyksikkö voi pitää kuria."
 msgstr[1] "Korkeintaan %d sotilasyksikköä voi pitää kuria."
 
-#: client/text.c:1907
+#: client/text.c:1909
 #, c-format
 msgid "Each military unit makes %d unhappy citizen content."
 msgid_plural "Each military unit makes %d unhappy citizens content."
@@ -13992,15 +14066,15 @@ msgstr[0] ""
 msgstr[1] ""
 "Jokainen sotilasyksikkö tekee %d tyytymättömästä asukkaasta rauhallisia."
 
-#: client/text.c:1914
+#: client/text.c:1916
 msgid "Military units in the field may cause unhappiness. "
 msgstr "Sotilasyksiköt poissa kotoa voivat aiheuttaa tyytymättömyyttä. "
 
-#: client/text.c:1917
+#: client/text.c:1919
 msgid "Military units have no happiness effect. "
 msgstr "Sotilasyksiköillä ei ole vaikutusta onnellisuuteen. "
 
-#: client/text.c:1932
+#: client/text.c:1934
 #, c-format
 msgid "Luxury: %d total."
 msgstr "Luksus: %d kaikkiaan."
@@ -14183,7 +14257,7 @@ msgstr ""
 "Kuvitus \"%s\" ei tue %d ruudun pituisia reittinuolia. Reittinuolia ei "
 "välttämättä voida näyttää tavalliseen tapaan."
 
-#: client/tilespec.c:5911
+#: client/tilespec.c:5912
 #, c-format
 msgid ""
 "Tileset \"%s\" doesn't support big cities size, such as %d. Size not "
@@ -14192,12 +14266,12 @@ msgstr ""
 "Kuvitus \"%s\" ei tue %d kokoisia kaupunkeja. Kaupungin kokoa ei voida "
 "näyttää tavalliseen tapaan."
 
-#: client/tilespec.c:6053
+#: client/tilespec.c:6054
 #, c-format
 msgid "City style \"%s\": no city graphics."
 msgstr "Kaupunkityylille \"%s\" ei löydy grafiikoita."
 
-#: client/tilespec.c:6057
+#: client/tilespec.c:6058
 #, c-format
 msgid "City style \"%s\": no occupied graphics."
 msgstr ""
@@ -14287,134 +14361,134 @@ msgstr ""
 "olevilla tiedoilla.)"
 
 #. TRANS: _Poison City (3% chance of success).
-#: common/actions.c:4997 data/civ2/game.ruleset:273
-#: data/classic/game.ruleset:280 data/sandbox/game.ruleset:283
-#: data/civ2civ3/game.ruleset:285 data/multiplayer/game.ruleset:283
+#: common/actions.c:5001 data/civ2/game.ruleset:283
+#: data/classic/game.ruleset:290 data/sandbox/game.ruleset:293
+#: data/civ2civ3/game.ruleset:295 data/multiplayer/game.ruleset:293
 #, c-format
 msgid "%sPoison City%s"
 msgstr "%sMyrkytä kaupunki%s"
 
 #. TRANS: _Poison City and Escape (3% chance of success).
-#: common/actions.c:5000
+#: common/actions.c:5004
 #, fuzzy, c-format
 #| msgid "%sPoison City%s"
 msgid "%sPoison City and Escape%s"
 msgstr "%sMyrkytä kaupunki%s"
 
 #. TRANS: S_abotage Enemy Unit (3% chance of success).
-#: common/actions.c:5003
+#: common/actions.c:5007
 #, c-format
 msgid "S%sabotage Enemy Unit%s"
 msgstr "%sSabotoi vihollisen yksikkö%s"
 
 #. TRANS: S_abotage Enemy Unit and Escape (3% chance of success).
-#: common/actions.c:5006
+#: common/actions.c:5010
 #, fuzzy, c-format
 #| msgid "S%sabotage Enemy Unit%s"
 msgid "S%sabotage Enemy Unit and Escape%s"
 msgstr "%sSabotoi vihollisen yksikkö%s"
 
 #. TRANS: Bribe Enemy _Unit (3% chance of success).
-#: common/actions.c:5009
+#: common/actions.c:5013
 #, c-format
 msgid "Bribe Enemy %sUnit%s"
 msgstr "%sLahjo vihollisen yksikkö%s"
 
 #. TRANS: _Sabotage City (3% chance of success).
-#: common/actions.c:5012 data/civ1/game.ruleset:259 data/civ2/game.ruleset:285
-#: data/classic/game.ruleset:289 data/sandbox/game.ruleset:292
-#: data/civ2civ3/game.ruleset:294 data/alien/game.ruleset:282
-#: data/multiplayer/game.ruleset:292
+#: common/actions.c:5016 data/civ1/game.ruleset:269 data/civ2/game.ruleset:295
+#: data/classic/game.ruleset:299 data/sandbox/game.ruleset:302
+#: data/civ2civ3/game.ruleset:304 data/alien/game.ruleset:292
+#: data/multiplayer/game.ruleset:302
 #, c-format
 msgid "%sSabotage City%s"
 msgstr "%sSabotoi kaupunkia%s"
 
 #. TRANS: _Sabotage City and Escape (3% chance of success).
-#: common/actions.c:5015
+#: common/actions.c:5019
 #, fuzzy, c-format
 #| msgid "%sSabotage City%s"
 msgid "%sSabotage City and Escape%s"
 msgstr "%sSabotoi kaupunkia%s"
 
 #. TRANS: Industria_l Sabotage (3% chance of success).
-#: common/actions.c:5018
+#: common/actions.c:5022
 #, c-format
 msgid "Industria%sl Sabotage%s"
 msgstr "%sSabotoi tuotantoa%s"
 
 #. TRANS: Industria_l Sabotage and Escape (3% chance of success).
-#: common/actions.c:5021
+#: common/actions.c:5025
 #, fuzzy, c-format
 #| msgid "Industria%sl Sabotage%s"
 msgid "Industria%sl Sabotage and Escape%s"
 msgstr "%sSabotoi tuotantoa%s"
 
 #. TRANS: Incite a Re_volt (3% chance of success).
-#: common/actions.c:5024
+#: common/actions.c:5028
 #, c-format
 msgid "Incite a Re%svolt%s"
 msgstr "%sYllytä kapinaan%s"
 
 #. TRANS: Incite a Re_volt and Escape (3% chance of success).
 #. TRANS: Incite a _Revolt and Escape (3% chance of success).
-#: common/actions.c:5027 data/civ2/game.ruleset:297
-#: data/classic/game.ruleset:301 data/sandbox/game.ruleset:304
-#: data/civ2civ3/game.ruleset:306 data/multiplayer/game.ruleset:304
+#: common/actions.c:5031 data/civ2/game.ruleset:307
+#: data/classic/game.ruleset:311 data/sandbox/game.ruleset:314
+#: data/civ2civ3/game.ruleset:316 data/multiplayer/game.ruleset:314
 #, fuzzy, c-format
 #| msgid "Incite a Re%svolt%s"
 msgid "Incite a Re%svolt and Escape%s"
 msgstr "%sYllytä kapinaan%s"
 
 #. TRANS: Establish _Embassy (100% chance of success).
-#: common/actions.c:5030 data/civ2/game.ruleset:300
-#: data/classic/game.ruleset:304 data/sandbox/game.ruleset:307
-#: data/civ2civ3/game.ruleset:309 data/multiplayer/game.ruleset:307
+#: common/actions.c:5034 data/civ2/game.ruleset:310
+#: data/classic/game.ruleset:314 data/sandbox/game.ruleset:317
+#: data/civ2civ3/game.ruleset:319 data/multiplayer/game.ruleset:317
 #, c-format
 msgid "Establish %sEmbassy%s"
 msgstr "%sPerusta lähetystö%s"
 
 #. TRANS: Becom_e Ambassador (100% chance of success).
-#: common/actions.c:5033 data/civ1/game.ruleset:265 data/civ2/game.ruleset:303
-#: data/classic/game.ruleset:307 data/sandbox/game.ruleset:310
-#: data/civ2civ3/game.ruleset:312 data/multiplayer/game.ruleset:310
+#: common/actions.c:5037 data/civ1/game.ruleset:275 data/civ2/game.ruleset:313
+#: data/classic/game.ruleset:317 data/sandbox/game.ruleset:320
+#: data/civ2civ3/game.ruleset:322 data/multiplayer/game.ruleset:320
 #, c-format
 msgid "Becom%se Ambassador%s"
 msgstr "Ryhdy suurläh%settilääksi%s"
 
 #. TRANS: Steal _Technology (3% chance of success).
-#: common/actions.c:5036 data/civ1/game.ruleset:268 data/civ2/game.ruleset:306
-#: data/classic/game.ruleset:310 data/sandbox/game.ruleset:313
-#: data/civ2civ3/game.ruleset:315 data/multiplayer/game.ruleset:313
+#: common/actions.c:5040 data/civ1/game.ruleset:278 data/civ2/game.ruleset:316
+#: data/classic/game.ruleset:320 data/sandbox/game.ruleset:323
+#: data/civ2civ3/game.ruleset:325 data/multiplayer/game.ruleset:323
 #, c-format
 msgid "Steal %sTechnology%s"
 msgstr "%sVarasta teknologia%s"
 
 #. TRANS: Steal _Technology and Escape (3% chance of success).
-#: common/actions.c:5039 data/civ2/game.ruleset:309
-#: data/classic/game.ruleset:313 data/sandbox/game.ruleset:316
-#: data/civ2civ3/game.ruleset:318 data/multiplayer/game.ruleset:316
+#: common/actions.c:5043 data/civ2/game.ruleset:319
+#: data/classic/game.ruleset:323 data/sandbox/game.ruleset:326
+#: data/civ2civ3/game.ruleset:328 data/multiplayer/game.ruleset:326
 #, fuzzy, c-format
 #| msgid "Steal %sGold%s"
 msgid "Steal %sTechnology and Escape%s"
 msgstr "%sVarasta kultaa%s"
 
 #. TRANS: In_dustrial Espionage (3% chance of success).
-#: common/actions.c:5042
+#: common/actions.c:5046
 #, c-format
 msgid "In%sdustrial Espionage%s"
 msgstr "%sTeollisuusvakoilu%s"
 
 #. TRANS: In_dustrial Espionage and Escape (3% chance of success).
-#: common/actions.c:5045
+#: common/actions.c:5049
 #, fuzzy, c-format
 #| msgid "In%sdustrial Espionage%s"
 msgid "In%sdustrial Espionage and Escape%s"
 msgstr "%sTeollisuusvakoilu%s"
 
 #. TRANS: _Investigate City (100% chance of success).
-#: common/actions.c:5048 data/civ2/game.ruleset:315
-#: data/classic/game.ruleset:319 data/sandbox/game.ruleset:325
-#: data/civ2civ3/game.ruleset:324 data/multiplayer/game.ruleset:322
+#: common/actions.c:5052 data/civ2/game.ruleset:325
+#: data/classic/game.ruleset:329 data/sandbox/game.ruleset:335
+#: data/civ2civ3/game.ruleset:334 data/multiplayer/game.ruleset:332
 #, c-format
 msgid "%sInvestigate City%s"
 msgstr "%sTutki kaupunkia%s"
@@ -14422,308 +14496,307 @@ msgstr "%sTutki kaupunkia%s"
 #. TRANS: _Investigate City (spends the unit) (100% chance of
 #. * success).
 #. TRANS: _Investigate City (spends the unit) (100% chance of success).
-#: common/actions.c:5052 data/civ1/game.ruleset:271 data/civ2/game.ruleset:318
-#: data/classic/game.ruleset:322 data/sandbox/game.ruleset:328
-#: data/civ2civ3/game.ruleset:327 data/alien/game.ruleset:291
-#: data/multiplayer/game.ruleset:325
+#: common/actions.c:5056 data/civ1/game.ruleset:281 data/civ2/game.ruleset:328
+#: data/classic/game.ruleset:332 data/sandbox/game.ruleset:338
+#: data/civ2civ3/game.ruleset:337 data/alien/game.ruleset:301
+#: data/multiplayer/game.ruleset:335
 #, fuzzy, c-format
 #| msgid "%sInvestigate City%s"
 msgid "%sInvestigate City (spends the unit)%s"
 msgstr "%sTutki kaupunkia%s"
 
 #. TRANS: Steal _Gold (100% chance of success).
-#: common/actions.c:5055
+#: common/actions.c:5059
 #, c-format
 msgid "Steal %sGold%s"
 msgstr "%sVarasta kultaa%s"
 
 #. TRANS: Steal _Gold and Escape (100% chance of success).
-#: common/actions.c:5058
+#: common/actions.c:5062
 #, fuzzy, c-format
 #| msgid "Steal %sGold%s"
 msgid "Steal %sGold and Escape%s"
 msgstr "%sVarasta kultaa%s"
 
 #. TRANS: Steal _Maps (100% chance of success).
-#: common/actions.c:5061
+#: common/actions.c:5065
 #, fuzzy, c-format
 #| msgid "Steal %sGold%s"
 msgid "Steal %sMaps%s"
 msgstr "%sVarasta kultaa%s"
 
 #. TRANS: Steal _Maps and Escape (100% chance of success).
-#: common/actions.c:5064
+#: common/actions.c:5068
 #, fuzzy, c-format
 #| msgid "Steal %sGold%s"
 msgid "Steal %sMaps and Escape%s"
 msgstr "%sVarasta kultaa%s"
 
 #. TRANS: Establish Trade _Route (100% chance of success).
-#: common/actions.c:5067 data/civ1/game.ruleset:274 data/civ2/game.ruleset:321
-#: data/classic/game.ruleset:325 data/sandbox/game.ruleset:331
-#: data/civ2civ3/game.ruleset:330 data/alien/game.ruleset:294
+#: common/actions.c:5071 data/civ1/game.ruleset:284 data/civ2/game.ruleset:331
+#: data/classic/game.ruleset:335 data/sandbox/game.ruleset:341
+#: data/civ2civ3/game.ruleset:340 data/alien/game.ruleset:304
 #, c-format
 msgid "Establish Trade %sRoute%s"
 msgstr "%sPerusta kauppareitti%s"
 
 #. TRANS: Enter _Marketplace (100% chance of success).
-#: common/actions.c:5070 data/civ1/game.ruleset:277 data/civ2/game.ruleset:324
-#: data/sandbox/game.ruleset:334 data/civ2civ3/game.ruleset:333
+#: common/actions.c:5074 data/civ1/game.ruleset:287 data/civ2/game.ruleset:334
+#: data/sandbox/game.ruleset:344 data/civ2civ3/game.ruleset:343
 #, c-format
 msgid "Enter %sMarketplace%s"
 msgstr "%sAstu torille%s"
 
 #. TRANS: Help _build Wonder (100% chance of success).
-#: common/actions.c:5073 data/civ1/game.ruleset:280 data/civ2/game.ruleset:327
-#: data/classic/game.ruleset:331 data/sandbox/game.ruleset:337
-#: data/civ2civ3/game.ruleset:336 data/alien/game.ruleset:300
-#: data/multiplayer/game.ruleset:328
+#: common/actions.c:5077 data/civ1/game.ruleset:290 data/civ2/game.ruleset:337
+#: data/classic/game.ruleset:341 data/sandbox/game.ruleset:347
+#: data/civ2civ3/game.ruleset:346 data/alien/game.ruleset:310
+#: data/multiplayer/game.ruleset:338
 #, c-format
 msgid "Help %sbuild Wonder%s"
 msgstr "%sAuta ihmeen rakentamisessa%s"
 
 #. TRANS: _Capture Units (100% chance of success).
-#: common/actions.c:5076 data/sandbox/game.ruleset:346
-#: data/civ2civ3/game.ruleset:345 data/alien/game.ruleset:309
+#: common/actions.c:5080 data/sandbox/game.ruleset:356
+#: data/civ2civ3/game.ruleset:355 data/alien/game.ruleset:319
 #, fuzzy, c-format
 #| msgid "%sSabotage Enemy Unit%s"
 msgid "%sCapture Units%s"
 msgstr "%sSabotoi vihollisen yksikkö%s"
 
 #. TRANS: _Expel Unit (100% chance of success).
-#: common/actions.c:5079
+#: common/actions.c:5083
 #, fuzzy, c-format
 #| msgid "%sBribe Enemy Unit%s"
 msgid "%sExpel Unit%s"
 msgstr "%sLahjo vihollisen yksikkö%s"
 
 #. TRANS: _Found City (100% chance of success).
-#: common/actions.c:5082
+#: common/actions.c:5086
 #, fuzzy, c-format
 #| msgid "%sPoison City%s"
 msgid "%sFound City%s"
 msgstr "%sMyrkytä kaupunki%s"
 
 #. TRANS: _Join City (100% chance of success).
-#: common/actions.c:5085
+#: common/actions.c:5089
 #, fuzzy, c-format
 #| msgid "%sPoison City%s"
 msgid "%sJoin City%s"
 msgstr "%sMyrkytä kaupunki%s"
 
 #. TRANS: B_ombard (100% chance of success).
-#: common/actions.c:5088
+#: common/actions.c:5092
 #, c-format
 msgid "B%sombard%s"
 msgstr "%sPommita%s"
 
 #. TRANS: Suitcase _Nuke (100% chance of success).
-#: common/actions.c:5091
+#: common/actions.c:5095
 #, c-format
 msgid "Suitcase %sNuke%s"
 msgstr "Salkku%sydinpommi%s"
 
 #. TRANS: Suitcase _Nuke and Escape (100% chance of success).
-#: common/actions.c:5094
+#: common/actions.c:5098
 #, c-format
 msgid "Suitcase %sNuke and Escape%s"
 msgstr "Salkku%sydinpommi ja pakeneminen%s"
 
 #. TRANS: Explode _Nuclear (100% chance of success).
-#: common/actions.c:5097 data/civ1/game.ruleset:295 data/civ2/game.ruleset:342
-#: data/classic/game.ruleset:346 data/sandbox/game.ruleset:358
-#: data/civ2civ3/game.ruleset:357 data/multiplayer/game.ruleset:343
+#: common/actions.c:5101 data/civ1/game.ruleset:305 data/civ2/game.ruleset:352
+#: data/classic/game.ruleset:356 data/sandbox/game.ruleset:368
+#: data/civ2civ3/game.ruleset:367 data/multiplayer/game.ruleset:353
 #, c-format
 msgid "Explode %sNuclear%s"
 msgstr "Räjäytä %sydinlataus%s"
 
 #. TRANS: Destroy _City (100% chance of success).
-#: common/actions.c:5100 data/sandbox/game.ruleset:361
+#: common/actions.c:5104 data/sandbox/game.ruleset:371
 #, fuzzy, c-format
 #| msgid "%s destroys %s in %s."
 msgid "Destroy %sCity%s"
 msgstr "%s tuhosi kohteen %s kaupungissa %s."
 
 #. TRANS: Rec_ycle Unit (100% chance of success).
-#: common/actions.c:5103 data/civ1/game.ruleset:283 data/civ2/game.ruleset:330
-#: data/classic/game.ruleset:334 data/sandbox/game.ruleset:340
-#: data/civ2civ3/game.ruleset:339 data/alien/game.ruleset:303
-#: data/multiplayer/game.ruleset:331
+#: common/actions.c:5107 data/civ1/game.ruleset:293 data/civ2/game.ruleset:340
+#: data/classic/game.ruleset:344 data/sandbox/game.ruleset:350
+#: data/civ2civ3/game.ruleset:349 data/alien/game.ruleset:313
+#: data/multiplayer/game.ruleset:341
 #, fuzzy, c-format
 #| msgid "Select Unit(s)"
 msgid "Rec%sycle Unit%s"
 msgstr "Valitse yksiköt"
 
 #. TRANS: _You're Fired (100% chance of success).
-#: common/actions.c:5106 data/civ1/game.ruleset:286 data/civ2/game.ruleset:333
-#: data/classic/game.ruleset:337 data/sandbox/game.ruleset:343
-#: data/civ2civ3/game.ruleset:342 data/alien/game.ruleset:306
-#: data/multiplayer/game.ruleset:334
+#: common/actions.c:5110 data/civ1/game.ruleset:296 data/civ2/game.ruleset:343
+#: data/classic/game.ruleset:347 data/sandbox/game.ruleset:353
+#: data/civ2civ3/game.ruleset:352 data/alien/game.ruleset:316
+#: data/multiplayer/game.ruleset:344
 #, c-format
 msgid "%sYou're Fired%s"
 msgstr "Saat %spotkut%s"
 
 #. TRANS: Set _Home City (100% chance of success).
-#: common/actions.c:5109 data/civ1/game.ruleset:298 data/civ2/game.ruleset:345
-#: data/classic/game.ruleset:349 data/sandbox/game.ruleset:364
-#: data/civ2civ3/game.ruleset:360 data/alien/game.ruleset:321
-#: data/multiplayer/game.ruleset:346
+#: common/actions.c:5113 data/civ1/game.ruleset:308 data/civ2/game.ruleset:355
+#: data/classic/game.ruleset:359 data/sandbox/game.ruleset:374
+#: data/civ2civ3/game.ruleset:370 data/alien/game.ruleset:331
+#: data/multiplayer/game.ruleset:356
 #, c-format
 msgid "Set %sHome City%s"
 msgstr "Tee tästä uusi %skotikaupunki%s"
 
 #. TRANS: _Upgrade Unit (100% chance of success).
-#: common/actions.c:5112 data/civ2/game.ruleset:348
-#: data/classic/game.ruleset:352 data/sandbox/game.ruleset:367
-#: data/civ2civ3/game.ruleset:363 data/alien/game.ruleset:324
-#: data/multiplayer/game.ruleset:349
+#: common/actions.c:5116 data/civ2/game.ruleset:358
+#: data/classic/game.ruleset:362 data/sandbox/game.ruleset:377
+#: data/civ2civ3/game.ruleset:373 data/alien/game.ruleset:334
+#: data/multiplayer/game.ruleset:359
 #, c-format
 msgid "%sUpgrade Unit%s"
 msgstr "%sAjanmukaista%s"
 
 #. TRANS: Drop _Paratrooper (100% chance of success).
-#: common/actions.c:5115 data/civ2/game.ruleset:351
-#: data/classic/game.ruleset:355 data/sandbox/game.ruleset:370
-#: data/civ2civ3/game.ruleset:366 data/alien/game.ruleset:327
-#: data/multiplayer/game.ruleset:352
+#: common/actions.c:5119 data/civ2/game.ruleset:361
+#: data/classic/game.ruleset:365 data/sandbox/game.ruleset:380
+#: data/civ2civ3/game.ruleset:376 data/alien/game.ruleset:337
+#: data/multiplayer/game.ruleset:362
 #, fuzzy, c-format
 #| msgid "Drop Paratrooper"
 msgid "Drop %sParatrooper%s"
 msgstr "Laskuvarjohyppy"
 
 #. TRANS: _Airlift to City (100% chance of success).
-#: common/actions.c:5118 data/civ2/game.ruleset:354
-#: data/classic/game.ruleset:358 data/sandbox/game.ruleset:373
-#: data/civ2civ3/game.ruleset:369 data/alien/game.ruleset:330
-#: data/multiplayer/game.ruleset:355
+#: common/actions.c:5122 data/civ2/game.ruleset:364
+#: data/classic/game.ruleset:368 data/sandbox/game.ruleset:383
+#: data/civ2civ3/game.ruleset:379 data/alien/game.ruleset:340
+#: data/multiplayer/game.ruleset:365
 #, c-format
 msgid "%sAirlift to City%s"
 msgstr "%sLennätä kaupunkiin%s"
 
 #. TRANS: _Attack (100% chance of success).
-#: common/actions.c:5121 data/civ1/game.ruleset:301 data/civ2/game.ruleset:357
-#: data/classic/game.ruleset:361 data/sandbox/game.ruleset:376
-#: data/civ2civ3/game.ruleset:372 data/alien/game.ruleset:333
-#: data/multiplayer/game.ruleset:358
+#: common/actions.c:5125 data/civ1/game.ruleset:311 data/civ2/game.ruleset:367
+#: data/classic/game.ruleset:371 data/sandbox/game.ruleset:386
+#: data/civ2civ3/game.ruleset:382 data/alien/game.ruleset:343
+#: data/multiplayer/game.ruleset:368
 #, c-format
 msgid "%sAttack%s"
 msgstr "%sHyökkäys%s"
 
 #. TRANS: _Suicide Attack (100% chance of success).
-#: common/actions.c:5124
+#: common/actions.c:5128
 #, fuzzy, c-format
 #| msgid "%sAttack%s"
 msgid "%sSuicide Attack%s"
 msgstr "%sHyökkäys%s"
 
 #. TRANS: _Conquer City (100% chance of success).
-#: common/actions.c:5127 data/civ1/game.ruleset:307 data/civ2/game.ruleset:363
-#: data/classic/game.ruleset:367 data/sandbox/game.ruleset:382
-#: data/civ2civ3/game.ruleset:378 data/alien/game.ruleset:339
-#: data/multiplayer/game.ruleset:364
+#: common/actions.c:5131 data/civ1/game.ruleset:317 data/civ2/game.ruleset:373
+#: data/classic/game.ruleset:377 data/sandbox/game.ruleset:392
+#: data/civ2civ3/game.ruleset:388 data/alien/game.ruleset:349
+#: data/multiplayer/game.ruleset:374
 #, fuzzy, c-format
 #| msgid "%sPoison City%s"
 msgid "%sConquer City%s"
 msgstr "%sMyrkytä kaupunki%s"
 
 #. TRANS: Heal _Unit (3% chance of success).
-#: common/actions.c:5130
+#: common/actions.c:5134
 #, c-format
 msgid "Heal %sUnit%s"
 msgstr "%sParanna yksikkö%s"
 
 #. TRANS: _Transform Terrain (3% chance of success).
-#: common/actions.c:5133 data/civ1/game.ruleset:310 data/civ2/game.ruleset:366
-#: data/classic/game.ruleset:370 data/sandbox/game.ruleset:385
-#: data/civ2civ3/game.ruleset:381 data/alien/game.ruleset:342
-#: data/multiplayer/game.ruleset:367
+#: common/actions.c:5137 data/civ1/game.ruleset:320 data/civ2/game.ruleset:376
+#: data/classic/game.ruleset:380 data/sandbox/game.ruleset:395
+#: data/civ2civ3/game.ruleset:391 data/alien/game.ruleset:352
+#: data/multiplayer/game.ruleset:377
 #, fuzzy, c-format
 #| msgid "Transform Terrain"
 msgid "%sTransform Terrain%s"
 msgstr "Muokkaa maastoa"
 
-#. TRANS: Transform by _Irrigate (3% chance of success).
-#: common/actions.c:5136 data/civ1/game.ruleset:313 data/civ2/game.ruleset:369
-#: data/classic/game.ruleset:373 data/sandbox/game.ruleset:388
-#: data/civ2civ3/game.ruleset:384 data/alien/game.ruleset:345
-#: data/multiplayer/game.ruleset:370
+#. TRANS: Transform by _Cultivating (3% chance of success).
+#: common/actions.c:5140 data/civ1/game.ruleset:323 data/civ2/game.ruleset:379
+#: data/classic/game.ruleset:383 data/sandbox/game.ruleset:398
+#: data/civ2civ3/game.ruleset:394 data/multiplayer/game.ruleset:380
 #, fuzzy, c-format
 #| msgid "Transform to %s"
-msgid "Transform by %sIrrigate%s"
+msgid "Transform by %sCultivating%s"
 msgstr "Muokkaa tästä %s"
 
-#. TRANS: Transform by _Mine (3% chance of success).
-#: common/actions.c:5139 data/civ1/game.ruleset:316 data/civ2/game.ruleset:372
-#: data/classic/game.ruleset:376 data/sandbox/game.ruleset:391
-#: data/civ2civ3/game.ruleset:387 data/alien/game.ruleset:348
-#: data/multiplayer/game.ruleset:373
+#. TRANS: Transform by _Planting (3% chance of success).
+#: common/actions.c:5143 data/civ1/game.ruleset:326 data/civ2/game.ruleset:382
+#: data/classic/game.ruleset:386 data/sandbox/game.ruleset:401
+#: data/civ2civ3/game.ruleset:397 data/alien/game.ruleset:358
+#: data/multiplayer/game.ruleset:383
 #, fuzzy, c-format
 #| msgid "Transform to %s"
-msgid "Transform by %sMine%s"
+msgid "Transform by %sPlanting%s"
 msgstr "Muokkaa tästä %s"
 
 #. TRANS: Pilla_ge (100% chance of success).
-#: common/actions.c:5142 data/civ1/game.ruleset:319 data/civ2/game.ruleset:375
-#: data/classic/game.ruleset:379 data/sandbox/game.ruleset:394
-#: data/civ2civ3/game.ruleset:390 data/alien/game.ruleset:351
-#: data/multiplayer/game.ruleset:376
+#: common/actions.c:5146 data/civ1/game.ruleset:329 data/civ2/game.ruleset:385
+#: data/classic/game.ruleset:389 data/sandbox/game.ruleset:404
+#: data/civ2civ3/game.ruleset:400 data/alien/game.ruleset:361
+#: data/multiplayer/game.ruleset:386
 #, fuzzy, c-format
 #| msgid "Pillage"
 msgid "Pilla%sge%s"
 msgstr "Turmele"
 
 #. TRANS: _Fortify (100% chance of success).
-#: common/actions.c:5145 data/civ1/game.ruleset:322 data/civ2/game.ruleset:378
-#: data/classic/game.ruleset:382 data/sandbox/game.ruleset:397
-#: data/civ2civ3/game.ruleset:393 data/alien/game.ruleset:354
-#: data/multiplayer/game.ruleset:379
+#: common/actions.c:5149 data/civ1/game.ruleset:332 data/civ2/game.ruleset:388
+#: data/classic/game.ruleset:392 data/sandbox/game.ruleset:407
+#: data/civ2civ3/game.ruleset:403 data/alien/game.ruleset:364
+#: data/multiplayer/game.ruleset:389
 #, fuzzy, c-format
 #| msgid "Fortify"
 msgid "%sFortify%s"
 msgstr "Linnoittaudu"
 
 #. TRANS: Build _Road (100% chance of success).
-#: common/actions.c:5148 data/civ1/game.ruleset:325 data/civ2/game.ruleset:381
-#: data/classic/game.ruleset:385 data/sandbox/game.ruleset:400
-#: data/civ2civ3/game.ruleset:396 data/alien/game.ruleset:357
-#: data/multiplayer/game.ruleset:382
+#: common/actions.c:5152 data/civ1/game.ruleset:335 data/civ2/game.ruleset:391
+#: data/classic/game.ruleset:395 data/sandbox/game.ruleset:410
+#: data/civ2civ3/game.ruleset:406 data/alien/game.ruleset:367
+#: data/multiplayer/game.ruleset:392
 #, fuzzy, c-format
 #| msgid "Build Road"
 msgid "Build %sRoad%s"
 msgstr "Rakenna tie"
 
 #. TRANS: _Convert Unit (100% chance of success).
-#: common/actions.c:5151
+#: common/actions.c:5155
 #, fuzzy, c-format
 #| msgid "Convert Unit"
 msgid "%sConvert Unit%s"
 msgstr "Muunna yksikkö"
 
 #. TRANS: _Build Base (100% chance of success).
-#: common/actions.c:5154 data/civ1/game.ruleset:328 data/civ2/game.ruleset:384
-#: data/classic/game.ruleset:388 data/sandbox/game.ruleset:403
-#: data/civ2civ3/game.ruleset:399 data/alien/game.ruleset:360
-#: data/multiplayer/game.ruleset:385
+#: common/actions.c:5158 data/civ1/game.ruleset:338 data/civ2/game.ruleset:394
+#: data/classic/game.ruleset:398 data/sandbox/game.ruleset:413
+#: data/civ2civ3/game.ruleset:409 data/alien/game.ruleset:370
+#: data/multiplayer/game.ruleset:395
 #, fuzzy, c-format
 #| msgid "Build Base"
 msgid "%sBuild Base%s"
 msgstr "Rakenna tukikohta"
 
 #. TRANS: Build _Mine (100% chance of success).
-#: common/actions.c:5157 data/civ1/game.ruleset:331 data/civ2/game.ruleset:387
-#: data/classic/game.ruleset:391 data/sandbox/game.ruleset:406
-#: data/civ2civ3/game.ruleset:402 data/alien/game.ruleset:363
-#: data/multiplayer/game.ruleset:388
+#: common/actions.c:5161 data/civ1/game.ruleset:341 data/civ2/game.ruleset:397
+#: data/classic/game.ruleset:401 data/sandbox/game.ruleset:416
+#: data/civ2civ3/game.ruleset:412 data/alien/game.ruleset:373
+#: data/multiplayer/game.ruleset:398
 #, fuzzy, c-format
 #| msgid "Build Mine"
 msgid "Build %sMine%s"
 msgstr "Louhi kaivos"
 
 #. TRANS: Build _Irrigation (100% chance of success).
-#: common/actions.c:5160 data/civ1/game.ruleset:334 data/civ2/game.ruleset:390
-#: data/classic/game.ruleset:394 data/sandbox/game.ruleset:409
-#: data/civ2civ3/game.ruleset:405 data/alien/game.ruleset:366
-#: data/multiplayer/game.ruleset:391
+#: common/actions.c:5164 data/civ1/game.ruleset:344 data/civ2/game.ruleset:400
+#: data/classic/game.ruleset:404 data/sandbox/game.ruleset:419
+#: data/civ2civ3/game.ruleset:415 data/alien/game.ruleset:376
+#: data/multiplayer/game.ruleset:401
 #, fuzzy, c-format
 #| msgid "Build Irrigation"
 msgid "Build %sIrrigation%s"
@@ -14963,7 +15036,7 @@ msgstr "Juhlii"
 msgid "Civil Disorder"
 msgstr "Levottomuuksia"
 
-#: common/events.c:101 data/civ1/game.ruleset:812
+#: common/events.c:101 data/civ1/game.ruleset:827
 msgid "Famine"
 msgstr "Nälänhätä"
 
@@ -14987,7 +15060,7 @@ msgstr "Tarvitsee vesijohdon tai viemäriverkoston"
 msgid "Needs Aqueduct Being Built"
 msgstr "Tarvitsee vesijohdon tai viemäriverkoston, työn alla"
 
-#: common/events.c:107 common/fc_types.h:260
+#: common/events.c:107 common/fc_types.h:264
 msgid "Normal"
 msgstr "Normaali"
 
@@ -15432,66 +15505,66 @@ msgstr "Kokeile \"%s -- --help\" nähdäksesi lisää."
 msgid "Pass any following options to the UI."
 msgstr "Välitä tästä seuraavat parametrit käyttöliittymälle."
 
-#: common/fc_types.h:252
+#: common/fc_types.h:256
 msgid "Away"
 msgstr "Poissa"
 
-#: common/fc_types.h:254
+#: common/fc_types.h:258
 msgid "Handicapped"
 msgstr "Heikennetty"
 
-#: common/fc_types.h:256
+#: common/fc_types.h:260
 msgid "Novice"
 msgstr "Vasta-alkaja"
 
-#: common/fc_types.h:258
+#: common/fc_types.h:262
 msgid "Easy"
 msgstr "Helppo"
 
-#: common/fc_types.h:262
+#: common/fc_types.h:266
 msgid "Hard"
 msgstr "Vaikea"
 
-#: common/fc_types.h:264
+#: common/fc_types.h:268
 msgid "Cheating"
 msgstr "Huijaava"
 
-#: common/fc_types.h:268
+#: common/fc_types.h:272
 msgid "Experimental"
 msgstr "Kokeellinen"
 
-#: common/fc_types.h:326
+#: common/fc_types.h:330
 msgid "WrapX"
 msgstr "kiertyy horisontaalisti"
 
-#: common/fc_types.h:328
+#: common/fc_types.h:332
 msgid "WrapY"
 msgstr "kiertyy vertikaalisti"
 
-#: common/fc_types.h:330
+#: common/fc_types.h:334
 msgid "ISO"
 msgstr "isometrinen"
 
-#: common/fc_types.h:332
+#: common/fc_types.h:336
 msgid "Hex"
 msgstr "heksa"
 
 #. TRANS: in place of player name or "global observer"
-#: common/fc_types.h:797 server/stdinhand.c:5354
+#: common/fc_types.h:803 server/stdinhand.c:5354
 msgid "nothing"
 msgstr "ei mikään"
 
-#: common/fc_types.h:800
+#: common/fc_types.h:806
 msgid "passive"
 msgstr "passiivinen"
 
 #. TRANS: year label (Anno Domini)
-#: common/game.h:711 data/civ1/game.ruleset:779 data/civ2/game.ruleset:1015
+#: common/game.h:725 data/civ1/game.ruleset:794 data/civ2/game.ruleset:1030
 msgid "AD"
 msgstr "jaa."
 
 #. TRANS: year label (Before Christ)
-#: common/game.h:713 data/civ1/game.ruleset:781 data/civ2/game.ruleset:1017
+#: common/game.h:727 data/civ1/game.ruleset:796 data/civ2/game.ruleset:1032
 msgid "BC"
 msgstr "eaa."
 
@@ -15557,7 +15630,7 @@ msgstr "yksi kuva per 'plrbv':stä löytyvä pelaaja"
 #. * "define" in the first column are server keywords that must not
 #. * be translated. Do not translate keywords in single quotes, but
 #. * strings in <angle brackets> should be translated.
-#: common/mapimg.c:680
+#: common/mapimg.c:685
 #, c-format
 msgid ""
 "This command controls the creation of map images. Supported arguments:\n"
@@ -15659,176 +15732,176 @@ msgstr ""
 " 'zoom=3:map=cu:show=plrbv:plrbv=010011:format=jpg'\n"
 " 'zoom=1:map=t:show=none:format=magick|jpg'"
 
-#: common/mapimg.c:766
+#: common/mapimg.c:771
 msgid "no map definition"
 msgstr "ei karttamäärittelyä"
 
-#: common/mapimg.c:772
+#: common/mapimg.c:777
 #, c-format
 msgid "map definition string too long (max %d characters)"
 msgstr "karttamäärittelyn merkkijono on liian pitkä (maksimi on %d merkkiä)"
 
-#: common/mapimg.c:778
+#: common/mapimg.c:783
 #, c-format
 msgid "maximum number of map definitions reached (%d)"
 msgstr "määrittelyjen maksimimäärä (%d) saavutettu"
 
-#: common/mapimg.c:786
+#: common/mapimg.c:791
 #, c-format
 msgid "duplicate of map image definition %d ('%s')"
 msgstr "karttakuvan määrittely %d ('%s') esiintyy useammin kuin kerran"
 
-#: common/mapimg.c:807 common/mapimg.c:811
+#: common/mapimg.c:812 common/mapimg.c:816
 #, c-format
 msgid "unknown map option: '%s'"
 msgstr "tuntematon karttaparametri '%s'"
 
-#: common/mapimg.c:827
+#: common/mapimg.c:832
 #, c-format
 msgid "'show=%s' but no player name 'plrname'"
 msgstr "'show=%s' mutta ei pelaajanimeä 'plrname'"
 
-#: common/mapimg.c:834
+#: common/mapimg.c:839
 #, c-format
 msgid "'show=%s' but no player id 'plrid'"
 msgstr "'show=%s' mutta ei pelaaja-id:tä 'plrid'"
 
-#: common/mapimg.c:841
+#: common/mapimg.c:846
 #, c-format
 msgid "'show=%s' but no player bitvector 'plrbv'"
 msgstr "'show=%s' mutta ei pelaaja-bittivektoria 'plrbv'"
 
-#: common/mapimg.c:994
+#: common/mapimg.c:999
 #, c-format
 msgid "invalid character in bitvector: '%c' (%s)"
 msgstr "kelpaamaton merkki bitvektorissa: '%c' (%s)"
 
-#: common/mapimg.c:1015
+#: common/mapimg.c:1020
 #, c-format
 msgid "'plrid' should be between 0 and %d"
 msgstr "parametrin 'plrid' arvo pitää olla välillä 0-%d"
 
-#: common/mapimg.c:1031
+#: common/mapimg.c:1036
 #, c-format
 msgid "player name too long: '%s' (max: %lu)"
 msgstr "pelaajan nimi on liian pitkä: '%s' (maksimi on %lu)"
 
-#: common/mapimg.c:1061
+#: common/mapimg.c:1066
 msgid "'turns' should be between 0 and 99"
 msgstr "'turns' pitää olla välillä 0-99"
 
-#: common/mapimg.c:1079
+#: common/mapimg.c:1084
 msgid "'zoom' factor should be between 1 and 5"
 msgstr "'zoom' kerroin pitää olla välillä 1-5"
 
-#: common/mapimg.c:1098
+#: common/mapimg.c:1103
 #, c-format
 msgid "invalid value for option '%s': '%s'"
 msgstr "kelvoton arvo optiolla '%s': '%s'"
 
-#: common/mapimg.c:1122
+#: common/mapimg.c:1127
 msgid "map definition not checked (game not started)"
 msgstr "karttamäärittelyä ei ole tarkistettu (peliä ei aloitettu)"
 
-#: common/mapimg.c:1126
+#: common/mapimg.c:1131
 #, c-format
 msgid "map definition deactivated: %s"
 msgstr "karttamäärittely deaktivoitu: %s"
 
-#: common/mapimg.c:1225
+#: common/mapimg.c:1230
 #, c-format
 msgid "Detailed information for map image definition %d\n"
 msgstr "Yksityiskohtaista tietoa karttakuvan määrittelystä %d\n"
 
-#: common/mapimg.c:1228
+#: common/mapimg.c:1233
 #, c-format
 msgid "  - status:                   %s (%s)\n"
 msgstr "  - tila:                     %s (%s)\n"
 
-#: common/mapimg.c:1231
+#: common/mapimg.c:1236
 #, c-format
 msgid "  - status:                   %s\n"
 msgstr "  - tila:                     %s\n"
 
-#: common/mapimg.c:1234
+#: common/mapimg.c:1239
 #, c-format
 msgid "  - file name string:         %s\n"
 msgstr "  - tiedostonimi-merkkijono:  %s\n"
 
-#: common/mapimg.c:1236
+#: common/mapimg.c:1241
 #, c-format
 msgid "  - image toolkit:            %s\n"
 msgstr "  - kuvatyökalu:              %s\n"
 
-#: common/mapimg.c:1238
+#: common/mapimg.c:1243
 #, c-format
 msgid "  - image format:             %s\n"
 msgstr "  - kuvaformaatti:            %s\n"
 
-#: common/mapimg.c:1240
+#: common/mapimg.c:1245
 #, c-format
 msgid "  - zoom factor:              %d\n"
 msgstr "  - zoomauskerroin:           %d\n"
 
-#: common/mapimg.c:1242
+#: common/mapimg.c:1247
 #, c-format
 msgid "  - show area within borders: %s\n"
 msgstr "  - näytä rajojen sis. alue:  %s\n"
 
-#: common/mapimg.c:1243 common/mapimg.c:1245 common/mapimg.c:1247
-#: common/mapimg.c:1249 common/mapimg.c:1251 common/mapimg.c:1255
+#: common/mapimg.c:1248 common/mapimg.c:1250 common/mapimg.c:1252
+#: common/mapimg.c:1254 common/mapimg.c:1256 common/mapimg.c:1260
 msgid "yes"
 msgstr "Kyllä"
 
-#: common/mapimg.c:1243 common/mapimg.c:1245 common/mapimg.c:1247
-#: common/mapimg.c:1249 common/mapimg.c:1251 common/mapimg.c:1255
+#: common/mapimg.c:1248 common/mapimg.c:1250 common/mapimg.c:1252
+#: common/mapimg.c:1254 common/mapimg.c:1256 common/mapimg.c:1260
 msgid "no"
 msgstr "ei"
 
-#: common/mapimg.c:1244
+#: common/mapimg.c:1249
 #, c-format
 msgid "  - show borders:             %s\n"
 msgstr "  - näytä rajat:              %s\n"
 
-#: common/mapimg.c:1246
+#: common/mapimg.c:1251
 #, c-format
 msgid "  - show cities:              %s\n"
 msgstr "  - näytä rajat:              %s\n"
 
-#: common/mapimg.c:1248
+#: common/mapimg.c:1253
 #, c-format
 msgid "  - show fog of war:          %s\n"
 msgstr "  - hämärrä näkymätön alue:   %s\n"
 
-#: common/mapimg.c:1250
+#: common/mapimg.c:1255
 #, c-format
 msgid "  - show player knowledge:    %s\n"
 msgstr "  - näytä pelaajan tieto:     %s\n"
 
-#: common/mapimg.c:1252
+#: common/mapimg.c:1257
 #, c-format
 msgid "  - show terrain:             %s\n"
 msgstr "  - näytä maastotyyppi:       %s\n"
 
-#: common/mapimg.c:1253
+#: common/mapimg.c:1258
 msgid "full"
 msgstr "täysi"
 
-#: common/mapimg.c:1253
+#: common/mapimg.c:1258
 msgid "basic"
 msgstr "perus"
 
-#: common/mapimg.c:1254
+#: common/mapimg.c:1259
 #, c-format
 msgid "  - show units:               %s\n"
 msgstr "  - näytä yksiköt:            %s\n"
 
-#: common/mapimg.c:1256
+#: common/mapimg.c:1261
 #, c-format
 msgid "  - players included:         %s"
 msgstr "  - pelaajat:                 %s"
 
-#: common/mapimg.c:1266
+#: common/mapimg.c:1271
 #, c-format
 msgid ""
 "\n"
@@ -15837,7 +15910,7 @@ msgstr ""
 "\n"
 "  - pelaajan nimi:            %s"
 
-#: common/mapimg.c:1270
+#: common/mapimg.c:1275
 #, c-format
 msgid ""
 "\n"
@@ -15846,7 +15919,7 @@ msgstr ""
 "\n"
 "  - pelaajan id:              %d"
 
-#: common/mapimg.c:1274
+#: common/mapimg.c:1279
 #, c-format
 msgid ""
 "\n"
@@ -15855,52 +15928,52 @@ msgstr ""
 "\n"
 "  - pelaajat:                 %s"
 
-#: common/mapimg.c:1329
+#: common/mapimg.c:1334
 msgid "map not yet created"
 msgstr "karttaa ei vielä luotu"
 
-#: common/mapimg.c:1337 common/mapimg.c:1565
+#: common/mapimg.c:1342 common/mapimg.c:1570
 msgid "map definition not checked or error"
 msgstr "karttamäärittelyä ei ole tarkistettu tai virhe"
 
-#: common/mapimg.c:1548
+#: common/mapimg.c:1553
 #, c-format
 msgid "no map definition with id %d"
 msgstr "ei karttamäärittelyä id:llä %d"
 
-#: common/mapimg.c:1654
+#: common/mapimg.c:1659
 #, c-format
 msgid "unknown player name: '%s'"
 msgstr "tuntematon pelaajan nimi: '%s'"
 
-#: common/mapimg.c:1670
+#: common/mapimg.c:1675
 #, c-format
 msgid "invalid player id: %d"
 msgstr "kelvoton pelaajan id: %d"
 
-#: common/mapimg.c:1855
+#: common/mapimg.c:1860
 #, c-format
 msgid "Turn: %4d - Year: %10s"
 msgstr "Vuoro: %4d - Vuosi: %10s"
 
-#: common/mapimg.c:2025
+#: common/mapimg.c:2030
 msgid "toolkit not defined"
 msgstr "toolkittiä ei määritty"
 
-#: common/mapimg.c:2088 common/mapimg.c:2296
+#: common/mapimg.c:2093 common/mapimg.c:2301
 msgid "error generating the file name"
 msgstr "virhe tiedoston nimeä luodessa"
 
-#: common/mapimg.c:2262
+#: common/mapimg.c:2267
 #, c-format
 msgid "error saving map image '%s'"
 msgstr "virhe karttakuvaa '%s' tallennettaessa"
 
-#: common/mapimg.c:2290
+#: common/mapimg.c:2295
 msgid "the ppm toolkit can only create images in the ppm format"
 msgstr "ppm-työkalu osaa luoda vain ppm-formaattisia kuvia"
 
-#: common/mapimg.c:2302
+#: common/mapimg.c:2307
 #, c-format
 msgid "could not open file: %s"
 msgstr "Tiedoston '%s' avaaminen epäonnistui"
@@ -15908,47 +15981,47 @@ msgstr "Tiedoston '%s' avaaminen epäonnistui"
 #. TRANS: These words should be adjectives which can fit in the sentence
 #. "The x are y towards us"
 #. "The Babylonians are respectful towards us"
-#: common/player.c:1277
+#: common/player.c:1278
 msgid "?attitude:Genocidal"
 msgstr "Kansansurmahakuinen"
 
-#: common/player.c:1279
+#: common/player.c:1280
 msgid "?attitude:Belligerent"
 msgstr "Sotaisa"
 
-#: common/player.c:1281
+#: common/player.c:1282
 msgid "?attitude:Hostile"
 msgstr "Vihamielinen"
 
-#: common/player.c:1283
+#: common/player.c:1284
 msgid "?attitude:Uncooperative"
 msgstr "Yhteistyökyvytön"
 
-#: common/player.c:1285
+#: common/player.c:1286
 msgid "?attitude:Uneasy"
 msgstr "Rauhaton"
 
-#: common/player.c:1287
+#: common/player.c:1288
 msgid "?attitude:Neutral"
 msgstr "Neutraali"
 
-#: common/player.c:1289
+#: common/player.c:1290
 msgid "?attitude:Respectful"
 msgstr "Kunnioittava"
 
-#: common/player.c:1291
+#: common/player.c:1292
 msgid "?attitude:Helpful"
 msgstr "Avulias"
 
-#: common/player.c:1293
+#: common/player.c:1294
 msgid "?attitude:Enthusiastic"
 msgstr "Innokas"
 
-#: common/player.c:1295
+#: common/player.c:1296
 msgid "?attitude:Admiring"
 msgstr "Ihaileva"
 
-#: common/player.c:1298
+#: common/player.c:1299
 msgid "?attitude:Worshipful"
 msgstr "Palvova"
 
@@ -15956,55 +16029,55 @@ msgstr "Palvova"
 msgid "Unassigned"
 msgstr "Nimeämätön"
 
-#: common/player.h:141
+#: common/player.h:142
 msgid "?diplomatic_state:Armistice"
 msgstr "Aselepo"
 
-#: common/player.h:143
+#: common/player.h:144
 msgid "?diplomatic_state:War"
 msgstr "Sotatila"
 
-#: common/player.h:151
+#: common/player.h:152
 msgid "?diplomatic_state:Never met"
 msgstr "Ei tavattu"
 
-#: common/player.h:153
+#: common/player.h:154
 msgid "?diplomatic_state:Team"
 msgstr "Joukkuetoveri"
 
-#: common/player.h:167
+#: common/player.h:168
 msgid "Gives shared vision"
 msgstr "Jakaa näkymän"
 
-#: common/player.h:169
+#: common/player.h:170
 msgid "Receives shared vision"
 msgstr "Vastaanottaa näkymän"
 
-#: common/player.h:171
+#: common/player.h:172
 msgid "Hosts embassy"
 msgstr "Lähetystön sijoituspaikka"
 
-#: common/player.h:173
+#: common/player.h:174
 msgid "Has embassy"
 msgstr "Omaa lähetystön"
 
-#: common/player.h:175
+#: common/player.h:176
 msgid "Hosts real embassy"
 msgstr "Todellisen lähetystön sijoituspaikka"
 
-#: common/player.h:177
+#: common/player.h:178
 msgid "Has real embassy"
 msgstr "Omaa todellisen lähetystön"
 
-#: common/player.h:179
+#: common/player.h:180
 msgid "Has Casus Belli"
 msgstr "Oikeutettu vastatoimiin"
 
-#: common/player.h:181
+#: common/player.h:182
 msgid "Provided Casus Belli"
 msgstr "Provosoi vastatoimia"
 
-#: common/player.h:183
+#: common/player.h:184
 #, fuzzy
 #| msgid "foreign "
 msgid "Foreign"
@@ -18099,39 +18172,45 @@ msgstr "Ei linnoittautumista"
 msgid "Frozen"
 msgstr "Jäätynyt"
 
-#: common/unit.c:546
+#: common/unit.c:550
+#, fuzzy
+#| msgid "Culturists"
+msgid "Cultivate"
+msgstr "Kultturisteja"
+
+#: common/unit.c:552
 msgid "Fortifying"
 msgstr "Linnoittautumassa"
 
-#: common/unit.c:554
+#: common/unit.c:560
 msgid "Goto"
 msgstr "Mene"
 
-#: common/unit.c:556
+#: common/unit.c:562
 msgid "Explore"
 msgstr "Tutki"
 
-#: common/unit.c:560 data/classic/terrain.ruleset:1331
-#: data/sandbox/terrain.ruleset:1421 data/civ2civ3/terrain.ruleset:1390
-#: data/alien/terrain.ruleset:873 data/multiplayer/terrain.ruleset:1306
+#: common/unit.c:566 data/classic/terrain.ruleset:1337
+#: data/sandbox/terrain.ruleset:1426 data/civ2civ3/terrain.ruleset:1396
+#: data/alien/terrain.ruleset:879 data/multiplayer/terrain.ruleset:1312
 msgid "Fallout"
 msgstr "laskeuma"
 
-#: common/unit.c:562
+#: common/unit.c:568
 msgid "Base"
 msgstr "Tukikohta"
 
 # *** '(s/he/it) moves' ***
-#: common/unit.c:1136 common/unit.c:1141
+#: common/unit.c:1166 common/unit.c:1171
 msgid "Moves"
 msgstr "Liikkuu"
 
-#: common/unit.c:1207
+#: common/unit.c:1239
 msgid "Food/Shield/Gold:"
 msgstr "Ruoka/Tuotanto/Kulta:"
 
 #. TRANS: Last %s is pre-pluralised "Treasury contains %d gold."
-#: common/unit.c:1920
+#: common/unit.c:1952
 #, c-format
 msgid ""
 "Upgrade %s to %s for %d gold?\n"
@@ -18146,13 +18225,13 @@ msgstr[1] ""
 "Ajanmukaista %s yksiköksi %s, kustannus on %d kultaa?\n"
 "%s"
 
-#: common/unit.c:1929
+#: common/unit.c:1961
 #, c-format
 msgid "Sorry, cannot upgrade %s (yet)."
 msgstr "Valitan: yksikköä %s ei voi (vielä) ajanmukaistaa."
 
 #. TRANS: Last %s is pre-pluralised "Treasury contains %d gold."
-#: common/unit.c:1935
+#: common/unit.c:1967
 #, c-format
 msgid ""
 "Upgrading %s to %s costs %d gold.\n"
@@ -18167,24 +18246,24 @@ msgstr[1] ""
 "Yksikön %s ajanmukaistaminen yksiköksi %s maksaa %d kultaa.\n"
 "%s"
 
-#: common/unit.c:1945
+#: common/unit.c:1977
 msgid "You can only upgrade units in your cities."
 msgstr "Voit ajanmukaistaa yksiköitä vain omissa kaupungeissasi."
 
-#: common/unit.c:1949
+#: common/unit.c:1981
 #, c-format
 msgid "Upgrading this %s would strand units it transports."
 msgstr ""
 "Jos ajanmukaistaisit yksikön %s, sen kuljettamat yksiköt jäisivät rannalle."
 
-#: common/unit.c:1954
+#: common/unit.c:1986
 #, c-format
 msgid ""
 "Upgrading this %s would result in a %s which can not survive at this place."
 msgstr ""
 "Ajanmukaistettu yksikkö %1$.0s%2$s ei tulisi toimeen tällaisessa maastossa."
 
-#: common/unit.c:1961
+#: common/unit.c:1993
 #, c-format
 msgid ""
 "Upgrading this %s would result in a %s which its current transport, %s, "
@@ -18296,6 +18375,12 @@ msgstr "Kenttäyksikkö"
 #| msgid "?unitflag:Partisan"
 msgid "?unitflag:Provoking"
 msgstr "Sissiryhmä"
+
+#: common/unittype.h:193
+#, fuzzy
+#| msgid "?unitflag:FerryBoat"
+msgid "?unitflag:NeverProtects"
+msgstr "Kuljetusalus"
 
 #: common/unittype.h:196 common/unittype.h:418
 msgid "?unitflag:Settlers"
@@ -18755,17 +18840,15 @@ msgstr ""
 #: data/civ1/buildings.ruleset:234
 msgid ""
 "City Walls make it easier to defend a city.  They triple the defense "
-"strength of units within the city against land, sea, and helicopter units.  "
-"They are ineffective against non-helicopter airborne units as well as "
-"Artillery.  City Walls also prevent the loss of population which occurs when "
-"a defending unit is destroyed by a land unit."
+"strength of units within the city. They are ineffective against Artillery "
+"and Bombers. City Walls also prevent the loss of population which occurs "
+"when a defending unit is destroyed by a land unit."
 msgstr ""
-"Kaupunginmuuri helpottaa kaupungin puolustamista. Se kolminkertaistaa "
-"kaupungissa olevien yksiköiden puolustuskyvyn maa- ja merivoimien yksiköitä "
-"sekä helikoptereita vastaan. Muurit eivät auta puolustauduttaessa muita ilma-"
-"aluksia tai tykistöä vastaan. Muurit suojaavat myös siviiliväestöä; "
-"kaupungin väkiluku ei laske vaikka puolustava yksikkö tuhoutuisikin "
-"maavoimien yksikön hyökkäyksessä."
+"Kaupunginmuuri helpottaa kaupungin puolustusta. Se kolminkertaistaa "
+"kaupungissa olevien yksiköiden puolustuskyvyn. Sillä ei ole vaikutusta "
+"puolustautumiseen tykistöä tai pommikoneita vastaan. Muuri suojaa kaupungin "
+"asukkaita jos hyökkäävät maajoukot tuhoavat puolustavan yksikön, eikä "
+"kaupungin väkiluku vähene."
 
 #: data/civ1/buildings.ruleset:240
 msgid ""
@@ -19555,7 +19638,7 @@ msgstr ""
 msgid "Civ1 ruleset"
 msgstr "Civ1-sääntökokoelma"
 
-#: data/civ1/game.ruleset:32
+#: data/civ1/game.ruleset:38
 msgid ""
 "You are playing with civ1 style rules. These rules are much simpler than the "
 "Freeciv default rules. If you know only the default rules, spend some time "
@@ -19574,121 +19657,121 @@ msgstr ""
 "täysissä voimissa.\n"
 
 #. TRANS: _Bribe Enemy Unit (3% chance of success).
-#: data/civ1/game.ruleset:256 data/civ2/game.ruleset:282
-#: data/classic/game.ruleset:286 data/sandbox/game.ruleset:289
-#: data/civ2civ3/game.ruleset:291 data/alien/game.ruleset:279
-#: data/multiplayer/game.ruleset:289
+#: data/civ1/game.ruleset:266 data/civ2/game.ruleset:292
+#: data/classic/game.ruleset:296 data/sandbox/game.ruleset:299
+#: data/civ2civ3/game.ruleset:301 data/alien/game.ruleset:289
+#: data/multiplayer/game.ruleset:299
 #, c-format
 msgid "%sBribe Enemy Unit%s"
 msgstr "%sLahjo vihollisen yksikkö%s"
 
 #. TRANS: Incite a _Revolt (3% chance of success).
-#: data/civ1/game.ruleset:262 data/civ2/game.ruleset:294
-#: data/classic/game.ruleset:298 data/sandbox/game.ruleset:301
-#: data/civ2civ3/game.ruleset:303 data/alien/game.ruleset:285
-#: data/multiplayer/game.ruleset:301
+#: data/civ1/game.ruleset:272 data/civ2/game.ruleset:304
+#: data/classic/game.ruleset:308 data/sandbox/game.ruleset:311
+#: data/civ2civ3/game.ruleset:313 data/alien/game.ruleset:295
+#: data/multiplayer/game.ruleset:311
 #, c-format
 msgid "Incite a %sRevolt%s"
 msgstr "%sYllytä kapinaan%s"
 
 #. TRANS: _Build City (100% chance of success).
-#: data/civ1/game.ruleset:289 data/civ2/game.ruleset:336
-#: data/classic/game.ruleset:340 data/sandbox/game.ruleset:349
-#: data/civ2civ3/game.ruleset:348 data/alien/game.ruleset:312
-#: data/multiplayer/game.ruleset:337
+#: data/civ1/game.ruleset:299 data/civ2/game.ruleset:346
+#: data/classic/game.ruleset:350 data/sandbox/game.ruleset:359
+#: data/civ2civ3/game.ruleset:358 data/alien/game.ruleset:322
+#: data/multiplayer/game.ruleset:347
 #, fuzzy, c-format
 #| msgid "Build City"
 msgid "%sBuild City%s"
 msgstr "Perusta kaupunki"
 
 #. TRANS: _Add to City (100% chance of success).
-#: data/civ1/game.ruleset:292 data/civ2/game.ruleset:339
-#: data/classic/game.ruleset:343 data/sandbox/game.ruleset:352
-#: data/civ2civ3/game.ruleset:351 data/alien/game.ruleset:315
-#: data/multiplayer/game.ruleset:340
+#: data/civ1/game.ruleset:302 data/civ2/game.ruleset:349
+#: data/classic/game.ruleset:353 data/sandbox/game.ruleset:362
+#: data/civ2civ3/game.ruleset:361 data/alien/game.ruleset:325
+#: data/multiplayer/game.ruleset:350
 #, c-format
 msgid "%sAdd to City%s"
 msgstr "%sLisää kaupunkiin%s"
 
 #. TRANS: _Explode Missile (100% chance of success).
-#: data/civ1/game.ruleset:304 data/civ2/game.ruleset:360
-#: data/classic/game.ruleset:364 data/sandbox/game.ruleset:379
-#: data/civ2civ3/game.ruleset:375 data/alien/game.ruleset:336
-#: data/multiplayer/game.ruleset:361
+#: data/civ1/game.ruleset:314 data/civ2/game.ruleset:370
+#: data/classic/game.ruleset:374 data/sandbox/game.ruleset:389
+#: data/civ2civ3/game.ruleset:385 data/alien/game.ruleset:346
+#: data/multiplayer/game.ruleset:371
 #, fuzzy, c-format
 #| msgid "Explode %sNuclear%s"
 msgid "%sExplode Missile%s"
 msgstr "Räjäytä %sydinlataus%s"
 
 # *** -kuu can be removed from months to produce shortenings. ***
-#: data/civ1/game.ruleset:773 data/civ2/game.ruleset:1009
-#: data/classic/game.ruleset:1059 data/sandbox/game.ruleset:1368
-#: data/civ2civ3/game.ruleset:1211 data/multiplayer/game.ruleset:1055
+#: data/civ1/game.ruleset:788 data/civ2/game.ruleset:1024
+#: data/classic/game.ruleset:1074 data/sandbox/game.ruleset:1383
+#: data/civ2civ3/game.ruleset:1226 data/multiplayer/game.ruleset:1070
 msgid "Jan"
 msgstr "tam"
 
-#: data/civ1/game.ruleset:774 data/civ2/game.ruleset:1010
-#: data/classic/game.ruleset:1060 data/sandbox/game.ruleset:1369
-#: data/civ2civ3/game.ruleset:1212 data/multiplayer/game.ruleset:1056
+#: data/civ1/game.ruleset:789 data/civ2/game.ruleset:1025
+#: data/classic/game.ruleset:1075 data/sandbox/game.ruleset:1384
+#: data/civ2civ3/game.ruleset:1227 data/multiplayer/game.ruleset:1071
 msgid "Feb"
 msgstr "hel"
 
-#: data/civ1/game.ruleset:803 data/classic/game.ruleset:1089
-#: data/sandbox/game.ruleset:1398 data/civ2civ3/game.ruleset:1241
-#: data/alien/game.ruleset:945
+#: data/civ1/game.ruleset:818 data/classic/game.ruleset:1104
+#: data/sandbox/game.ruleset:1413 data/civ2civ3/game.ruleset:1256
+#: data/alien/game.ruleset:960
 msgid "Earthquake"
 msgstr "Maanjäristys"
 
-#: data/civ1/game.ruleset:821 data/classic/game.ruleset:1099
-#: data/sandbox/game.ruleset:1416 data/civ2civ3/game.ruleset:1259
-#: data/alien/game.ruleset:950
+#: data/civ1/game.ruleset:836 data/classic/game.ruleset:1114
+#: data/sandbox/game.ruleset:1431 data/civ2civ3/game.ruleset:1274
+#: data/alien/game.ruleset:965
 msgid "Fire"
 msgstr "Tuli"
 
-#: data/civ1/game.ruleset:830 data/sandbox/game.ruleset:1407
-#: data/civ2civ3/game.ruleset:1250
+#: data/civ1/game.ruleset:845 data/sandbox/game.ruleset:1422
+#: data/civ2civ3/game.ruleset:1265
 msgid "Flood"
 msgstr "Tulva"
 
-#: data/civ1/game.ruleset:840
+#: data/civ1/game.ruleset:855
 msgid "Piracy"
 msgstr "Piratismi"
 
-#: data/civ1/game.ruleset:852
+#: data/civ1/game.ruleset:867
 msgid "Plague"
 msgstr "Rutto"
 
-#: data/civ1/game.ruleset:862
+#: data/civ1/game.ruleset:877
 msgid "Volcano"
 msgstr "Tulivuorenpurkaus"
 
-#: data/civ1/game.ruleset:975 data/civ2/game.ruleset:1143
-#: data/classic/game.ruleset:1217 data/sandbox/game.ruleset:1660
-#: data/civ2civ3/game.ruleset:1451 data/multiplayer/game.ruleset:1182
+#: data/civ1/game.ruleset:990 data/civ2/game.ruleset:1158
+#: data/classic/game.ruleset:1232 data/sandbox/game.ruleset:1675
+#: data/civ2civ3/game.ruleset:1466 data/multiplayer/game.ruleset:1197
 msgid "Goods"
 msgstr "Kauppatavarat"
 
-#: data/civ1/game.ruleset:1067 data/civ2/game.ruleset:1235
-#: data/classic/game.ruleset:1310 data/sandbox/game.ruleset:1773
-#: data/civ2civ3/game.ruleset:1543 data/alien/game.ruleset:1159
+#: data/civ1/game.ruleset:1082 data/civ2/game.ruleset:1250
+#: data/classic/game.ruleset:1325 data/sandbox/game.ruleset:1788
+#: data/civ2civ3/game.ruleset:1558 data/alien/game.ruleset:1174
 msgid "Team 1"
 msgstr "Joukkue 1"
 
-#: data/civ1/game.ruleset:1068 data/civ2/game.ruleset:1236
-#: data/classic/game.ruleset:1311 data/sandbox/game.ruleset:1774
-#: data/civ2civ3/game.ruleset:1544 data/alien/game.ruleset:1160
+#: data/civ1/game.ruleset:1083 data/civ2/game.ruleset:1251
+#: data/classic/game.ruleset:1326 data/sandbox/game.ruleset:1789
+#: data/civ2civ3/game.ruleset:1559 data/alien/game.ruleset:1175
 msgid "Team 2"
 msgstr "Joukkue 2"
 
-#: data/civ1/game.ruleset:1069 data/civ2/game.ruleset:1237
-#: data/classic/game.ruleset:1312 data/sandbox/game.ruleset:1775
-#: data/civ2civ3/game.ruleset:1545 data/alien/game.ruleset:1161
+#: data/civ1/game.ruleset:1084 data/civ2/game.ruleset:1252
+#: data/classic/game.ruleset:1327 data/sandbox/game.ruleset:1790
+#: data/civ2civ3/game.ruleset:1560 data/alien/game.ruleset:1176
 msgid "Team 3"
 msgstr "Joukkue 3"
 
-#: data/civ1/game.ruleset:1070 data/civ2/game.ruleset:1238
-#: data/classic/game.ruleset:1313 data/sandbox/game.ruleset:1776
-#: data/civ2civ3/game.ruleset:1546 data/alien/game.ruleset:1162
+#: data/civ1/game.ruleset:1085 data/civ2/game.ruleset:1253
+#: data/classic/game.ruleset:1328 data/sandbox/game.ruleset:1791
+#: data/civ2civ3/game.ruleset:1561 data/alien/game.ruleset:1177
 #, fuzzy
 #| msgid "Team 0"
 msgid "Team 4"
@@ -21367,15 +21450,15 @@ msgstr ""
 "Tundra on laajaa, kylmää aluetta, joka sopii pienviljelyyn, mutta ei juuri "
 "muuhun."
 
-#: data/civ1/terrain.ruleset:746
+#: data/civ1/terrain.ruleset:748
 msgid "?gui_type:Build Fortress"
 msgstr "Rakenna linnoitus"
 
-#: data/civ1/terrain.ruleset:747
+#: data/civ1/terrain.ruleset:751
 msgid "?gui_type:Build None"
 msgstr "Ei rakennettavissa"
 
-#: data/civ1/terrain.ruleset:885 data/civ2/terrain.ruleset:957
+#: data/civ1/terrain.ruleset:891 data/civ2/terrain.ruleset:963
 #, fuzzy
 #| msgid ""
 #| "Building an irrigation system on a suitable tile causes it to produce "
@@ -21396,12 +21479,12 @@ msgstr ""
 "rinnalla. Kun kasteluverkosto on kaivettu, ruutu pysyy kasteltuna vaikka "
 "vedenlähde poistettaisiin."
 
-#: data/civ1/terrain.ruleset:892 data/civ2/terrain.ruleset:964
+#: data/civ1/terrain.ruleset:898 data/civ2/terrain.ruleset:970
 msgid "Building irrigation on a tile with a mine will destroy it."
 msgstr ""
 "Kasteluverkoston rakentaminen ruutuun jossa on kaivos tuhoaa kaivoksen."
 
-#: data/civ1/terrain.ruleset:894 data/civ2/terrain.ruleset:966
+#: data/civ1/terrain.ruleset:900 data/civ2/terrain.ruleset:972
 msgid ""
 "City center tiles get their terrain's irrigation bonus automatically, if "
 "there is no conflicting mine on the tile; however, this does not make cities "
@@ -21416,8 +21499,8 @@ msgstr ""
 "johtamiseksi kastseluverkoston rakentamisen tueksi muualle. Tämä ei "
 "kuitenkaan anna lisäetua itse ruudulle."
 
-#: data/civ1/terrain.ruleset:918 data/civ2/terrain.ruleset:990
-#: data/classic/terrain.ruleset:1176 data/multiplayer/terrain.ruleset:1150
+#: data/civ1/terrain.ruleset:924 data/civ2/terrain.ruleset:996
+#: data/classic/terrain.ruleset:1182 data/multiplayer/terrain.ruleset:1156
 msgid ""
 "Mines can be built on some types of terrain, which increases the number of "
 "production points produced by that tile. Hills get an extra 3 production "
@@ -21427,15 +21510,15 @@ msgstr ""
 "saatavien tuotantoyksiköiden määrää. Kukkulat saavat 3 lisätuotantoa "
 "ruudulta, muista maastotyypeistä saa 1 lisää."
 
-#: data/civ1/terrain.ruleset:923 data/civ2/terrain.ruleset:995
-#: data/classic/terrain.ruleset:1181 data/sandbox/terrain.ruleset:1207
-#: data/civ2civ3/terrain.ruleset:1206 data/multiplayer/terrain.ruleset:1155
+#: data/civ1/terrain.ruleset:929 data/civ2/terrain.ruleset:1001
+#: data/classic/terrain.ruleset:1187 data/sandbox/terrain.ruleset:1213
+#: data/civ2civ3/terrain.ruleset:1212 data/multiplayer/terrain.ruleset:1161
 msgid "Building a mine on an irrigated tile will destroy the irrigation."
 msgstr ""
 "Kaivoksen rakentaminen ruudulle jossa on kasteluverkosto tuhoaa "
 "kasteluverkoston."
 
-#: data/civ1/terrain.ruleset:945 data/civ2/terrain.ruleset:1017
+#: data/civ1/terrain.ruleset:951 data/civ2/terrain.ruleset:1023
 msgid ""
 "Pollution appears on land tiles around cities with high production or "
 "population, or when a Nuclear unit is detonated. It halves all output from "
@@ -21445,16 +21528,16 @@ msgstr ""
 "tuotanto tai asukasmäärä ovat korkeita, tai kun ydinase räjäytetään. Se "
 "puolittaa kaikki ruudun tuotannon, ja lisää ilmastonmuutoksen riskiä."
 
-#: data/civ1/terrain.ruleset:950
+#: data/civ1/terrain.ruleset:956
 msgid ""
 "The pollution can only be cleared by dispatching Settlers with the \"clean "
 "pollution\" order."
 msgstr ""
 "Saasteen voi poistaa vain komentamalla uudisraivaaja siivoamaan saastetta."
 
-#: data/civ1/terrain.ruleset:953 data/civ2/terrain.ruleset:1025
-#: data/classic/terrain.ruleset:1238 data/sandbox/terrain.ruleset:1292
-#: data/civ2civ3/terrain.ruleset:1291
+#: data/civ1/terrain.ruleset:959 data/civ2/terrain.ruleset:1031
+#: data/classic/terrain.ruleset:1244 data/sandbox/terrain.ruleset:1298
+#: data/civ2civ3/terrain.ruleset:1297
 msgid ""
 "Pollution from production is likely to start becoming important as your "
 "civilization becomes more industrialized, giving you buildings such as "
@@ -21470,8 +21553,8 @@ msgstr ""
 "aurinkovoimalalla - saat tuotannosta johtuvan saasteen laskemaan. "
 "Kierrätyskeskus auttaa samaan tapaan. "
 
-#: data/civ1/terrain.ruleset:960 data/civ2/terrain.ruleset:1032
-#: data/classic/terrain.ruleset:1245 data/multiplayer/terrain.ruleset:1220
+#: data/civ1/terrain.ruleset:966 data/civ2/terrain.ruleset:1038
+#: data/classic/terrain.ruleset:1251 data/multiplayer/terrain.ruleset:1226
 msgid ""
 "The city's population starts adding to pollution with the discovery of "
 "Industrialization, and Automobile, Mass Production, and Plastics make this "
@@ -21483,9 +21566,9 @@ msgstr ""
 "Joukkoliikenteen rakentaminen kaupunkiin poistaa väestön vaikutuksen "
 "saastumiseen."
 
-#: data/civ1/terrain.ruleset:965 data/civ2/terrain.ruleset:1037
-#: data/classic/terrain.ruleset:1250 data/sandbox/terrain.ruleset:1306
-#: data/civ2civ3/terrain.ruleset:1305 data/multiplayer/terrain.ruleset:1225
+#: data/civ1/terrain.ruleset:971 data/civ2/terrain.ruleset:1043
+#: data/classic/terrain.ruleset:1256 data/sandbox/terrain.ruleset:1312
+#: data/civ2civ3/terrain.ruleset:1311 data/multiplayer/terrain.ruleset:1231
 msgid ""
 "The contribution of these factors can be seen in the city dialog; once it "
 "exceeds a threshold, the excess is the percent chance of pollution appearing "
@@ -21495,7 +21578,7 @@ msgstr ""
 "tietyn rajan, ylittävä osa lasketaan saasteen ilmestymistodennäköisyydeksi "
 "joka vuorolla."
 
-#: data/civ1/terrain.ruleset:969 data/civ2/terrain.ruleset:1041
+#: data/civ1/terrain.ruleset:975 data/civ2/terrain.ruleset:1047
 #, fuzzy
 #| msgid ""
 #| "When an unused tile becomes polluted, there is the temptation to avoid "
@@ -21520,9 +21603,9 @@ msgstr ""
 "ja sisämaassa ruudut muuttuvat aavikoksi. Tällä on taipumus autioittaa "
 "kaupunkeja ja johtaa maailmanlaajuiseen kurjistumiseen."
 
-#: data/civ1/terrain.ruleset:977 data/civ2/terrain.ruleset:1049
-#: data/classic/terrain.ruleset:1262 data/sandbox/terrain.ruleset:1318
-#: data/civ2civ3/terrain.ruleset:1317 data/multiplayer/terrain.ruleset:1237
+#: data/civ1/terrain.ruleset:983 data/civ2/terrain.ruleset:1055
+#: data/classic/terrain.ruleset:1268 data/sandbox/terrain.ruleset:1324
+#: data/civ2civ3/terrain.ruleset:1323 data/multiplayer/terrain.ruleset:1243
 msgid ""
 "The risk of global warming is cumulative; the longer polluted tiles are left "
 "uncleaned, the higher the risk becomes, and the risk can linger for some "
@@ -21536,15 +21619,15 @@ msgstr ""
 "siivottu. Mitä kauemmin ilmastonlämpenemisen riski on ollut koholla, sitä "
 "vakavempia seuraukset ovat sen tapahtuessa."
 
-#: data/civ1/terrain.ruleset:986 data/civ2/terrain.ruleset:1058
-#: data/classic/terrain.ruleset:1271 data/sandbox/terrain.ruleset:1327
-#: data/civ2civ3/terrain.ruleset:1326 data/multiplayer/terrain.ruleset:1246
+#: data/civ1/terrain.ruleset:992 data/civ2/terrain.ruleset:1064
+#: data/classic/terrain.ruleset:1277 data/sandbox/terrain.ruleset:1333
+#: data/civ2civ3/terrain.ruleset:1332 data/multiplayer/terrain.ruleset:1252
 msgid "Minor Tribe Village"
 msgstr "Pieni heimokylä"
 
-#: data/civ1/terrain.ruleset:1002 data/civ2/terrain.ruleset:1074
-#: data/classic/terrain.ruleset:1287 data/sandbox/terrain.ruleset:1343
-#: data/civ2civ3/terrain.ruleset:1342 data/multiplayer/terrain.ruleset:1262
+#: data/civ1/terrain.ruleset:1008 data/civ2/terrain.ruleset:1080
+#: data/classic/terrain.ruleset:1293 data/sandbox/terrain.ruleset:1349
+#: data/civ2civ3/terrain.ruleset:1348 data/multiplayer/terrain.ruleset:1268
 msgid ""
 "Villages (also called \"huts\") are primitive communities spread across the "
 "world at the beginning of the game. Any land unit can enter a village, "
@@ -21563,26 +21646,26 @@ msgstr ""
 "edistysaskeleen, sotilasyksikön (toisinaan uudisraivaajan tai yksikön jota "
 "pelaaja ei voi vielä tuottaa) tai jopa uuden kaupungin."
 
-#: data/civ1/terrain.ruleset:1011
+#: data/civ1/terrain.ruleset:1017
 msgid "Flying units just fly over the village, leaving it untouched."
 msgstr ""
 "Lentävät yksiköt eivät vaikuta kyliin, vaan lentävät vain niiden ylitse."
 
-#: data/civ1/terrain.ruleset:1016 data/civ2/terrain.ruleset:1118
-#: data/classic/terrain.ruleset:1361 data/sandbox/terrain.ruleset:1485
-#: data/civ2civ3/terrain.ruleset:1454 data/multiplayer/terrain.ruleset:1335
+#: data/civ1/terrain.ruleset:1022 data/civ2/terrain.ruleset:1124
+#: data/classic/terrain.ruleset:1367 data/sandbox/terrain.ruleset:1490
+#: data/civ2civ3/terrain.ruleset:1460 data/multiplayer/terrain.ruleset:1341
 msgid "Fortress"
 msgstr "linnoitus"
 
-#: data/civ1/terrain.ruleset:1039
+#: data/civ1/terrain.ruleset:1045
 msgid "Fortresses improve defense for land units outside cities."
 msgstr ""
 "Linnoitukset kohentavat maavoimien yksiköiden puolustuskykyä kaupunkien "
 "ulkopuolella."
 
-#: data/civ1/terrain.ruleset:1043 data/civ2/terrain.ruleset:1147
-#: data/classic/terrain.ruleset:1391 data/sandbox/terrain.ruleset:43
-#: data/civ2civ3/terrain.ruleset:42 data/multiplayer/terrain.ruleset:1365
+#: data/civ1/terrain.ruleset:1049 data/civ2/terrain.ruleset:1153
+#: data/classic/terrain.ruleset:1397 data/sandbox/terrain.ruleset:43
+#: data/civ2civ3/terrain.ruleset:42 data/multiplayer/terrain.ruleset:1371
 #, fuzzy, no-c-format
 #| msgid "  * Diplomatic units get a 25% defense bonus in diplomatic fights.\n"
 msgid "Diplomatic units get a 25% defense bonus in diplomatic fights."
@@ -21590,8 +21673,8 @@ msgstr ""
 "  · Diplomaattiyksiköt saavat 25% puolustusedun diplomaattisissa "
 "taisteluissa.\n"
 
-#: data/civ1/terrain.ruleset:1070 data/civ2/terrain.ruleset:1205
-#: data/classic/terrain.ruleset:1500 data/multiplayer/terrain.ruleset:1474
+#: data/civ1/terrain.ruleset:1076 data/civ2/terrain.ruleset:1211
+#: data/classic/terrain.ruleset:1506 data/multiplayer/terrain.ruleset:1480
 msgid ""
 "Roads allow your land units to move more quickly, and on some terrain, also "
 "provide a trade bonus."
@@ -21599,7 +21682,7 @@ msgstr ""
 "Tiet mahdollistavat maayksiköille nopeamman etenemisen ja joillakin "
 "maastotyypeillä ne myös antavat kauppabonuksen."
 
-#: data/civ1/terrain.ruleset:1073 data/civ2/terrain.ruleset:1208
+#: data/civ1/terrain.ruleset:1079 data/civ2/terrain.ruleset:1214
 msgid ""
 "Building roads on river tiles requires knowledge of Bridge Building. City "
 "center tiles automatically get roads, and are an exception to this "
@@ -21609,14 +21692,14 @@ msgstr ""
 "Kaupungin keskusruudut saavat aina tiet automaattisesti, jopa silloin kun "
 "sillanrakennusta ei tunneta."
 
-#: data/civ1/terrain.ruleset:1080 data/civ2/terrain.ruleset:1215
-#: data/classic/terrain.ruleset:1510 data/sandbox/terrain.ruleset:1705
-#: data/civ2civ3/terrain.ruleset:1666 data/multiplayer/terrain.ruleset:1484
+#: data/civ1/terrain.ruleset:1086 data/civ2/terrain.ruleset:1221
+#: data/classic/terrain.ruleset:1516 data/sandbox/terrain.ruleset:1710
+#: data/civ2civ3/terrain.ruleset:1672 data/multiplayer/terrain.ruleset:1490
 msgid "Railroad"
 msgstr "rautatie"
 
-#: data/civ1/terrain.ruleset:1103 data/civ2/terrain.ruleset:1238
-#: data/classic/terrain.ruleset:1533 data/multiplayer/terrain.ruleset:1507
+#: data/civ1/terrain.ruleset:1109 data/civ2/terrain.ruleset:1244
+#: data/classic/terrain.ruleset:1539 data/multiplayer/terrain.ruleset:1513
 msgid ""
 "Once you learn the Railroad technology, you may upgrade your roads to "
 "railroads. Units expend no movement points when moving along a railroad; you "
@@ -21626,7 +21709,7 @@ msgstr ""
 "Rautatietä pitkin kulkevat yksiköt eivät kuluta lainkaan liikepisteitä. Voit "
 "ajella junalla loputtomiin. (Kuten myös vihollisesi!)"
 
-#: data/civ1/terrain.ruleset:1107
+#: data/civ1/terrain.ruleset:1113
 msgid ""
 "A railroad also increases by half (rounding down) all resources produced by "
 "a tile. A tile whose road is upgraded to a railroad retains any trade bonus "
@@ -21636,18 +21719,18 @@ msgstr ""
 "rautatie tavallisen tien päälle, myös tien mahdollisesti tarjoamat "
 "kauppabonukset säilyvät."
 
-#: data/civ1/terrain.ruleset:1114 data/civ2/terrain.ruleset:1252
-#: data/classic/terrain.ruleset:1547 data/sandbox/terrain.ruleset:1783
-#: data/civ2civ3/terrain.ruleset:1744 data/multiplayer/terrain.ruleset:1521
+#: data/civ1/terrain.ruleset:1120 data/civ2/terrain.ruleset:1258
+#: data/classic/terrain.ruleset:1553 data/sandbox/terrain.ruleset:1788
+#: data/civ2civ3/terrain.ruleset:1750 data/multiplayer/terrain.ruleset:1527
 msgid "River"
 msgstr "joki"
 
-#: data/civ1/terrain.ruleset:1128
-msgid "Any land terrain type may have a River on it."
-msgstr "Jokia voi esiintyä millä hyvänsä maaruudulla."
+#: data/civ1/terrain.ruleset:1134
+msgid "Grassland tile may have a River on it."
+msgstr "Jokia voi esiintyä ruohomaaruudulla."
 
-#: data/civ1/terrain.ruleset:1130 data/civ2/terrain.ruleset:1273
-#: data/classic/terrain.ruleset:1567 data/multiplayer/terrain.ruleset:1541
+#: data/civ1/terrain.ruleset:1136 data/civ2/terrain.ruleset:1279
+#: data/classic/terrain.ruleset:1573 data/multiplayer/terrain.ruleset:1547
 msgid ""
 "Roads and railroads can only be built on River tiles if your civilization "
 "has learned Bridge Building technology."
@@ -21655,7 +21738,7 @@ msgstr ""
 "Teitä ja rautateitä voidaan rakentaa jokiruutujen yli vain jos "
 "sivilisaatiosi on oppinut sillanrakennustaidon."
 
-#: data/civ1/terrain.ruleset:1133
+#: data/civ1/terrain.ruleset:1139
 msgid ""
 "Cities built on or next to rivers are at risk of flooding, which will cause "
 "a loss of population and stored food. City Walls eliminate this risk."
@@ -21664,52 +21747,52 @@ msgstr ""
 "tuhoavan ja väestöä vähentävän tulvan jalkoihin. Kaupunginmuuri ehkäisee "
 "tämänvaaran."
 
-#: data/civ1/terrain.ruleset:1153 data/civ2/terrain.ruleset:1305
-#: data/classic/terrain.ruleset:1599 data/sandbox/terrain.ruleset:1844
-#: data/civ2civ3/terrain.ruleset:1803 data/multiplayer/terrain.ruleset:1573
+#: data/civ1/terrain.ruleset:1159 data/civ2/terrain.ruleset:1311
+#: data/classic/terrain.ruleset:1605 data/sandbox/terrain.ruleset:1849
+#: data/civ2civ3/terrain.ruleset:1809 data/multiplayer/terrain.ruleset:1579
 msgid "?animals:Game"
 msgstr "riistaa"
 
-#: data/civ1/terrain.ruleset:1166 data/civ2/terrain.ruleset:1331
-#: data/classic/terrain.ruleset:1625 data/sandbox/terrain.ruleset:1870
-#: data/civ2civ3/terrain.ruleset:1829 data/multiplayer/terrain.ruleset:1599
+#: data/civ1/terrain.ruleset:1172 data/civ2/terrain.ruleset:1337
+#: data/classic/terrain.ruleset:1631 data/sandbox/terrain.ruleset:1875
+#: data/civ2civ3/terrain.ruleset:1835 data/multiplayer/terrain.ruleset:1605
 msgid "Coal"
 msgstr "hiiltä"
 
-#: data/civ1/terrain.ruleset:1179 data/civ2/terrain.ruleset:1344
-#: data/classic/terrain.ruleset:1638 data/sandbox/terrain.ruleset:1883
-#: data/civ2civ3/terrain.ruleset:1842 data/alien/terrain.ruleset:1242
-#: data/multiplayer/terrain.ruleset:1612
+#: data/civ1/terrain.ruleset:1185 data/civ2/terrain.ruleset:1350
+#: data/classic/terrain.ruleset:1644 data/sandbox/terrain.ruleset:1888
+#: data/civ2civ3/terrain.ruleset:1848 data/alien/terrain.ruleset:1248
+#: data/multiplayer/terrain.ruleset:1618
 msgid "Fish"
 msgstr "kalaa"
 
-#: data/civ1/terrain.ruleset:1192 data/civ2/terrain.ruleset:1370
-#: data/classic/terrain.ruleset:1664 data/sandbox/game.ruleset:1622
-#: data/sandbox/terrain.ruleset:1909 data/civ2civ3/terrain.ruleset:1868
-#: data/multiplayer/terrain.ruleset:1638
+#: data/civ1/terrain.ruleset:1198 data/civ2/terrain.ruleset:1376
+#: data/classic/terrain.ruleset:1670 data/sandbox/game.ruleset:1637
+#: data/sandbox/terrain.ruleset:1914 data/civ2civ3/terrain.ruleset:1874
+#: data/multiplayer/terrain.ruleset:1644
 msgid "Gems"
 msgstr "jalokiviä"
 
-#: data/civ1/terrain.ruleset:1205
+#: data/civ1/terrain.ruleset:1211
 msgid "Horses"
 msgstr "hevosia"
 
-#: data/civ1/terrain.ruleset:1218 data/civ2/terrain.ruleset:1409
-#: data/classic/terrain.ruleset:1703 data/sandbox/terrain.ruleset:1948
-#: data/civ2civ3/terrain.ruleset:1907 data/multiplayer/terrain.ruleset:1677
+#: data/civ1/terrain.ruleset:1224 data/civ2/terrain.ruleset:1415
+#: data/classic/terrain.ruleset:1709 data/sandbox/terrain.ruleset:1953
+#: data/civ2civ3/terrain.ruleset:1913 data/multiplayer/terrain.ruleset:1683
 msgid "Oasis"
 msgstr "keidas"
 
-#: data/civ1/terrain.ruleset:1231 data/civ2/terrain.ruleset:1526
-#: data/civ2/terrain.ruleset:1540 data/classic/terrain.ruleset:26
-#: data/classic/terrain.ruleset:1820 data/sandbox/terrain.ruleset:26
-#: data/sandbox/terrain.ruleset:2066 data/civ2civ3/terrain.ruleset:26
-#: data/civ2civ3/terrain.ruleset:2025 data/multiplayer/terrain.ruleset:26
-#: data/multiplayer/terrain.ruleset:1794
+#: data/civ1/terrain.ruleset:1237 data/civ2/terrain.ruleset:1532
+#: data/civ2/terrain.ruleset:1546 data/classic/terrain.ruleset:26
+#: data/classic/terrain.ruleset:1826 data/sandbox/terrain.ruleset:26
+#: data/sandbox/terrain.ruleset:2071 data/civ2civ3/terrain.ruleset:26
+#: data/civ2civ3/terrain.ruleset:2031 data/multiplayer/terrain.ruleset:26
+#: data/multiplayer/terrain.ruleset:1800
 msgid "Oil"
 msgstr "öljyä"
 
-#: data/civ1/terrain.ruleset:1257
+#: data/civ1/terrain.ruleset:1263
 msgid "Seals"
 msgstr "hylkeitä"
 
@@ -21743,10 +21826,10 @@ msgstr "Lisää kaupunkiin"
 
 #: data/civ1/units.ruleset:28 data/civ1/units.ruleset:1179
 #: data/civ2/units.ruleset:33 data/civ2/units.ruleset:1883
-#: data/classic/units.ruleset:40 data/classic/units.ruleset:1930
-#: data/sandbox/units.ruleset:43 data/sandbox/units.ruleset:2160
-#: data/civ2civ3/units.ruleset:42 data/civ2civ3/units.ruleset:2143
-#: data/multiplayer/units.ruleset:39 data/multiplayer/units.ruleset:2028
+#: data/classic/units.ruleset:40 data/classic/units.ruleset:1933
+#: data/sandbox/units.ruleset:43 data/sandbox/units.ruleset:2163
+#: data/civ2civ3/units.ruleset:42 data/civ2civ3/units.ruleset:2146
+#: data/multiplayer/units.ruleset:39 data/multiplayer/units.ruleset:2031
 msgid "Nuclear"
 msgstr "Ydinohjus"
 
@@ -21767,29 +21850,29 @@ msgstr "Voi perustaa kaupungin."
 #: data/civ1/units.ruleset:44 data/civ1/units.ruleset:1253
 #: data/civ2/units.ruleset:51 data/civ2/units.ruleset:1957
 #: data/civ2/units.ruleset:2052 data/classic/units.ruleset:59
-#: data/classic/units.ruleset:468 data/classic/units.ruleset:513
-#: data/classic/units.ruleset:554 data/classic/units.ruleset:1956
-#: data/classic/units.ruleset:2307 data/classic/units.ruleset:2347
-#: data/sandbox/units.ruleset:67 data/sandbox/units.ruleset:502
-#: data/sandbox/units.ruleset:546 data/sandbox/units.ruleset:589
-#: data/sandbox/units.ruleset:2106 data/sandbox/units.ruleset:2186
-#: data/sandbox/units.ruleset:2560 data/sandbox/units.ruleset:2600
-#: data/civ2civ3/units.ruleset:62 data/civ2civ3/units.ruleset:492
-#: data/civ2civ3/units.ruleset:536 data/civ2civ3/units.ruleset:579
-#: data/civ2civ3/units.ruleset:2089 data/civ2civ3/units.ruleset:2169
-#: data/civ2civ3/units.ruleset:2539 data/civ2civ3/units.ruleset:2579
-#: data/multiplayer/units.ruleset:58 data/multiplayer/units.ruleset:467
-#: data/multiplayer/units.ruleset:513 data/multiplayer/units.ruleset:554
-#: data/multiplayer/units.ruleset:2054 data/multiplayer/units.ruleset:2393
-#: data/multiplayer/units.ruleset:2433
+#: data/classic/units.ruleset:471 data/classic/units.ruleset:516
+#: data/classic/units.ruleset:557 data/classic/units.ruleset:1959
+#: data/classic/units.ruleset:2310 data/classic/units.ruleset:2350
+#: data/sandbox/units.ruleset:67 data/sandbox/units.ruleset:505
+#: data/sandbox/units.ruleset:549 data/sandbox/units.ruleset:592
+#: data/sandbox/units.ruleset:2109 data/sandbox/units.ruleset:2189
+#: data/sandbox/units.ruleset:2563 data/sandbox/units.ruleset:2603
+#: data/civ2civ3/units.ruleset:62 data/civ2civ3/units.ruleset:495
+#: data/civ2civ3/units.ruleset:539 data/civ2civ3/units.ruleset:582
+#: data/civ2civ3/units.ruleset:2092 data/civ2civ3/units.ruleset:2172
+#: data/civ2civ3/units.ruleset:2542 data/civ2civ3/units.ruleset:2582
+#: data/multiplayer/units.ruleset:58 data/multiplayer/units.ruleset:470
+#: data/multiplayer/units.ruleset:516 data/multiplayer/units.ruleset:557
+#: data/multiplayer/units.ruleset:2057 data/multiplayer/units.ruleset:2396
+#: data/multiplayer/units.ruleset:2436
 msgid "green"
 msgstr "kokematon"
 
 #: data/civ1/units.ruleset:44 data/civ1/units.ruleset:1253
 #: data/civ2/units.ruleset:51 data/civ2/units.ruleset:1957
 #: data/civ2/units.ruleset:2052 data/classic/units.ruleset:59
-#: data/sandbox/units.ruleset:67 data/sandbox/units.ruleset:2106
-#: data/civ2civ3/units.ruleset:62 data/civ2civ3/units.ruleset:2089
+#: data/sandbox/units.ruleset:67 data/sandbox/units.ruleset:2109
+#: data/civ2civ3/units.ruleset:62 data/civ2civ3/units.ruleset:2092
 #: data/multiplayer/units.ruleset:58
 msgid "veteran"
 msgstr "konkari"
@@ -21844,9 +21927,9 @@ msgstr "ohjusjoukkojen"
 
 # NOTE: All unit names are now transformed to singular or something that can be with only mild ridicule be treated as singular, to facilitate more sensible use in sentences. Words like 'ryhmä' refer to civillian groups, '-väki' is used where possible, 'joukkue' and 'joukko' for cannon fodder, 'partio' for anything mounted, and other words for suitable other special cases.
 #: data/civ1/units.ruleset:351 data/civ2/units.ruleset:355
-#: data/classic/units.ruleset:442 data/sandbox/units.ruleset:476
-#: data/civ2civ3/units.ruleset:466 data/alien/units.ruleset:437
-#: data/multiplayer/units.ruleset:441
+#: data/classic/units.ruleset:445 data/sandbox/units.ruleset:479
+#: data/civ2civ3/units.ruleset:469 data/alien/units.ruleset:440
+#: data/multiplayer/units.ruleset:444
 msgid "Settlers"
 msgstr "Uudisraivaajaryhmä"
 
@@ -21860,7 +21943,7 @@ msgstr ""
 "saada uusia kaupunkeja perustettua, ja sen lisäksi he voivat parantaa "
 "ruutuja. Katso ohjen kohta \\\"Maasto\\\" ja \\\"Maastonmuokkaukset\\\"."
 
-#: data/civ1/units.ruleset:381 data/classic/units.ruleset:480
+#: data/civ1/units.ruleset:381 data/classic/units.ruleset:483
 msgid ""
 "Upkeep for Settlers is in food as well as production, and a Settler can die "
 "if its supporting city runs out of food. Settlers in a Republic or Democracy "
@@ -21876,8 +21959,8 @@ msgid "Militia"
 msgstr "Nostoväki"
 
 #: data/civ1/units.ruleset:414 data/civ2/units.ruleset:461
-#: data/classic/units.ruleset:604 data/sandbox/units.ruleset:676
-#: data/civ2civ3/units.ruleset:666 data/multiplayer/units.ruleset:604
+#: data/classic/units.ruleset:607 data/sandbox/units.ruleset:679
+#: data/civ2civ3/units.ruleset:669 data/multiplayer/units.ruleset:607
 msgid ""
 "This unit may be built from the start of the game.  It is the weakest "
 "offensive unit."
@@ -21886,28 +21969,28 @@ msgstr ""
 "sotilasyksikkö."
 
 #: data/civ1/units.ruleset:420 data/civ2/units.ruleset:467
-#: data/classic/units.ruleset:610 data/sandbox/units.ruleset:682
-#: data/civ2civ3/units.ruleset:672 data/multiplayer/units.ruleset:610
+#: data/classic/units.ruleset:613 data/sandbox/units.ruleset:685
+#: data/civ2civ3/units.ruleset:675 data/multiplayer/units.ruleset:613
 msgid "Phalanx"
 msgstr "Falangi"
 
 #: data/civ1/units.ruleset:446 data/civ2/units.ruleset:493
-#: data/classic/units.ruleset:636 data/sandbox/units.ruleset:708
-#: data/civ2civ3/units.ruleset:698 data/multiplayer/units.ruleset:636
+#: data/classic/units.ruleset:639 data/sandbox/units.ruleset:711
+#: data/civ2civ3/units.ruleset:701 data/multiplayer/units.ruleset:639
 msgid "The Phalanx is armored infantry, suitable for defending your cities."
 msgstr ""
 "Falangi on kaupunkiesi puolustamiseen soveltuvaa, kilvin ja keihäin "
 "varustettua, säännöllistä muodostelmaa noudattavaa jalkaväkeä."
 
 #: data/civ1/units.ruleset:451 data/civ2/units.ruleset:530
-#: data/classic/units.ruleset:673 data/sandbox/units.ruleset:745
-#: data/civ2civ3/units.ruleset:735 data/multiplayer/units.ruleset:673
+#: data/classic/units.ruleset:676 data/sandbox/units.ruleset:748
+#: data/civ2civ3/units.ruleset:738 data/multiplayer/units.ruleset:676
 msgid "Legion"
 msgstr "Legioona"
 
 #: data/civ1/units.ruleset:477 data/civ2/units.ruleset:556
-#: data/classic/units.ruleset:699 data/sandbox/units.ruleset:771
-#: data/civ2civ3/units.ruleset:761 data/multiplayer/units.ruleset:699
+#: data/classic/units.ruleset:702 data/sandbox/units.ruleset:774
+#: data/civ2civ3/units.ruleset:764 data/multiplayer/units.ruleset:702
 msgid ""
 "Legions are heavily armed and well disciplined infantry units with an "
 "excellent offensive value."
@@ -21916,8 +21999,8 @@ msgstr ""
 "hyökkäysteho on erinomainen."
 
 #: data/civ1/units.ruleset:483 data/civ2/units.ruleset:598
-#: data/classic/units.ruleset:741 data/sandbox/units.ruleset:809
-#: data/civ2civ3/units.ruleset:799 data/multiplayer/units.ruleset:741
+#: data/classic/units.ruleset:744 data/sandbox/units.ruleset:812
+#: data/civ2civ3/units.ruleset:802 data/multiplayer/units.ruleset:744
 msgid "Musketeers"
 msgstr "Muskettijoukkue"
 
@@ -21930,14 +22013,14 @@ msgstr ""
 "Ne korvaavat falangin suositeltuna kaupunginpuolustajana."
 
 #: data/civ1/units.ruleset:517 data/civ2/units.ruleset:739
-#: data/classic/units.ruleset:847 data/sandbox/units.ruleset:843
-#: data/civ2civ3/units.ruleset:833 data/multiplayer/units.ruleset:882
+#: data/classic/units.ruleset:850 data/sandbox/units.ruleset:846
+#: data/civ2civ3/units.ruleset:836 data/multiplayer/units.ruleset:885
 msgid "Riflemen"
 msgstr "Kiväärijoukkue"
 
 #: data/civ1/units.ruleset:543 data/civ2/units.ruleset:765
-#: data/classic/units.ruleset:873 data/sandbox/units.ruleset:869
-#: data/civ2civ3/units.ruleset:859 data/multiplayer/units.ruleset:908
+#: data/classic/units.ruleset:876 data/sandbox/units.ruleset:872
+#: data/civ2civ3/units.ruleset:862 data/multiplayer/units.ruleset:911
 msgid ""
 "Riflemen are World War-era infantry, very good at defending your cities."
 msgstr ""
@@ -21946,8 +22029,8 @@ msgstr ""
 
 # Liberal translation
 #: data/civ1/units.ruleset:549 data/civ2/units.ruleset:841
-#: data/classic/units.ruleset:949 data/sandbox/units.ruleset:1063
-#: data/civ2civ3/units.ruleset:1053 data/multiplayer/units.ruleset:984
+#: data/classic/units.ruleset:952 data/sandbox/units.ruleset:1066
+#: data/civ2civ3/units.ruleset:1056 data/multiplayer/units.ruleset:987
 msgid "Mech. Inf."
 msgstr "Panssarijalkaväki"
 
@@ -21960,8 +22043,8 @@ msgstr ""
 "on käytettävissä vasta aivan pelin loppuvaiheessa."
 
 #: data/civ1/units.ruleset:582 data/civ2/units.ruleset:1067
-#: data/classic/units.ruleset:1111 data/sandbox/units.ruleset:1294
-#: data/civ2civ3/units.ruleset:1284 data/multiplayer/units.ruleset:1210
+#: data/classic/units.ruleset:1114 data/sandbox/units.ruleset:1297
+#: data/civ2civ3/units.ruleset:1287 data/multiplayer/units.ruleset:1213
 msgid "Cavalry"
 msgstr "Ratsuväki"
 
@@ -21974,8 +22057,8 @@ msgstr ""
 "vastarinnan se voi edetä nopeasti syvälle vihollisen selustaan."
 
 #: data/civ1/units.ruleset:615 data/civ2/units.ruleset:907
-#: data/classic/units.ruleset:1015 data/sandbox/units.ruleset:1131
-#: data/civ2civ3/units.ruleset:1121 data/multiplayer/units.ruleset:1050
+#: data/classic/units.ruleset:1018 data/sandbox/units.ruleset:1134
+#: data/civ2civ3/units.ruleset:1124 data/multiplayer/units.ruleset:1053
 msgid "Chariot"
 msgstr "Sotavaunu"
 
@@ -21989,25 +22072,25 @@ msgstr ""
 "kalliimpia."
 
 #: data/civ1/units.ruleset:647 data/civ2/units.ruleset:1003
-#: data/classic/units.ruleset:1047 data/sandbox/units.ruleset:1231
-#: data/civ2civ3/units.ruleset:1221 data/multiplayer/units.ruleset:1146
+#: data/classic/units.ruleset:1050 data/sandbox/units.ruleset:1234
+#: data/civ2civ3/units.ruleset:1224 data/multiplayer/units.ruleset:1149
 msgid "Knights"
 msgstr "Ritarikaarti"
 
 #: data/civ1/units.ruleset:674 data/civ2/units.ruleset:1030
-#: data/classic/units.ruleset:1074 data/sandbox/units.ruleset:1258
-#: data/civ2civ3/units.ruleset:1248 data/multiplayer/units.ruleset:1173
+#: data/classic/units.ruleset:1077 data/sandbox/units.ruleset:1261
+#: data/civ2civ3/units.ruleset:1251 data/multiplayer/units.ruleset:1176
 msgid "Knights are mounted and heavily armored warriors."
 msgstr "Ritarit ovat raskaasti haarniskoituja ja ratsain liikkuvia sotureita."
 
 #: data/civ1/units.ruleset:679 data/civ2/units.ruleset:1098
-#: data/classic/units.ruleset:1142 data/sandbox/units.ruleset:1325
-#: data/civ2civ3/units.ruleset:1315 data/multiplayer/units.ruleset:1241
+#: data/classic/units.ruleset:1145 data/sandbox/units.ruleset:1328
+#: data/civ2civ3/units.ruleset:1318 data/multiplayer/units.ruleset:1244
 msgid "Armor"
 msgstr "Panssarivaunu"
 
 #: data/civ1/units.ruleset:705 data/civ2/units.ruleset:1124
-#: data/classic/units.ruleset:1168 data/multiplayer/units.ruleset:1267
+#: data/classic/units.ruleset:1171 data/multiplayer/units.ruleset:1270
 msgid ""
 "Armors are motorized war wagons that are faster, stronger, and can take more "
 "damage than any mounted unit."
@@ -22017,14 +22100,14 @@ msgstr ""
 "hevosvoiman ratsuyksikkö."
 
 #: data/civ1/units.ruleset:712 data/civ2/units.ruleset:1131
-#: data/classic/units.ruleset:1175 data/sandbox/units.ruleset:1360
-#: data/civ2civ3/units.ruleset:1350 data/multiplayer/units.ruleset:1274
+#: data/classic/units.ruleset:1178 data/sandbox/units.ruleset:1363
+#: data/civ2civ3/units.ruleset:1353 data/multiplayer/units.ruleset:1277
 msgid "Catapult"
 msgstr "Katapultti"
 
 #: data/civ1/units.ruleset:738 data/civ2/units.ruleset:1157
-#: data/classic/units.ruleset:1201 data/sandbox/units.ruleset:1386
-#: data/civ2civ3/units.ruleset:1376 data/multiplayer/units.ruleset:1300
+#: data/classic/units.ruleset:1204 data/sandbox/units.ruleset:1389
+#: data/civ2civ3/units.ruleset:1379 data/multiplayer/units.ruleset:1303
 msgid ""
 "Catapults are large rock-throwing machines of war. They are very strong "
 "attackers but equally weak defenders and will need an escort to be effective."
@@ -22034,13 +22117,13 @@ msgstr ""
 "toimiakseen tehokkaasti."
 
 #: data/civ1/units.ruleset:745 data/civ2/units.ruleset:1164
-#: data/classic/units.ruleset:1208 data/sandbox/units.ruleset:1398
-#: data/civ2civ3/units.ruleset:1388 data/multiplayer/units.ruleset:1307
+#: data/classic/units.ruleset:1211 data/sandbox/units.ruleset:1401
+#: data/civ2civ3/units.ruleset:1391 data/multiplayer/units.ruleset:1310
 msgid "Cannon"
 msgstr "Kanuuna"
 
 #: data/civ1/units.ruleset:771 data/civ2/units.ruleset:1190
-#: data/classic/units.ruleset:1234 data/multiplayer/units.ruleset:1333
+#: data/classic/units.ruleset:1237 data/multiplayer/units.ruleset:1336
 msgid ""
 "Cannons are large firearms that can fire heavy projectiles over long "
 "distances. They are very strong attackers but equally weak defenders and "
@@ -22051,8 +22134,8 @@ msgstr ""
 "tarvitsevat siksi saattojoukkoja toimiakseen tehokkaasti."
 
 #: data/civ1/units.ruleset:779 data/civ2/units.ruleset:1198
-#: data/classic/units.ruleset:1242 data/sandbox/units.ruleset:1432
-#: data/civ2civ3/units.ruleset:1422 data/multiplayer/units.ruleset:1341
+#: data/classic/units.ruleset:1245 data/sandbox/units.ruleset:1435
+#: data/civ2civ3/units.ruleset:1425 data/multiplayer/units.ruleset:1344
 msgid "Artillery"
 msgstr "Tykistö"
 
@@ -22066,14 +22149,14 @@ msgstr ""
 "näiden vaikutuksen puolustukseen huomiotta."
 
 #: data/civ1/units.ruleset:812 data/civ2/units.ruleset:1264
-#: data/classic/units.ruleset:1308 data/sandbox/units.ruleset:1498
-#: data/civ2civ3/units.ruleset:1488 data/multiplayer/units.ruleset:1407
+#: data/classic/units.ruleset:1311 data/sandbox/units.ruleset:1501
+#: data/civ2civ3/units.ruleset:1491 data/multiplayer/units.ruleset:1410
 msgid "Fighter"
 msgstr "Hävittäjäkone"
 
 #: data/civ1/units.ruleset:839 data/civ2/units.ruleset:1296
-#: data/classic/units.ruleset:1340 data/sandbox/units.ruleset:1525
-#: data/civ2civ3/units.ruleset:1515 data/multiplayer/units.ruleset:1439
+#: data/classic/units.ruleset:1343 data/sandbox/units.ruleset:1528
+#: data/civ2civ3/units.ruleset:1518 data/multiplayer/units.ruleset:1442
 msgid ""
 "Fighters are your first airborne units. They can move anywhere and attack "
 "any unit."
@@ -22082,14 +22165,14 @@ msgstr ""
 "mihin tahansa ja hyökätä minkä tahansa yksikön kimppuun."
 
 #: data/civ1/units.ruleset:845 data/civ2/units.ruleset:1302
-#: data/classic/units.ruleset:1346 data/sandbox/units.ruleset:1536
-#: data/civ2civ3/units.ruleset:1526 data/multiplayer/units.ruleset:1445
+#: data/classic/units.ruleset:1349 data/sandbox/units.ruleset:1539
+#: data/civ2civ3/units.ruleset:1529 data/multiplayer/units.ruleset:1448
 msgid "Bomber"
 msgstr "Pommikone"
 
 #: data/civ1/units.ruleset:871 data/civ2/units.ruleset:1328
-#: data/classic/units.ruleset:1372 data/sandbox/units.ruleset:1562
-#: data/civ2civ3/units.ruleset:1552 data/multiplayer/units.ruleset:1471
+#: data/classic/units.ruleset:1375 data/sandbox/units.ruleset:1565
+#: data/civ2civ3/units.ruleset:1555 data/multiplayer/units.ruleset:1474
 msgid ""
 "Bombers are specialized airborne units that may only attack ground targets, "
 "not other airborne units."
@@ -22101,8 +22184,8 @@ msgstr ""
 # Finnish translations of some naval units based on Jussi Mannerberg's book (JARKKO)
 #. TRANS: unit type
 #: data/civ1/units.ruleset:879 data/civ2/units.ruleset:1442
-#: data/classic/units.ruleset:1489 data/sandbox/units.ruleset:1691
-#: data/civ2civ3/units.ruleset:1681 data/multiplayer/units.ruleset:1587
+#: data/classic/units.ruleset:1492 data/sandbox/units.ruleset:1694
+#: data/civ2civ3/units.ruleset:1684 data/multiplayer/units.ruleset:1590
 msgid "Trireme"
 msgstr "Kaleeri"
 
@@ -22125,13 +22208,13 @@ msgid ""
 msgstr "Purjelaiva korvaa kaleerin ja on sitä paljon luotettavampi avomerellä."
 
 #: data/civ1/units.ruleset:946 data/civ2/units.ruleset:1543
-#: data/classic/units.ruleset:1590 data/sandbox/units.ruleset:1795
-#: data/civ2civ3/units.ruleset:1784 data/multiplayer/units.ruleset:1688
+#: data/classic/units.ruleset:1593 data/sandbox/units.ruleset:1798
+#: data/civ2civ3/units.ruleset:1787 data/multiplayer/units.ruleset:1691
 msgid "Frigate"
 msgstr "Fregatti"
 
 #: data/civ1/units.ruleset:973 data/civ2/units.ruleset:1570
-#: data/classic/units.ruleset:1617 data/multiplayer/units.ruleset:1715
+#: data/classic/units.ruleset:1620 data/multiplayer/units.ruleset:1718
 msgid ""
 "The Frigate is a highly versatile boat unit, that is both a strong offensive "
 "unit as well as a decent transport ship."
@@ -22140,13 +22223,13 @@ msgstr ""
 "kuljetusalus."
 
 #: data/civ1/units.ruleset:980 data/civ2/units.ruleset:1577
-#: data/classic/units.ruleset:1624 data/sandbox/units.ruleset:1827
-#: data/civ2civ3/units.ruleset:1816 data/multiplayer/units.ruleset:1722
+#: data/classic/units.ruleset:1627 data/sandbox/units.ruleset:1830
+#: data/civ2civ3/units.ruleset:1819 data/multiplayer/units.ruleset:1725
 msgid "Ironclad"
 msgstr "Panssarilaiva"
 
 #: data/civ1/units.ruleset:1006 data/civ2/units.ruleset:1603
-#: data/classic/units.ruleset:1650 data/multiplayer/units.ruleset:1748
+#: data/classic/units.ruleset:1653 data/multiplayer/units.ruleset:1751
 msgid ""
 "The Ironclad is an armored ship that is much more sturdy than the Frigate "
 "but loses the latter's transport capability."
@@ -22155,26 +22238,26 @@ msgstr ""
 "muttei kykene sen tavoin kuljettamaan yksiköitä."
 
 #: data/civ1/units.ruleset:1013 data/civ2/units.ruleset:1644
-#: data/classic/units.ruleset:1691 data/sandbox/units.ruleset:1898
-#: data/civ2civ3/units.ruleset:1887 data/multiplayer/units.ruleset:1789
+#: data/classic/units.ruleset:1694 data/sandbox/units.ruleset:1901
+#: data/civ2civ3/units.ruleset:1890 data/multiplayer/units.ruleset:1792
 msgid "Cruiser"
 msgstr "Risteilijä"
 
 #: data/civ1/units.ruleset:1039 data/civ2/units.ruleset:1670
-#: data/classic/units.ruleset:1717 data/sandbox/units.ruleset:1924
-#: data/civ2civ3/units.ruleset:1913 data/multiplayer/units.ruleset:1815
+#: data/classic/units.ruleset:1720 data/sandbox/units.ruleset:1927
+#: data/civ2civ3/units.ruleset:1916 data/multiplayer/units.ruleset:1818
 msgid "The Cruiser is a strong offensive boat unit."
 msgstr "Risteilijä on hyökkäysteholtaan vahva alus."
 
 #: data/civ1/units.ruleset:1044 data/civ2/units.ruleset:1711
-#: data/classic/units.ruleset:1758 data/sandbox/units.ruleset:1965
-#: data/civ2civ3/units.ruleset:1954 data/multiplayer/units.ruleset:1856
+#: data/classic/units.ruleset:1761 data/sandbox/units.ruleset:1968
+#: data/civ2civ3/units.ruleset:1957 data/multiplayer/units.ruleset:1859
 msgid "Battleship"
 msgstr "Taistelulaiva"
 
 #: data/civ1/units.ruleset:1070 data/civ2/units.ruleset:1737
-#: data/classic/units.ruleset:1784 data/sandbox/units.ruleset:1995
-#: data/civ2civ3/units.ruleset:1980 data/multiplayer/units.ruleset:1882
+#: data/classic/units.ruleset:1787 data/sandbox/units.ruleset:1998
+#: data/civ2civ3/units.ruleset:1983 data/multiplayer/units.ruleset:1885
 msgid ""
 "The Battleship is the supreme naval unit with excellent offensive and "
 "defensive values."
@@ -22183,15 +22266,15 @@ msgstr ""
 "puolustusteho ovat erinomaisia."
 
 #: data/civ1/units.ruleset:1076 data/civ2/units.ruleset:1743
-#: data/classic/units.ruleset:1790 data/sandbox/units.ruleset:33
-#: data/sandbox/units.ruleset:2001 data/civ2civ3/units.ruleset:33
-#: data/civ2civ3/units.ruleset:1986 data/multiplayer/units.ruleset:1888
+#: data/classic/units.ruleset:1793 data/sandbox/units.ruleset:33
+#: data/sandbox/units.ruleset:2004 data/civ2civ3/units.ruleset:33
+#: data/civ2civ3/units.ruleset:1989 data/multiplayer/units.ruleset:1891
 msgid "Submarine"
 msgstr "Sukellusvene"
 
 #: data/civ1/units.ruleset:1103 data/civ2/units.ruleset:1772
-#: data/classic/units.ruleset:1819 data/sandbox/units.ruleset:2030
-#: data/civ2civ3/units.ruleset:2015 data/multiplayer/units.ruleset:1917
+#: data/classic/units.ruleset:1822 data/sandbox/units.ruleset:2033
+#: data/civ2civ3/units.ruleset:2018 data/multiplayer/units.ruleset:1920
 msgid ""
 "Traveling under the surface of the ocean, Submarines have a very high "
 "strategic value, but a weak defense if caught off guard."
@@ -22200,20 +22283,20 @@ msgstr ""
 "arvoa, mutta ne ovat heikkoja puolustautumaan tullessaan yllätetyiksi."
 
 #: data/civ1/units.ruleset:1110 data/civ2/units.ruleset:1779
-#: data/classic/units.ruleset:1826 data/sandbox/units.ruleset:2037
-#: data/civ2civ3/units.ruleset:2022 data/multiplayer/units.ruleset:1924
+#: data/classic/units.ruleset:1829 data/sandbox/units.ruleset:2040
+#: data/civ2civ3/units.ruleset:2025 data/multiplayer/units.ruleset:1927
 msgid "Carrier"
 msgstr "Lentotukialus"
 
 #: data/civ1/units.ruleset:1137 data/civ2/units.ruleset:1806
-#: data/classic/units.ruleset:1853 data/sandbox/units.ruleset:2066
-#: data/civ2civ3/units.ruleset:2049 data/multiplayer/units.ruleset:1951
+#: data/classic/units.ruleset:1856 data/sandbox/units.ruleset:2069
+#: data/civ2civ3/units.ruleset:2052 data/multiplayer/units.ruleset:1954
 msgid "The Carrier is a mobile airport."
 msgstr "Lentotukialus on liikkuva lentokenttä."
 
 #: data/civ1/units.ruleset:1139 data/civ2/units.ruleset:1808
-#: data/classic/units.ruleset:1855 data/sandbox/units.ruleset:2072
-#: data/civ2civ3/units.ruleset:2055 data/multiplayer/units.ruleset:1953
+#: data/classic/units.ruleset:1858 data/sandbox/units.ruleset:2075
+#: data/civ2civ3/units.ruleset:2058 data/multiplayer/units.ruleset:1956
 msgid ""
 "TIP:  Guard Carriers with a handful of fast-moving ships and a battleship, "
 "as losing a fully-equipped Carrier is VERY painful and expensive."
@@ -22223,14 +22306,14 @@ msgstr ""
 "tuskallista ja kallista."
 
 #: data/civ1/units.ruleset:1146 data/civ2/units.ruleset:1815
-#: data/classic/units.ruleset:1862 data/sandbox/units.ruleset:2079
-#: data/civ2civ3/units.ruleset:2062 data/multiplayer/units.ruleset:1960
+#: data/classic/units.ruleset:1865 data/sandbox/units.ruleset:2082
+#: data/civ2civ3/units.ruleset:2065 data/multiplayer/units.ruleset:1963
 msgid "Transport"
 msgstr "Rahtilaiva"
 
 #: data/civ1/units.ruleset:1173 data/civ2/units.ruleset:1842
-#: data/classic/units.ruleset:1889 data/sandbox/units.ruleset:2112
-#: data/civ2civ3/units.ruleset:2095 data/multiplayer/units.ruleset:1987
+#: data/classic/units.ruleset:1892 data/sandbox/units.ruleset:2115
+#: data/civ2civ3/units.ruleset:2098 data/multiplayer/units.ruleset:1990
 msgid ""
 "The Transport cannot attack on its own but may defend itself when under "
 "attack."
@@ -22238,7 +22321,7 @@ msgstr ""
 "Rahtilaiva ei voi hyökätä itse, mutta voi puolustautua hyökkäystä vastaan."
 
 #: data/civ1/units.ruleset:1205 data/civ2/units.ruleset:1909
-#: data/classic/units.ruleset:1962 data/multiplayer/units.ruleset:2060
+#: data/classic/units.ruleset:1965 data/multiplayer/units.ruleset:2063
 msgid ""
 "You can build Nuclear units when you have the required advance, and the "
 "Manhattan Project wonder has been built by any player."
@@ -22267,7 +22350,7 @@ msgstr ""
 "voi jäädä ydinlaskeumaa."
 
 #: data/civ1/units.ruleset:1214 data/civ2/units.ruleset:1918
-#: data/classic/units.ruleset:1973 data/multiplayer/units.ruleset:2071
+#: data/classic/units.ruleset:1976 data/multiplayer/units.ruleset:2074
 msgid ""
 "TIP 1:  Nuking the ocean will not generate fallout, and is a most effective "
 "(but expensive!!) way of getting rid of enemy ships."
@@ -22298,14 +22381,14 @@ msgstr ""
 "ympäristöystävällisesti!"
 
 #: data/civ1/units.ruleset:1228 data/civ2/units.ruleset:1932
-#: data/classic/units.ruleset:1987 data/sandbox/units.ruleset:2221
-#: data/civ2civ3/units.ruleset:2201 data/multiplayer/units.ruleset:2085
+#: data/classic/units.ruleset:1990 data/sandbox/units.ruleset:2224
+#: data/civ2civ3/units.ruleset:2204 data/multiplayer/units.ruleset:2088
 msgid "Diplomat"
 msgstr "Diplomaatti"
 
 #: data/civ1/units.ruleset:1259 data/civ2/units.ruleset:1963
-#: data/classic/units.ruleset:2026 data/sandbox/units.ruleset:2262
-#: data/civ2civ3/units.ruleset:2242 data/multiplayer/units.ruleset:2124
+#: data/classic/units.ruleset:2029 data/sandbox/units.ruleset:2265
+#: data/civ2civ3/units.ruleset:2245 data/multiplayer/units.ruleset:2127
 msgid ""
 "A Diplomat is an official that carries your dispatches and is authorized to "
 "deal with foreign dignitaries. He may also undertake various covert "
@@ -22318,7 +22401,7 @@ msgstr ""
 "Omissa kaupungeissasi diplomaatit antavat suojaa peiteoperaatioita vastaan."
 
 #: data/civ1/units.ruleset:1265 data/civ2/units.ruleset:1969
-#: data/classic/units.ruleset:2032 data/multiplayer/units.ruleset:2130
+#: data/classic/units.ruleset:2035 data/multiplayer/units.ruleset:2133
 msgid ""
 "Many covert actions may be attempted even in peacetime, but the more "
 "aggressive actions will be discovered and cause diplomatic incidents, which "
@@ -22330,7 +22413,7 @@ msgstr ""
 "niitä sitovat sopimukset."
 
 #: data/civ1/units.ruleset:1269 data/civ2/units.ruleset:1973
-#: data/classic/units.ruleset:2036 data/multiplayer/units.ruleset:2134
+#: data/classic/units.ruleset:2039 data/multiplayer/units.ruleset:2137
 msgid ""
 "If a foreign unit is alone on a tile, you may attempt to bribe it with your "
 "Diplomat. By paying a sum of gold the unit will immediately become yours; "
@@ -22362,13 +22445,13 @@ msgstr ""
 "menetät yhden liikepisteen ja voit yrittää uudelleen."
 
 #: data/civ1/units.ruleset:1283 data/civ2/units.ruleset:1987
-#: data/classic/units.ruleset:2051 data/sandbox/units.ruleset:2289
-#: data/civ2civ3/units.ruleset:2269 data/multiplayer/units.ruleset:2149
+#: data/classic/units.ruleset:2054 data/sandbox/units.ruleset:2292
+#: data/civ2civ3/units.ruleset:2272 data/multiplayer/units.ruleset:2152
 msgid "The actions available to Diplomats in a city are:"
 msgstr "Diplomaatille mahdolliset toimet kaupungissa ovat:"
 
 #: data/civ1/units.ruleset:1285 data/civ2/units.ruleset:1989
-#: data/classic/units.ruleset:2053 data/multiplayer/units.ruleset:2151
+#: data/classic/units.ruleset:2056 data/multiplayer/units.ruleset:2154
 msgid ""
 " - \"Establish Embassy\": This action always succeeds, and gives permanent "
 "contact with the city's owner, as well as intelligence on their tax rates "
@@ -22379,9 +22462,9 @@ msgstr ""
 "veroasteista ja teknologioista."
 
 #: data/civ1/units.ruleset:1289 data/civ2/units.ruleset:1993
-#: data/classic/units.ruleset:2057 data/sandbox/units.ruleset:2297
-#: data/sandbox/units.ruleset:2525 data/civ2civ3/units.ruleset:2277
-#: data/civ2civ3/units.ruleset:2504 data/multiplayer/units.ruleset:2155
+#: data/classic/units.ruleset:2060 data/sandbox/units.ruleset:2300
+#: data/sandbox/units.ruleset:2528 data/civ2civ3/units.ruleset:2280
+#: data/civ2civ3/units.ruleset:2507 data/multiplayer/units.ruleset:2158
 msgid ""
 " - \"Investigate City\": Your unit attempts to report detailed information "
 "about the city: its status, what buildings and units are within, and what it "
@@ -22392,8 +22475,8 @@ msgstr ""
 "nykyinen tuotantohanke."
 
 #: data/civ1/units.ruleset:1293 data/civ2/units.ruleset:1997
-#: data/classic/units.ruleset:2061 data/sandbox/units.ruleset:2301
-#: data/civ2civ3/units.ruleset:2281 data/multiplayer/units.ruleset:2159
+#: data/classic/units.ruleset:2064 data/sandbox/units.ruleset:2304
+#: data/civ2civ3/units.ruleset:2284 data/multiplayer/units.ruleset:2162
 msgid ""
 " - \"Sabotage City\": Your unit attempts either to disrupt all the city's "
 "work so far towards its current project, or to destroy an existing building "
@@ -22409,8 +22492,8 @@ msgstr ""
 "vain kun osapuolet ovat avoimesti sodassa keskenään."
 
 #: data/civ1/units.ruleset:1300 data/civ2/units.ruleset:2004
-#: data/classic/units.ruleset:2068 data/sandbox/units.ruleset:2308
-#: data/civ2civ3/units.ruleset:2288 data/multiplayer/units.ruleset:2166
+#: data/classic/units.ruleset:2071 data/sandbox/units.ruleset:2311
+#: data/civ2civ3/units.ruleset:2291 data/multiplayer/units.ruleset:2169
 msgid ""
 " - \"Steal Technology\": Your unit attempts to learn the secrets of a random "
 "technology known to the city's owner but not to you. Technology may only be "
@@ -22424,7 +22507,7 @@ msgstr ""
 "selkkauksen."
 
 #: data/civ1/units.ruleset:1306 data/civ2/units.ruleset:2010
-#: data/classic/units.ruleset:2074 data/multiplayer/units.ruleset:2172
+#: data/classic/units.ruleset:2077 data/multiplayer/units.ruleset:2175
 msgid ""
 " - \"Incite a Revolt\": In return for gold a foreign city will change "
 "allegiance and join your empire, bringing along all nearby units that call "
@@ -22445,8 +22528,8 @@ msgstr ""
 "aikana, mutta se aiheuttaa diplomaattisen selkkauksen."
 
 #: data/civ1/units.ruleset:1316 data/civ2/units.ruleset:2020
-#: data/classic/units.ruleset:2084 data/sandbox/units.ruleset:2324
-#: data/civ2civ3/units.ruleset:2304 data/multiplayer/units.ruleset:2182
+#: data/classic/units.ruleset:2087 data/sandbox/units.ruleset:2327
+#: data/civ2civ3/units.ruleset:2307 data/multiplayer/units.ruleset:2185
 msgid ""
 "In some game strategies, hordes of Diplomats can be used to wreak havoc on "
 "the enemy.  Little wonder that Diplomats are often viewed with suspicion and "
@@ -22457,14 +22540,14 @@ msgstr ""
 "epäilystä ja pelkoa!"
 
 #: data/civ1/units.ruleset:1323 data/civ2/units.ruleset:2087
-#: data/classic/units.ruleset:2164 data/sandbox/units.ruleset:2405
-#: data/civ2civ3/units.ruleset:2385 data/alien/units.ruleset:1352
-#: data/multiplayer/units.ruleset:2262
+#: data/classic/units.ruleset:2167 data/sandbox/units.ruleset:2408
+#: data/civ2civ3/units.ruleset:2388 data/alien/units.ruleset:1355
+#: data/multiplayer/units.ruleset:2265
 msgid "Caravan"
 msgstr "Karavaani"
 
 #: data/civ1/units.ruleset:1349 data/civ2/units.ruleset:2113
-#: data/classic/units.ruleset:2190
+#: data/classic/units.ruleset:2193
 msgid ""
 "A Caravan carries goods or material for trading with distant cities and "
 "foreign countries, or to help build wonders in your cities."
@@ -22496,7 +22579,7 @@ msgstr ""
 "olla kolmen kauppareitin päätepiste."
 
 #: data/civ1/units.ruleset:1362 data/civ2/units.ruleset:2126
-#: data/classic/units.ruleset:2206
+#: data/classic/units.ruleset:2209
 msgid ""
 "Every Caravan that is used to build a wonder will add 50 shields towards the "
 "production of the wonder."
@@ -22505,8 +22588,8 @@ msgstr ""
 "valmistumista 50:llä yksiköllä."
 
 #: data/civ1/units.ruleset:1365 data/civ2/units.ruleset:2129
-#: data/classic/units.ruleset:2209 data/sandbox/units.ruleset:2447
-#: data/civ2civ3/units.ruleset:2426 data/multiplayer/units.ruleset:2294
+#: data/classic/units.ruleset:2212 data/sandbox/units.ruleset:2450
+#: data/civ2civ3/units.ruleset:2429 data/multiplayer/units.ruleset:2297
 msgid ""
 "TIP:  You can stockpile a stack of Caravans in advance and bring them all "
 "into a city where you have started to build a wonder, and finish it in only "
@@ -22517,14 +22600,14 @@ msgstr ""
 "valmiiksi yhden vuoron aikana!"
 
 #: data/civ1/units.ruleset:1372 data/civ2/units.ruleset:2199
-#: data/classic/units.ruleset:2320 data/sandbox/units.ruleset:2573
-#: data/civ2civ3/units.ruleset:2552 data/multiplayer/units.ruleset:2406
+#: data/classic/units.ruleset:2323 data/sandbox/units.ruleset:2576
+#: data/civ2civ3/units.ruleset:2555 data/multiplayer/units.ruleset:2409
 msgid "Barbarian Leader"
 msgstr "Barbaarijohtaja"
 
 #: data/civ1/units.ruleset:1398 data/civ2/units.ruleset:2225
-#: data/classic/units.ruleset:2353 data/sandbox/units.ruleset:2606
-#: data/civ2civ3/units.ruleset:2585 data/multiplayer/units.ruleset:2439
+#: data/classic/units.ruleset:2356 data/sandbox/units.ruleset:2609
+#: data/civ2civ3/units.ruleset:2588 data/multiplayer/units.ruleset:2442
 msgid ""
 "One Barbarian Leader appears every time there is a barbarian uprising "
 "somewhere in the world."
@@ -23158,7 +23241,7 @@ msgstr ""
 msgid "Civ2 ruleset"
 msgstr "Civ2-sääntökokoelma"
 
-#: data/civ2/game.ruleset:32
+#: data/civ2/game.ruleset:38
 #, fuzzy
 #| msgid ""
 #| "You are playing with civ2 style rules. These are quite close to Freeciv "
@@ -23171,40 +23254,40 @@ msgstr ""
 "oletussääntöjä, mutta sisältävät pieniä lisäyksiä."
 
 #. TRANS: Plant _Nuclear Device (3% chance of success).
-#: data/civ2/game.ruleset:276
+#: data/civ2/game.ruleset:286
 #, c-format
 msgid "Plant %sNuclear Device%s"
 msgstr "%sPiiluta ydinlataus%s"
 
 #. TRANS: _Sabotage Enemy Unit (3% chance of success).
-#: data/civ2/game.ruleset:279 data/classic/game.ruleset:283
-#: data/sandbox/game.ruleset:286 data/civ2civ3/game.ruleset:288
-#: data/multiplayer/game.ruleset:286
+#: data/civ2/game.ruleset:289 data/classic/game.ruleset:293
+#: data/sandbox/game.ruleset:296 data/civ2civ3/game.ruleset:298
+#: data/multiplayer/game.ruleset:296
 #, c-format
 msgid "%sSabotage Enemy Unit%s"
 msgstr "%sSabotoi vihollisen yksikkö%s"
 
 #. TRANS: _Sabotage City Escape (3% chance of success).
-#: data/civ2/game.ruleset:288 data/classic/game.ruleset:292
-#: data/sandbox/game.ruleset:295 data/civ2civ3/game.ruleset:297
-#: data/multiplayer/game.ruleset:295
+#: data/civ2/game.ruleset:298 data/classic/game.ruleset:302
+#: data/sandbox/game.ruleset:305 data/civ2civ3/game.ruleset:307
+#: data/multiplayer/game.ruleset:305
 #, fuzzy, c-format
 #| msgid "%sSabotage City%s"
 msgid "%sSabotage City Escape%s"
 msgstr "%sSabotoi kaupunkia%s"
 
 #. TRANS: Industrial _Sabotage (3% chance of success).
-#: data/civ2/game.ruleset:291 data/classic/game.ruleset:295
-#: data/sandbox/game.ruleset:298 data/civ2civ3/game.ruleset:300
-#: data/multiplayer/game.ruleset:298
+#: data/civ2/game.ruleset:301 data/classic/game.ruleset:305
+#: data/sandbox/game.ruleset:308 data/civ2civ3/game.ruleset:310
+#: data/multiplayer/game.ruleset:308
 #, c-format
 msgid "Industrial %sSabotage%s"
 msgstr "%sSabotoi tuotantoa%s"
 
 #. TRANS: Indus_trial Espionage (3% chance of success).
-#: data/civ2/game.ruleset:312 data/classic/game.ruleset:316
-#: data/sandbox/game.ruleset:319 data/civ2civ3/game.ruleset:321
-#: data/multiplayer/game.ruleset:319
+#: data/civ2/game.ruleset:322 data/classic/game.ruleset:326
+#: data/sandbox/game.ruleset:329 data/civ2civ3/game.ruleset:331
+#: data/multiplayer/game.ruleset:329
 #, c-format
 msgid "Indus%strial Espionage%s"
 msgstr "%sTeollisuusvakoilu%s"
@@ -23798,15 +23881,15 @@ msgstr ""
 "Jäätiköitä on vain kaikkein pohjoisimmilla ja eteläisimmillä alueilla. Ne "
 "ovat hyvin kylmiä ja sen vuoksi vaikeita hyödyntää."
 
-#: data/civ2/terrain.ruleset:817 data/alien/terrain.ruleset:613
+#: data/civ2/terrain.ruleset:819 data/alien/terrain.ruleset:615
 msgid "?gui_type:Build Land base"
 msgstr "Rakenna maatukikohta"
 
-#: data/civ2/terrain.ruleset:818 data/alien/terrain.ruleset:614
+#: data/civ2/terrain.ruleset:822 data/alien/terrain.ruleset:618
 msgid "?gui_type:Build Airforce base"
 msgstr "Rakenna ilmavoimien tukikohta"
 
-#: data/civ2/terrain.ruleset:1022
+#: data/civ2/terrain.ruleset:1028
 msgid ""
 "The pollution can only be cleared by dispatching Settlers or Engineers with "
 "the \"clean pollution\" order."
@@ -23814,9 +23897,9 @@ msgstr ""
 "Saaste voidaan poistaa vain komentamalla uudisraivaajat tai teknikot \\"
 "\"siivoamaan\\\" sitä."
 
-#: data/civ2/terrain.ruleset:1083 data/classic/terrain.ruleset:1296
-#: data/sandbox/terrain.ruleset:1352 data/civ2civ3/terrain.ruleset:1351
-#: data/multiplayer/terrain.ruleset:1271
+#: data/civ2/terrain.ruleset:1089 data/classic/terrain.ruleset:1302
+#: data/sandbox/terrain.ruleset:1358 data/civ2civ3/terrain.ruleset:1357
+#: data/multiplayer/terrain.ruleset:1277
 msgid ""
 "Later in the game, helicopters may also enter villages, but overflight by "
 "other aircraft will cause the villagers to take fright and disband."
@@ -23824,14 +23907,14 @@ msgstr ""
 "Pelin edetessä myös helikopterit voivat tutkia kyliä mutta muiden ilma-"
 "alusten ylilento saa kyläläiset paniikkiin ja kylän tyhjenemään."
 
-#: data/civ2/terrain.ruleset:1089 data/classic/terrain.ruleset:1302
-#: data/sandbox/terrain.ruleset:1388 data/civ2civ3/terrain.ruleset:1357
-#: data/multiplayer/terrain.ruleset:1277
+#: data/civ2/terrain.ruleset:1095 data/classic/terrain.ruleset:1308
+#: data/sandbox/terrain.ruleset:1393 data/civ2civ3/terrain.ruleset:1363
+#: data/multiplayer/terrain.ruleset:1283
 msgid "Farmland"
 msgstr "peltomaa"
 
-#: data/civ2/terrain.ruleset:1109 data/classic/terrain.ruleset:1322
-#: data/sandbox/terrain.ruleset:1410 data/civ2civ3/terrain.ruleset:1379
+#: data/civ2/terrain.ruleset:1115 data/classic/terrain.ruleset:1328
+#: data/sandbox/terrain.ruleset:1415 data/civ2civ3/terrain.ruleset:1385
 #, no-c-format
 msgid ""
 "Once Refrigeration is known, irrigation systems can be upgraded to farmland "
@@ -23842,12 +23925,12 @@ msgstr ""
 "viljelysmaaksi kastelemalla ne toiseen kertaan; jos ruutua työstävällä "
 "kaupungilla on supermarketti, ruutu tuottaa 50% enemmän ruokaa."
 
-#: data/civ2/terrain.ruleset:1113
+#: data/civ2/terrain.ruleset:1119
 msgid "Like irrigation, farmland is incompatible with mines."
 msgstr ""
 "Kastelujärjestelmän tapaan viljelysmaa ei sovi yhteen kaivosten kanssa."
 
-#: data/civ2/terrain.ruleset:1141
+#: data/civ2/terrain.ruleset:1147
 #, fuzzy
 #| msgid ""
 #| "Fortresses improve defense for land units. Among other effects, a land "
@@ -23862,16 +23945,16 @@ msgstr ""
 "Muiden vaikutusten ohessa linnoituksessa vuoron ajan liikkumatta elpyvä "
 "maavoimien yksikkö saa takaisin neljäsosan voimapisteistään."
 
-#: data/civ2/terrain.ruleset:1152 data/civ2/units.ruleset:24
-#: data/classic/terrain.ruleset:1396 data/classic/units.ruleset:30
-#: data/sandbox/terrain.ruleset:1570 data/sandbox/units.ruleset:30
-#: data/civ2civ3/terrain.ruleset:1538 data/civ2civ3/units.ruleset:30
-#: data/multiplayer/terrain.ruleset:1370 data/multiplayer/units.ruleset:30
+#: data/civ2/terrain.ruleset:1158 data/civ2/units.ruleset:24
+#: data/classic/terrain.ruleset:1402 data/classic/units.ruleset:30
+#: data/sandbox/terrain.ruleset:1575 data/sandbox/units.ruleset:30
+#: data/civ2civ3/terrain.ruleset:1544 data/civ2civ3/units.ruleset:30
+#: data/multiplayer/terrain.ruleset:1376 data/multiplayer/units.ruleset:30
 msgid "Airbase"
 msgstr "lentotukikohta"
 
-#: data/civ2/terrain.ruleset:1175 data/classic/terrain.ruleset:1418
-#: data/multiplayer/terrain.ruleset:1392
+#: data/civ2/terrain.ruleset:1181 data/classic/terrain.ruleset:1424
+#: data/multiplayer/terrain.ruleset:1398
 #, fuzzy
 #| msgid ""
 #| "Airbases allow your air units to land and refuel. Air units in an airbase "
@@ -23884,17 +23967,17 @@ msgstr ""
 "laskeutumispaikkoina. Maavoimien yksiköt voivat hyökätä lentotukikohtaan "
 "laskeutuneiden ilmavoimien yksiköiden kimppuun."
 
-#: data/civ2/terrain.ruleset:1178 data/classic/terrain.ruleset:1421
+#: data/civ2/terrain.ruleset:1184 data/classic/terrain.ruleset:1427
 #: data/sandbox/terrain.ruleset:40 data/civ2civ3/terrain.ruleset:39
-#: data/alien/terrain.ruleset:971 data/multiplayer/terrain.ruleset:1395
+#: data/alien/terrain.ruleset:977 data/multiplayer/terrain.ruleset:1401
 #, fuzzy
 #| msgid "* Units can paradrop from this tile.\n"
 msgid "Units can paradrop from this tile."
 msgstr "· Tästä ruudusta voi lähteä maahanlaskutehtäviin.\n"
 
-#: data/civ2/terrain.ruleset:1242 data/classic/terrain.ruleset:1537
-#: data/sandbox/terrain.ruleset:1734 data/civ2civ3/terrain.ruleset:1695
-#: data/multiplayer/terrain.ruleset:1511
+#: data/civ2/terrain.ruleset:1248 data/classic/terrain.ruleset:1543
+#: data/sandbox/terrain.ruleset:1739 data/civ2civ3/terrain.ruleset:1701
+#: data/multiplayer/terrain.ruleset:1517
 msgid ""
 "A railroad also increases any shield resources produced by a tile. A tile "
 "whose road is upgraded to a railroad retains any trade bonus from the road "
@@ -23903,9 +23986,9 @@ msgstr ""
 "Rautatie lisää ruudun tuotantoa. Myös jo ennen rautatietä rakennetun tien "
 "mahdollisesti kauppaan tarjoamat bonukset säilyvät."
 
-#: data/civ2/terrain.ruleset:1246 data/classic/terrain.ruleset:1541
-#: data/sandbox/terrain.ruleset:1738 data/civ2civ3/terrain.ruleset:1699
-#: data/multiplayer/terrain.ruleset:1515
+#: data/civ2/terrain.ruleset:1252 data/classic/terrain.ruleset:1547
+#: data/sandbox/terrain.ruleset:1743 data/civ2civ3/terrain.ruleset:1705
+#: data/multiplayer/terrain.ruleset:1521
 msgid ""
 "City center tiles with roads are automatically upgraded to railroads when "
 "you learn the Railroad technology."
@@ -23913,8 +23996,8 @@ msgstr ""
 "Kaupunkien keskusruudut, joissa on jo tie, saavat rautatiet automaattisesti "
 "kun rautatieteknologia opitaan."
 
-#: data/civ2/terrain.ruleset:1268 data/classic/terrain.ruleset:1562
-#: data/multiplayer/terrain.ruleset:1536
+#: data/civ2/terrain.ruleset:1274 data/classic/terrain.ruleset:1568
+#: data/multiplayer/terrain.ruleset:1542
 #, no-c-format
 msgid ""
 "Any land terrain type may have a River on it.  A River adds 1 trade to the "
@@ -23927,75 +24010,75 @@ msgstr ""
 "Maavoimien yksiköt voivat kulkea jokea pitkin, mutta eivät kulmittain "
 "olevien jokiruutujen välillä, tavallista nopeammin."
 
-#: data/civ2/terrain.ruleset:1292 data/classic/terrain.ruleset:1586
-#: data/sandbox/terrain.ruleset:1831 data/civ2civ3/terrain.ruleset:1790
-#: data/multiplayer/terrain.ruleset:1560
+#: data/civ2/terrain.ruleset:1298 data/classic/terrain.ruleset:1592
+#: data/sandbox/terrain.ruleset:1836 data/civ2civ3/terrain.ruleset:1796
+#: data/multiplayer/terrain.ruleset:1566
 msgid "Iron"
 msgstr "rautaa"
 
-#: data/civ2/terrain.ruleset:1318 data/classic/terrain.ruleset:1612
-#: data/sandbox/terrain.ruleset:1857 data/civ2civ3/terrain.ruleset:1816
-#: data/multiplayer/terrain.ruleset:1586
+#: data/civ2/terrain.ruleset:1324 data/classic/terrain.ruleset:1618
+#: data/sandbox/terrain.ruleset:1862 data/civ2civ3/terrain.ruleset:1822
+#: data/multiplayer/terrain.ruleset:1592
 msgid "Furs"
 msgstr "turkiseläimiä"
 
-#: data/civ2/terrain.ruleset:1357 data/classic/terrain.ruleset:1651
-#: data/sandbox/terrain.ruleset:1896 data/civ2civ3/terrain.ruleset:1855
-#: data/multiplayer/terrain.ruleset:1625
+#: data/civ2/terrain.ruleset:1363 data/classic/terrain.ruleset:1657
+#: data/sandbox/terrain.ruleset:1901 data/civ2civ3/terrain.ruleset:1861
+#: data/multiplayer/terrain.ruleset:1631
 msgid "Fruit"
 msgstr "hedelmiä"
 
-#: data/civ2/terrain.ruleset:1383 data/classic/terrain.ruleset:1677
-#: data/sandbox/terrain.ruleset:1922 data/civ2civ3/terrain.ruleset:1881
-#: data/multiplayer/terrain.ruleset:1651
+#: data/civ2/terrain.ruleset:1389 data/classic/terrain.ruleset:1683
+#: data/sandbox/terrain.ruleset:1927 data/civ2civ3/terrain.ruleset:1887
+#: data/multiplayer/terrain.ruleset:1657
 msgid "Buffalo"
 msgstr "puhveleita"
 
-#: data/civ2/terrain.ruleset:1396 data/classic/terrain.ruleset:1690
-#: data/sandbox/terrain.ruleset:1935 data/civ2civ3/terrain.ruleset:1894
-#: data/multiplayer/terrain.ruleset:1664
+#: data/civ2/terrain.ruleset:1402 data/classic/terrain.ruleset:1696
+#: data/sandbox/terrain.ruleset:1940 data/civ2civ3/terrain.ruleset:1900
+#: data/multiplayer/terrain.ruleset:1670
 msgid "Wheat"
 msgstr "vehnää"
 
-#: data/civ2/terrain.ruleset:1422 data/classic/terrain.ruleset:1716
-#: data/sandbox/terrain.ruleset:1962 data/civ2civ3/terrain.ruleset:1921
-#: data/multiplayer/terrain.ruleset:1690
+#: data/civ2/terrain.ruleset:1428 data/classic/terrain.ruleset:1722
+#: data/sandbox/terrain.ruleset:1967 data/civ2civ3/terrain.ruleset:1927
+#: data/multiplayer/terrain.ruleset:1696
 msgid "Peat"
 msgstr "turvetta"
 
-#: data/civ2/terrain.ruleset:1435 data/classic/terrain.ruleset:1729
-#: data/sandbox/terrain.ruleset:1975 data/civ2civ3/terrain.ruleset:1934
-#: data/multiplayer/terrain.ruleset:1703
+#: data/civ2/terrain.ruleset:1441 data/classic/terrain.ruleset:1735
+#: data/sandbox/terrain.ruleset:1980 data/civ2civ3/terrain.ruleset:1940
+#: data/multiplayer/terrain.ruleset:1709
 msgid "Pheasant"
 msgstr "fasaaneja"
 
-#: data/civ2/terrain.ruleset:1461 data/classic/terrain.ruleset:1755
-#: data/sandbox/terrain.ruleset:2001 data/civ2civ3/terrain.ruleset:1960
-#: data/multiplayer/terrain.ruleset:1729
+#: data/civ2/terrain.ruleset:1467 data/classic/terrain.ruleset:1761
+#: data/sandbox/terrain.ruleset:2006 data/civ2civ3/terrain.ruleset:1966
+#: data/multiplayer/terrain.ruleset:1735
 msgid "Ivory"
 msgstr "norsunluuta"
 
-#: data/civ2/terrain.ruleset:1474 data/classic/terrain.ruleset:1768
-#: data/sandbox/terrain.ruleset:2014 data/civ2civ3/terrain.ruleset:1973
-#: data/multiplayer/terrain.ruleset:1742
+#: data/civ2/terrain.ruleset:1480 data/classic/terrain.ruleset:1774
+#: data/sandbox/terrain.ruleset:2019 data/civ2civ3/terrain.ruleset:1979
+#: data/multiplayer/terrain.ruleset:1748
 msgid "Silk"
 msgstr "silkkiä"
 
-#: data/civ2/terrain.ruleset:1487 data/classic/terrain.ruleset:1781
-#: data/sandbox/game.ruleset:1612 data/sandbox/terrain.ruleset:2027
-#: data/civ2civ3/terrain.ruleset:1986 data/multiplayer/terrain.ruleset:1755
+#: data/civ2/terrain.ruleset:1493 data/classic/terrain.ruleset:1787
+#: data/sandbox/game.ruleset:1627 data/sandbox/terrain.ruleset:2032
+#: data/civ2civ3/terrain.ruleset:1992 data/multiplayer/terrain.ruleset:1761
 msgid "Spice"
 msgstr "mausteita"
 
-#: data/civ2/terrain.ruleset:1500 data/classic/terrain.ruleset:1794
-#: data/sandbox/terrain.ruleset:2040 data/civ2civ3/terrain.ruleset:1999
-#: data/multiplayer/terrain.ruleset:1768
+#: data/civ2/terrain.ruleset:1506 data/classic/terrain.ruleset:1800
+#: data/sandbox/terrain.ruleset:2045 data/civ2civ3/terrain.ruleset:2005
+#: data/multiplayer/terrain.ruleset:1774
 msgid "Whales"
 msgstr "valaita"
 
-#: data/civ2/terrain.ruleset:1513 data/classic/terrain.ruleset:1807
-#: data/sandbox/terrain.ruleset:2053 data/civ2civ3/terrain.ruleset:2012
-#: data/multiplayer/terrain.ruleset:1781
+#: data/civ2/terrain.ruleset:1519 data/classic/terrain.ruleset:1813
+#: data/sandbox/terrain.ruleset:2058 data/civ2civ3/terrain.ruleset:2018
+#: data/multiplayer/terrain.ruleset:1787
 msgid "Wine"
 msgstr "viiniköynnöksiä"
 
@@ -24023,9 +24106,9 @@ msgstr "Hyökkäysarvo puolitettu hyökättäessä keihäsmiehiä vastaan."
 
 #. TRANS: unit type
 #: data/civ2/units.ruleset:28 data/civ2/units.ruleset:1336
-#: data/classic/units.ruleset:34 data/classic/units.ruleset:1380
-#: data/sandbox/units.ruleset:1578 data/civ2civ3/units.ruleset:1568
-#: data/multiplayer/units.ruleset:34 data/multiplayer/units.ruleset:1479
+#: data/classic/units.ruleset:34 data/classic/units.ruleset:1383
+#: data/sandbox/units.ruleset:1581 data/civ2civ3/units.ruleset:1571
+#: data/multiplayer/units.ruleset:34 data/multiplayer/units.ruleset:1482
 msgid "Helicopter"
 msgstr "Helikopteri"
 
@@ -24035,11 +24118,11 @@ msgid "Defends very badly against Fighters."
 msgstr "Puolustautuu hyvin heikosti hävittäjäkoneita vastaan."
 
 #: data/civ2/units.ruleset:35 data/civ2/units.ruleset:802
-#: data/classic/units.ruleset:42 data/classic/units.ruleset:910
-#: data/sandbox/units.ruleset:45 data/sandbox/units.ruleset:1022
-#: data/civ2civ3/units.ruleset:44 data/civ2civ3/units.ruleset:1012
+#: data/classic/units.ruleset:42 data/classic/units.ruleset:913
+#: data/sandbox/units.ruleset:45 data/sandbox/units.ruleset:1025
+#: data/civ2civ3/units.ruleset:44 data/civ2civ3/units.ruleset:1015
 #: data/alien/units.ruleset:35 data/multiplayer/units.ruleset:41
-#: data/multiplayer/units.ruleset:945
+#: data/multiplayer/units.ruleset:948
 msgid "Paratroopers"
 msgstr "Laskuvarjojääkäripartio"
 
@@ -24059,10 +24142,10 @@ msgstr ""
 "tukikohdasta lähtien (toimintasäde: %d ruutu).\n"
 
 #: data/civ2/units.ruleset:36 data/civ2/units.ruleset:771
-#: data/classic/units.ruleset:43 data/classic/units.ruleset:879
-#: data/sandbox/units.ruleset:46 data/sandbox/units.ruleset:989
-#: data/civ2civ3/units.ruleset:45 data/civ2civ3/units.ruleset:979
-#: data/multiplayer/units.ruleset:42 data/multiplayer/units.ruleset:914
+#: data/classic/units.ruleset:43 data/classic/units.ruleset:882
+#: data/sandbox/units.ruleset:46 data/sandbox/units.ruleset:992
+#: data/civ2civ3/units.ruleset:45 data/civ2civ3/units.ruleset:982
+#: data/multiplayer/units.ruleset:42 data/multiplayer/units.ruleset:917
 msgid "Marines"
 msgstr "Merijalkaväki"
 
@@ -24084,9 +24167,9 @@ msgstr ""
 "Tasavallassa, Demokratiassa, Kommunismissa ja Fundamentalismissa "
 "Uudisraivaajat vaativat kaksinkertaisen määrän ruokaa."
 
-#: data/civ2/units.ruleset:393 data/classic/units.ruleset:528
-#: data/sandbox/units.ruleset:604 data/civ2civ3/units.ruleset:594
-#: data/multiplayer/units.ruleset:528
+#: data/civ2/units.ruleset:393 data/classic/units.ruleset:531
+#: data/sandbox/units.ruleset:607 data/civ2civ3/units.ruleset:597
+#: data/multiplayer/units.ruleset:531
 msgid "Engineers"
 msgstr "Teknikkoryhmä"
 
@@ -24121,20 +24204,20 @@ msgstr ""
 "valmistamaan räjähteitä ennenkuin työpaja vanhentuu. Näin työläisesi "
 "ajanmukaistetaan ilman kustannuksia."
 
-#: data/civ2/units.ruleset:435 data/classic/units.ruleset:578
-#: data/sandbox/units.ruleset:650 data/civ2civ3/units.ruleset:640
-#: data/multiplayer/units.ruleset:578
+#: data/civ2/units.ruleset:435 data/classic/units.ruleset:581
+#: data/sandbox/units.ruleset:653 data/civ2civ3/units.ruleset:643
+#: data/multiplayer/units.ruleset:581
 msgid "Warriors"
 msgstr "Soturijoukko"
 
-#: data/civ2/units.ruleset:498 data/classic/units.ruleset:641
-#: data/sandbox/units.ruleset:713 data/civ2civ3/units.ruleset:703
-#: data/multiplayer/units.ruleset:641
+#: data/civ2/units.ruleset:498 data/classic/units.ruleset:644
+#: data/sandbox/units.ruleset:716 data/civ2civ3/units.ruleset:706
+#: data/multiplayer/units.ruleset:644
 msgid "Archers"
 msgstr "Jousimiespartio"
 
-#: data/civ2/units.ruleset:524 data/classic/units.ruleset:667
-#: data/multiplayer/units.ruleset:667
+#: data/civ2/units.ruleset:524 data/classic/units.ruleset:670
+#: data/multiplayer/units.ruleset:670
 msgid ""
 "Archers fight with bows and arrows and have a good offensive value as well "
 "as decent defense."
@@ -24143,15 +24226,15 @@ msgstr ""
 "puolustus kelvollinen."
 
 # Perhaps peitsimiehet? This seems too much like ordinary warriors.
-#: data/civ2/units.ruleset:562 data/classic/units.ruleset:705
-#: data/sandbox/units.ruleset:777 data/civ2civ3/units.ruleset:767
-#: data/multiplayer/units.ruleset:705
+#: data/civ2/units.ruleset:562 data/classic/units.ruleset:708
+#: data/sandbox/units.ruleset:780 data/civ2civ3/units.ruleset:770
+#: data/multiplayer/units.ruleset:708
 msgid "Pikemen"
 msgstr "Keihäsjoukkue"
 
-#: data/civ2/units.ruleset:592 data/classic/units.ruleset:735
-#: data/sandbox/units.ruleset:803 data/civ2civ3/units.ruleset:793
-#: data/multiplayer/units.ruleset:735
+#: data/civ2/units.ruleset:592 data/classic/units.ruleset:738
+#: data/sandbox/units.ruleset:806 data/civ2civ3/units.ruleset:796
+#: data/multiplayer/units.ruleset:738
 msgid ""
 "Equipped with long pikes, Pikemen replaces Phalanx as the preferred city "
 "defender."
@@ -24159,9 +24242,9 @@ msgstr ""
 "Pitkin keihäin varustetut Keihäsmiehet korvaavat Falangin suositeltuna "
 "kaupunginpuolustajana."
 
-#: data/civ2/units.ruleset:625 data/classic/units.ruleset:768
-#: data/sandbox/units.ruleset:836 data/civ2civ3/units.ruleset:826
-#: data/multiplayer/units.ruleset:768
+#: data/civ2/units.ruleset:625 data/classic/units.ruleset:771
+#: data/sandbox/units.ruleset:839 data/civ2civ3/units.ruleset:829
+#: data/multiplayer/units.ruleset:771
 msgid ""
 "Musketeers are infantry equipped with early firearms and replace Pikemen as "
 "the preferred city defender."
@@ -24169,19 +24252,19 @@ msgstr ""
 "Muskettijoukkue on jalkaväkeä, joka on varustettu varhaisilla tuliaseilla. "
 "Ne korvaavat Keihäsmiehet suositeltuna kaupunginpuolustajana."
 
-#: data/civ2/units.ruleset:632 data/sandbox/units.ruleset:951
-#: data/civ2civ3/units.ruleset:941 data/multiplayer/units.ruleset:775
+#: data/civ2/units.ruleset:632 data/sandbox/units.ruleset:954
+#: data/civ2civ3/units.ruleset:944 data/multiplayer/units.ruleset:778
 msgid "Fanatics"
 msgstr "Fanaatikkolauma"
 
-#: data/civ2/units.ruleset:659 data/sandbox/units.ruleset:980
-#: data/civ2civ3/units.ruleset:970 data/multiplayer/units.ruleset:802
+#: data/civ2/units.ruleset:659 data/sandbox/units.ruleset:983
+#: data/civ2civ3/units.ruleset:973 data/multiplayer/units.ruleset:805
 msgid "Fanatics are warriors extremely devoted to a higher cause."
 msgstr ""
 "Fanaatikot ovat taistelijoita, jotka ovat sitoutuneet taistelemaan "
 "viimeiseen asti korkeamman aatteen puolesta."
 
-#: data/civ2/units.ruleset:661 data/multiplayer/units.ruleset:804
+#: data/civ2/units.ruleset:661 data/multiplayer/units.ruleset:807
 msgid ""
 "Fundamentalist nations can maintain Fanatic units without having to pay any "
 "shields for upkeep."
@@ -24189,15 +24272,15 @@ msgstr ""
 "Fundamentalistivaltioiden ei tarvitse huolehtia fanaatikkoyksiköiden "
 "ylläpidosta."
 
-#: data/civ2/units.ruleset:667 data/classic/units.ruleset:775
-#: data/sandbox/units.ruleset:909 data/civ2civ3/units.ruleset:899
-#: data/multiplayer/units.ruleset:810
+#: data/civ2/units.ruleset:667 data/classic/units.ruleset:778
+#: data/sandbox/units.ruleset:912 data/civ2civ3/units.ruleset:902
+#: data/multiplayer/units.ruleset:813
 msgid "Partisan"
 msgstr "Sissiryhmä"
 
-#: data/civ2/units.ruleset:693 data/classic/units.ruleset:801
-#: data/sandbox/units.ruleset:937 data/civ2civ3/units.ruleset:927
-#: data/multiplayer/units.ruleset:836
+#: data/civ2/units.ruleset:693 data/classic/units.ruleset:804
+#: data/sandbox/units.ruleset:940 data/civ2civ3/units.ruleset:930
+#: data/multiplayer/units.ruleset:839
 msgid ""
 "Partisans are guerilla fighters who are experts at using the terrain to "
 "their advantage."
@@ -24205,8 +24288,8 @@ msgstr ""
 "Sissiryhmät muodostuvat paikallisista vastarintaliikkeen jäsenistä, jotka "
 "osaavat käyttää maastoa erinomaisesti hyödykseen."
 
-#: data/civ2/units.ruleset:696 data/classic/units.ruleset:804
-#: data/multiplayer/units.ruleset:839
+#: data/civ2/units.ruleset:696 data/classic/units.ruleset:807
+#: data/multiplayer/units.ruleset:842
 msgid ""
 "A number of Partisans are granted free when an enemy conquers your city -- "
 "they automatically assume defensive positions in the surrounding countryside "
@@ -24224,28 +24307,28 @@ msgstr ""
 " - Olet saavuttanut edistysaskeleet Kommunismi ja Ruuti.\n"
 " - Valtiomuotosi on joko demokratia tai kommunismi."
 
-#: data/civ2/units.ruleset:707 data/classic/units.ruleset:815
-#: data/sandbox/units.ruleset:875 data/civ2civ3/units.ruleset:865
-#: data/multiplayer/units.ruleset:850
+#: data/civ2/units.ruleset:707 data/classic/units.ruleset:818
+#: data/sandbox/units.ruleset:878 data/civ2civ3/units.ruleset:868
+#: data/multiplayer/units.ruleset:853
 msgid "Alpine Troops"
 msgstr "Alppijääkäripartio"
 
-#: data/civ2/units.ruleset:733 data/classic/units.ruleset:841
-#: data/sandbox/units.ruleset:903 data/civ2civ3/units.ruleset:893
-#: data/multiplayer/units.ruleset:876
+#: data/civ2/units.ruleset:733 data/classic/units.ruleset:844
+#: data/sandbox/units.ruleset:906 data/civ2civ3/units.ruleset:896
+#: data/multiplayer/units.ruleset:879
 msgid "Alpine Troops are highly mobile units as well as excellent defenders."
 msgstr ""
 "Alppijääkäripartiot ovat nopeasti liikkuvia yksiköitä ja erinomaisia "
 "puolustautujia."
 
-#: data/civ2/units.ruleset:797 data/classic/units.ruleset:905
-#: data/sandbox/units.ruleset:1017 data/civ2civ3/units.ruleset:1007
-#: data/multiplayer/units.ruleset:940
+#: data/civ2/units.ruleset:797 data/classic/units.ruleset:908
+#: data/sandbox/units.ruleset:1020 data/civ2civ3/units.ruleset:1010
+#: data/multiplayer/units.ruleset:943
 msgid "Marines are infantry who are experts at marine warfare."
 msgstr "Merijalkaväki erikoistuu sodankäyntiin merellä."
 
-#: data/civ2/units.ruleset:828 data/classic/units.ruleset:936
-#: data/multiplayer/units.ruleset:971
+#: data/civ2/units.ruleset:828 data/classic/units.ruleset:939
+#: data/multiplayer/units.ruleset:974
 msgid ""
 "Paratroopers are experts at airborne attacks. From a friendly city or "
 "airbase, Paratroopers who have not expended any movement points can paradrop "
@@ -24261,8 +24344,8 @@ msgstr ""
 "johon sinulla ei ole näköyhteyttä, sillä vihollisyksiköiden miehittämään "
 "ruutuun hypätessään laskuvarjojoukot ovat helppoja kohteita!)"
 
-#: data/civ2/units.ruleset:867 data/classic/units.ruleset:975
-#: data/multiplayer/units.ruleset:1010
+#: data/civ2/units.ruleset:867 data/classic/units.ruleset:978
+#: data/multiplayer/units.ruleset:1013
 msgid ""
 "The Mechanized Infantry has the strongest defensive strength of any land "
 "unit, but is only available near the end of the technology tree."
@@ -24270,15 +24353,15 @@ msgstr ""
 "Moottoroidun panssarijalkaväen puolustuskyky on maavoimien suurin, mutta se "
 "on käytettävissä vasta aivan pelin loppuvaiheessa."
 
-#: data/civ2/units.ruleset:874 data/classic/units.ruleset:982
-#: data/sandbox/units.ruleset:1098 data/civ2civ3/units.ruleset:1088
-#: data/multiplayer/units.ruleset:1017
+#: data/civ2/units.ruleset:874 data/classic/units.ruleset:985
+#: data/sandbox/units.ruleset:1101 data/civ2civ3/units.ruleset:1091
+#: data/multiplayer/units.ruleset:1020
 msgid "Horsemen"
 msgstr "Hevospartio"
 
-#: data/civ2/units.ruleset:900 data/classic/units.ruleset:1008
-#: data/sandbox/units.ruleset:1124 data/civ2civ3/units.ruleset:1114
-#: data/multiplayer/units.ruleset:1043
+#: data/civ2/units.ruleset:900 data/classic/units.ruleset:1011
+#: data/sandbox/units.ruleset:1127 data/civ2civ3/units.ruleset:1117
+#: data/multiplayer/units.ruleset:1046
 msgid ""
 "Horsemen are mounted warriors and an early shock-troop that can penetrate "
 "deep into enemy territory."
@@ -24286,8 +24369,8 @@ msgstr ""
 "Hevospartio koostuu ratsain liikuvista sotureista. Murrettuaan vihollisen "
 "vastarinnan se voi edetä nopeasti syvälle vihollisen selustaan."
 
-#: data/civ2/units.ruleset:933 data/classic/units.ruleset:1041
-#: data/multiplayer/units.ruleset:1076
+#: data/civ2/units.ruleset:933 data/classic/units.ruleset:1044
+#: data/multiplayer/units.ruleset:1079
 msgid ""
 "Chariots are horse-pulled war wagons, stronger but more expensive than "
 "horsemen."
@@ -24295,12 +24378,12 @@ msgstr ""
 "Hevosten vetämät Sotavaunut ovat tavallista Hevospartiota vahvempia mutta "
 "myös kalliimpia yksiköitä."
 
-#: data/civ2/units.ruleset:939 data/sandbox/units.ruleset:1167
-#: data/civ2civ3/units.ruleset:1157 data/multiplayer/units.ruleset:1082
+#: data/civ2/units.ruleset:939 data/sandbox/units.ruleset:1170
+#: data/civ2civ3/units.ruleset:1160 data/multiplayer/units.ruleset:1085
 msgid "Elephants"
 msgstr "Sotanorsupartio"
 
-#: data/civ2/units.ruleset:965 data/multiplayer/units.ruleset:1108
+#: data/civ2/units.ruleset:965 data/multiplayer/units.ruleset:1111
 msgid ""
 "Elephants are towering animals trained for war that are often used as "
 "powerful shock troops, but defend poorly against most other units."
@@ -24309,39 +24392,39 @@ msgstr ""
 "käytetään usein voimakkaina rynnäkköyksikköinä, mutta ne puolustautuvat "
 "huonosti useimpia muita yksiköitä vastaan."
 
-#: data/civ2/units.ruleset:971 data/sandbox/units.ruleset:1199
-#: data/civ2civ3/units.ruleset:1189 data/multiplayer/units.ruleset:1114
+#: data/civ2/units.ruleset:971 data/sandbox/units.ruleset:1202
+#: data/civ2civ3/units.ruleset:1192 data/multiplayer/units.ruleset:1117
 msgid "Crusaders"
 msgstr "Ristiritarikaarti"
 
-#: data/civ2/units.ruleset:997 data/sandbox/units.ruleset:1225
-#: data/civ2civ3/units.ruleset:1215 data/multiplayer/units.ruleset:1140
+#: data/civ2/units.ruleset:997 data/sandbox/units.ruleset:1228
+#: data/civ2civ3/units.ruleset:1218 data/multiplayer/units.ruleset:1143
 msgid ""
 "Crusaders are highly disciplined mounted warriors driven by a higher cause."
 msgstr ""
 "Ristiritarit ovat äärimmäisen kurinalaista ratsuväkeä, jota ajaa eteenpäin "
 "elämää suurempi tehtävä."
 
-#: data/civ2/units.ruleset:1035 data/classic/units.ruleset:1079
-#: data/sandbox/units.ruleset:1263 data/civ2civ3/units.ruleset:1253
-#: data/multiplayer/units.ruleset:1178
+#: data/civ2/units.ruleset:1035 data/classic/units.ruleset:1082
+#: data/sandbox/units.ruleset:1266 data/civ2civ3/units.ruleset:1256
+#: data/multiplayer/units.ruleset:1181
 msgid "Dragoons"
 msgstr "Rakuunapartio"
 
-#: data/civ2/units.ruleset:1062 data/classic/units.ruleset:1106
-#: data/sandbox/units.ruleset:1289 data/civ2civ3/units.ruleset:1279
-#: data/multiplayer/units.ruleset:1205
+#: data/civ2/units.ruleset:1062 data/classic/units.ruleset:1109
+#: data/sandbox/units.ruleset:1292 data/civ2civ3/units.ruleset:1282
+#: data/multiplayer/units.ruleset:1208
 msgid "Dragoons are mounted warriors carrying early firearms."
 msgstr "Rakuunat ovat varhaisia tuliaseita käyttäviä ratsusotilaita."
 
-#: data/civ2/units.ruleset:1093 data/classic/units.ruleset:1137
-#: data/sandbox/units.ruleset:1320 data/civ2civ3/units.ruleset:1310
-#: data/multiplayer/units.ruleset:1236
+#: data/civ2/units.ruleset:1093 data/classic/units.ruleset:1140
+#: data/sandbox/units.ruleset:1323 data/civ2civ3/units.ruleset:1313
+#: data/multiplayer/units.ruleset:1239
 msgid "Cavalry are mounted and highly trained soldiers."
 msgstr "Ratsuväki on tarkkaan koulutettua."
 
-#: data/civ2/units.ruleset:1224 data/classic/units.ruleset:1268
-#: data/multiplayer/units.ruleset:1367
+#: data/civ2/units.ruleset:1224 data/classic/units.ruleset:1271
+#: data/multiplayer/units.ruleset:1370
 msgid ""
 "The artillery is an upgraded cannon. It is a very strong attacker but "
 "equally weak defender and will need an escort to be effective."
@@ -24350,14 +24433,14 @@ msgstr ""
 "mutta toivoton puolustaja ja tarvitsee siksi saattojoukon toimiakseen "
 "tehokkaasti."
 
-#: data/civ2/units.ruleset:1231 data/classic/units.ruleset:1275
-#: data/sandbox/units.ruleset:1465 data/civ2civ3/units.ruleset:1455
-#: data/multiplayer/units.ruleset:1374
+#: data/civ2/units.ruleset:1231 data/classic/units.ruleset:1278
+#: data/sandbox/units.ruleset:1468 data/civ2civ3/units.ruleset:1458
+#: data/multiplayer/units.ruleset:1377
 msgid "Howitzer"
 msgstr "Haupitsi"
 
-#: data/civ2/units.ruleset:1257 data/classic/units.ruleset:1301
-#: data/multiplayer/units.ruleset:1400
+#: data/civ2/units.ruleset:1257 data/classic/units.ruleset:1304
+#: data/multiplayer/units.ruleset:1403
 msgid ""
 "Howitzers are upgraded artillery with improved defensive as well as "
 "offensive capabilities. They can shoot over city walls, ignoring their "
@@ -24367,7 +24450,7 @@ msgstr ""
 "Tykistöön verrattuna. Se voi ampua kaupunginmuurien yli, jättäen näiden "
 "vaikutuksen puolustukseen huomiotta."
 
-#: data/civ2/units.ruleset:1362 data/classic/units.ruleset:1406
+#: data/civ2/units.ruleset:1362 data/classic/units.ruleset:1409
 msgid ""
 "The Helicopter is a very powerful unit, as it can both fly and conquer "
 "cities.  Care must be exercised, because Helicopters lose a small amount of "
@@ -24381,34 +24464,34 @@ msgstr ""
 "tai lentotukialuksessa (paitsi jos sinulla on ihme Yhdistyneet Kansakunnat). "
 "Vihollisen maavoimien yksiköt voivat lisäksi hyökätä Helikopterisi kimppuun."
 
-#: data/civ2/units.ruleset:1371 data/classic/units.ruleset:1415
-#: data/sandbox/units.ruleset:1623 data/civ2civ3/units.ruleset:1613
-#: data/multiplayer/units.ruleset:1513
+#: data/civ2/units.ruleset:1371 data/classic/units.ruleset:1418
+#: data/sandbox/units.ruleset:1626 data/civ2civ3/units.ruleset:1616
+#: data/multiplayer/units.ruleset:1516
 msgid "Stealth Fighter"
 msgstr "Häivehävittäjä"
 
-#: data/civ2/units.ruleset:1403 data/classic/units.ruleset:1448
-#: data/sandbox/units.ruleset:1651 data/civ2civ3/units.ruleset:1641
-#: data/multiplayer/units.ruleset:1546
+#: data/civ2/units.ruleset:1403 data/classic/units.ruleset:1451
+#: data/sandbox/units.ruleset:1654 data/civ2civ3/units.ruleset:1644
+#: data/multiplayer/units.ruleset:1549
 msgid "An improved Fighter, with improved attack and a higher movement radius."
 msgstr ""
 "Sekä toimintasäteeltään että tulivoimaltaan kohennettu hävittäjälentokone."
 
-#: data/civ2/units.ruleset:1409 data/classic/units.ruleset:1454
-#: data/sandbox/units.ruleset:1657 data/civ2civ3/units.ruleset:1647
-#: data/multiplayer/units.ruleset:1552
+#: data/civ2/units.ruleset:1409 data/classic/units.ruleset:1457
+#: data/sandbox/units.ruleset:1660 data/civ2civ3/units.ruleset:1650
+#: data/multiplayer/units.ruleset:1555
 msgid "Stealth Bomber"
 msgstr "Häivepommikone"
 
-#: data/civ2/units.ruleset:1435 data/classic/units.ruleset:1482
-#: data/sandbox/units.ruleset:1684 data/civ2civ3/units.ruleset:1674
-#: data/multiplayer/units.ruleset:1580
+#: data/civ2/units.ruleset:1435 data/classic/units.ruleset:1485
+#: data/sandbox/units.ruleset:1687 data/civ2civ3/units.ruleset:1677
+#: data/multiplayer/units.ruleset:1583
 msgid "An improved Bomber, with improved attack and a higher movement radius."
 msgstr "Sekä toimintasäteeltään että tulivoimaltaan kohennettu pommikone."
 
-#: data/civ2/units.ruleset:1476 data/classic/units.ruleset:1523
-#: data/sandbox/units.ruleset:1726 data/civ2civ3/units.ruleset:1716
-#: data/multiplayer/units.ruleset:1621
+#: data/civ2/units.ruleset:1476 data/classic/units.ruleset:1526
+#: data/sandbox/units.ruleset:1729 data/civ2civ3/units.ruleset:1719
+#: data/multiplayer/units.ruleset:1624
 msgid "Caravel"
 msgstr "Karaveli"
 
@@ -24417,14 +24500,14 @@ msgid ""
 "The Caravel replaces the Trireme and is much more reliable on the open seas."
 msgstr "Karaveli korvaa kaleerin ja on paljon luotettavampi avomerellä."
 
-#: data/civ2/units.ruleset:1509 data/classic/units.ruleset:1556
-#: data/sandbox/units.ruleset:1761 data/civ2civ3/units.ruleset:1750
-#: data/multiplayer/units.ruleset:1654
+#: data/civ2/units.ruleset:1509 data/classic/units.ruleset:1559
+#: data/sandbox/units.ruleset:1764 data/civ2civ3/units.ruleset:1753
+#: data/multiplayer/units.ruleset:1657
 msgid "Galleon"
 msgstr "Kaljuuna"
 
-#: data/civ2/units.ruleset:1536 data/classic/units.ruleset:1583
-#: data/multiplayer/units.ruleset:1681
+#: data/civ2/units.ruleset:1536 data/classic/units.ruleset:1586
+#: data/multiplayer/units.ruleset:1684
 msgid ""
 "The Galleon is a pure transport ship and cannot attack other ships, though "
 "it may still defend itself when attacked."
@@ -24432,20 +24515,20 @@ msgstr ""
 "Kaljuuna on puhdas kuljetusalus eikä voi hyökätä toisten laivojen kimppuun; "
 "se kykenee silti tosin puolustautumaan hyökkäykseltä."
 
-#: data/civ2/units.ruleset:1610 data/classic/units.ruleset:1657
-#: data/sandbox/units.ruleset:1859 data/civ2civ3/units.ruleset:1848
-#: data/alien/units.ruleset:1225 data/multiplayer/units.ruleset:1755
+#: data/civ2/units.ruleset:1610 data/classic/units.ruleset:1660
+#: data/sandbox/units.ruleset:1862 data/civ2civ3/units.ruleset:1851
+#: data/alien/units.ruleset:1228 data/multiplayer/units.ruleset:1758
 msgid "Destroyer"
 msgstr "Hävittäjä"
 
-#: data/civ2/units.ruleset:1636 data/classic/units.ruleset:1683
-#: data/multiplayer/units.ruleset:1781
+#: data/civ2/units.ruleset:1636 data/classic/units.ruleset:1686
+#: data/multiplayer/units.ruleset:1784
 msgid "An improved Ironclad, with better move rate and vision."
 msgstr ""
 "Kehittyneempi panssarilaiva, jolla on parempi liikkuvuus ja näkökenttä."
 
-#: data/civ2/units.ruleset:1638 data/classic/units.ruleset:1685
-#: data/multiplayer/units.ruleset:1783
+#: data/civ2/units.ruleset:1638 data/classic/units.ruleset:1688
+#: data/multiplayer/units.ruleset:1786
 msgid ""
 "TIP:  A very fast unit, which is very useful for hunting down enemy "
 "Transports."
@@ -24453,30 +24536,30 @@ msgstr ""
 "VIHJE: Erittäin nopea alus, joka sopii hyvin vihollisen kuljetusalusten "
 "tuhoamiseen."
 
-#: data/civ2/units.ruleset:1675 data/classic/units.ruleset:1722
-#: data/sandbox/units.ruleset:1929 data/civ2civ3/units.ruleset:1918
-#: data/multiplayer/units.ruleset:1820
+#: data/civ2/units.ruleset:1675 data/classic/units.ruleset:1725
+#: data/sandbox/units.ruleset:1932 data/civ2civ3/units.ruleset:1921
+#: data/multiplayer/units.ruleset:1823
 msgid "AEGIS Cruiser"
 msgstr "Ohjusristeilijä"
 
-#: data/civ2/units.ruleset:1705 data/classic/units.ruleset:1752
-#: data/sandbox/units.ruleset:1959 data/civ2civ3/units.ruleset:1948
-#: data/multiplayer/units.ruleset:1850
+#: data/civ2/units.ruleset:1705 data/classic/units.ruleset:1755
+#: data/sandbox/units.ruleset:1962 data/civ2civ3/units.ruleset:1951
+#: data/multiplayer/units.ruleset:1853
 msgid ""
 "The AEGIS Cruiser is equipped with an advanced defensive missile system."
 msgstr ""
 "Ohjusristeilijä on varustettu tehokkaalla tietotekniikkaa ja ohjuksia "
 "hyödyntävällä ilmatorjuntajärjestelmällä."
 
-#: data/civ2/units.ruleset:1848 data/classic/units.ruleset:1895
-#: data/sandbox/units.ruleset:2124 data/civ2civ3/units.ruleset:2107
-#: data/multiplayer/units.ruleset:1993
+#: data/civ2/units.ruleset:1848 data/classic/units.ruleset:1898
+#: data/sandbox/units.ruleset:2127 data/civ2civ3/units.ruleset:2110
+#: data/multiplayer/units.ruleset:1996
 msgid "Cruise Missile"
 msgstr "Risteilyohjus"
 
-#: data/civ2/units.ruleset:1874 data/classic/units.ruleset:1921
-#: data/sandbox/units.ruleset:2151 data/civ2civ3/units.ruleset:2134
-#: data/multiplayer/units.ruleset:2019
+#: data/civ2/units.ruleset:1874 data/classic/units.ruleset:1924
+#: data/sandbox/units.ruleset:2154 data/civ2civ3/units.ruleset:2137
+#: data/multiplayer/units.ruleset:2022
 msgid ""
 "The Cruise Missile is a long-distance missile that can strike deep into "
 "enemy territory."
@@ -24484,9 +24567,9 @@ msgstr ""
 "Risteilyohjus on pitkänmatkan ohjus, joka voi iskeä syvälle vihollisen "
 "alueelle."
 
-#: data/civ2/units.ruleset:1877 data/classic/units.ruleset:1924
-#: data/sandbox/units.ruleset:2154 data/civ2civ3/units.ruleset:2137
-#: data/multiplayer/units.ruleset:2022
+#: data/civ2/units.ruleset:1877 data/classic/units.ruleset:1927
+#: data/sandbox/units.ruleset:2157 data/civ2civ3/units.ruleset:2140
+#: data/multiplayer/units.ruleset:2025
 msgid ""
 "TIP:  A handful of these can successfully keep the waters around your "
 "treasured homeland free of enemy ships."
@@ -24516,24 +24599,24 @@ msgstr ""
 "syntyy! Minimoit ydintalven syntymahdollisuuden ja käytät ydinaseitasi "
 "ympäristöystävällisesti!"
 
-#: data/civ2/units.ruleset:2027 data/classic/units.ruleset:2094
-#: data/sandbox/units.ruleset:2334 data/civ2civ3/units.ruleset:2314
-#: data/multiplayer/units.ruleset:2192
+#: data/civ2/units.ruleset:2027 data/classic/units.ruleset:2097
+#: data/sandbox/units.ruleset:2337 data/civ2civ3/units.ruleset:2317
+#: data/multiplayer/units.ruleset:2195
 msgid "Spy"
 msgstr "Vakooja"
 
-#: data/civ2/units.ruleset:2058 data/classic/units.ruleset:2134
-#: data/sandbox/units.ruleset:2375 data/civ2civ3/units.ruleset:2355
-#: data/multiplayer/units.ruleset:2232
+#: data/civ2/units.ruleset:2058 data/classic/units.ruleset:2137
+#: data/sandbox/units.ruleset:2378 data/civ2civ3/units.ruleset:2358
+#: data/multiplayer/units.ruleset:2235
 msgid ""
 "A Spy is more skilled in the arts of espionage than her Diplomat predecessor."
 msgstr ""
 "Nimensä mukaisesti Vakooja on edeltäjäänsä Diplomaattia kehittyneempi "
 "vakoilun enemmän tai vähemmän jaloissa taidoissa."
 
-#: data/civ2/units.ruleset:2060 data/classic/units.ruleset:2136
-#: data/sandbox/units.ruleset:2377 data/civ2civ3/units.ruleset:2357
-#: data/multiplayer/units.ruleset:2234
+#: data/civ2/units.ruleset:2060 data/classic/units.ruleset:2139
+#: data/sandbox/units.ruleset:2380 data/civ2civ3/units.ruleset:2360
+#: data/multiplayer/units.ruleset:2237
 msgid ""
 "She can perform all the functions of the Diplomat; refer to the Diplomat "
 "entry for more details. Unlike a Diplomat, a Spy may also survive an "
@@ -24547,9 +24630,9 @@ msgstr ""
 "Diplomaattia tehokkaampia kaupunkien puolustamisessa vieraiden valtojen "
 "Diplomaatteja ja Vakoojia vastaan."
 
-#: data/civ2/units.ruleset:2066 data/classic/units.ruleset:2142
-#: data/sandbox/units.ruleset:2383 data/civ2civ3/units.ruleset:2363
-#: data/multiplayer/units.ruleset:2240
+#: data/civ2/units.ruleset:2066 data/classic/units.ruleset:2145
+#: data/sandbox/units.ruleset:2386 data/civ2civ3/units.ruleset:2366
+#: data/multiplayer/units.ruleset:2243
 msgid ""
 "A Spy can also be used to:\n"
 " - sabotage an enemy unit (reducing its hit points to half), if it is alone "
@@ -24573,9 +24656,9 @@ msgstr ""
 "- halutun kohteen sabotoimiseen kaupungissa (tosin todennäköisyys onnistua "
 "on pienempi)."
 
-#: data/civ2/units.ruleset:2078 data/classic/units.ruleset:2154
-#: data/sandbox/units.ruleset:2395 data/civ2civ3/units.ruleset:2375
-#: data/multiplayer/units.ruleset:2252
+#: data/civ2/units.ruleset:2078 data/classic/units.ruleset:2157
+#: data/sandbox/units.ruleset:2398 data/civ2civ3/units.ruleset:2378
+#: data/multiplayer/units.ruleset:2255
 msgid ""
 "A Spy that survives the more aggressive actions (sabotage, theft, inciting "
 "rebellion, and poisoning) escapes to the safety of the nearest friendly city."
@@ -24589,27 +24672,27 @@ msgid "Spies built under a Communist government will be built as veteran."
 msgstr ""
 "Kommunistisen hallituksen alla rakennetut vakoojat aloittavat konkareina."
 
-#: data/civ2/units.ruleset:2136 data/classic/units.ruleset:2216
-#: data/sandbox/units.ruleset:2454 data/civ2civ3/units.ruleset:2433
-#: data/alien/units.ruleset:1316 data/multiplayer/units.ruleset:2301
+#: data/civ2/units.ruleset:2136 data/classic/units.ruleset:2219
+#: data/sandbox/units.ruleset:2457 data/civ2civ3/units.ruleset:2436
+#: data/alien/units.ruleset:1319 data/multiplayer/units.ruleset:2304
 msgid "Freight"
 msgstr "Rekka-auto"
 
-#: data/civ2/units.ruleset:2162 data/classic/units.ruleset:2242
+#: data/civ2/units.ruleset:2162 data/classic/units.ruleset:2245
 msgid "The Freight unit replaces the Caravan, and moves at twice the speed."
 msgstr ""
 "Rekka-auto liikkuu kaksinkertaisella nopeudella edeltäjäänsä Karavaaniin "
 "verrattuna."
 
-#: data/civ2/units.ruleset:2167 data/classic/units.ruleset:2247
-#: data/sandbox/units.ruleset:2486 data/civ2civ3/units.ruleset:2465
-#: data/alien/units.ruleset:1097 data/multiplayer/units.ruleset:2333
+#: data/civ2/units.ruleset:2167 data/classic/units.ruleset:2250
+#: data/sandbox/units.ruleset:2489 data/civ2civ3/units.ruleset:2468
+#: data/alien/units.ruleset:1100 data/multiplayer/units.ruleset:2336
 msgid "Explorer"
 msgstr "Seikkailija"
 
-#: data/civ2/units.ruleset:2193 data/classic/units.ruleset:2273
-#: data/sandbox/units.ruleset:2512 data/civ2civ3/units.ruleset:2491
-#: data/multiplayer/units.ruleset:2359
+#: data/civ2/units.ruleset:2193 data/classic/units.ruleset:2276
+#: data/sandbox/units.ruleset:2515 data/civ2civ3/units.ruleset:2494
+#: data/multiplayer/units.ruleset:2362
 msgid ""
 "Explorers are brave individuals that are very useful for mapping unknown "
 "territory."
@@ -24617,9 +24700,9 @@ msgstr ""
 "Seikkailijat ovat rohkeita yksilöitä, jotka ovat erittäin hyödyllisiä "
 "tuntemattomien alueiden kartoituksessa."
 
-#: data/civ2/units.ruleset:2228 data/classic/units.ruleset:2356
-#: data/sandbox/units.ruleset:2609 data/civ2civ3/units.ruleset:2588
-#: data/multiplayer/units.ruleset:2442
+#: data/civ2/units.ruleset:2228 data/classic/units.ruleset:2359
+#: data/sandbox/units.ruleset:2612 data/civ2civ3/units.ruleset:2591
+#: data/multiplayer/units.ruleset:2445
 msgid ""
 "When a Barbarian Leader is killed on a tile without any defending units, the "
 "100 gold ransom is paid, but only to land units and helicopters."
@@ -24628,7 +24711,7 @@ msgstr ""
 "yksiköitä, maksetaan hänestä 100 yksikön lunnaat kultana, mutta vain "
 "maavoimien yksiköille ja helikoptereille."
 
-#: data/default/default.lua:22 server/unittools.c:2956
+#: data/default/default.lua:22 server/unittools.c:2962
 #, c-format
 msgid "You found %d gold."
 msgid_plural "You found %d gold."
@@ -24666,7 +24749,7 @@ msgstr "Löysit ystävällismielisen kaupungin."
 msgid "Friendly nomads are impressed by you, and join you."
 msgstr "Joukko paimentolaisia liittyy valtakuntaasi."
 
-#: data/default/default.lua:114 server/unittools.c:2963
+#: data/default/default.lua:114 server/unittools.c:2969
 msgid "An abandoned village is here."
 msgstr "Täällä on vain hylätty kylä."
 
@@ -24674,7 +24757,7 @@ msgstr "Täällä on vain hylätty kylä."
 msgid "You have unleashed a horde of barbarians!"
 msgstr "Olet joutunut keskelle barbaarijoukon leiriä!"
 
-#: data/default/default.lua:124 server/unittools.c:2966
+#: data/default/default.lua:124 server/unittools.c:2972
 #, c-format
 msgid "Your %s has been killed by barbarians!"
 msgstr "%s menetettiin barbaarien hyökkäyksessä!"
@@ -25051,7 +25134,7 @@ msgstr ""
 msgid "Classic ruleset"
 msgstr "Freecivin perinteinen sääntökokoelma"
 
-#: data/classic/game.ruleset:32
+#: data/classic/game.ruleset:38
 #, fuzzy
 #| msgid "You are playing with classic Freeciv rules for single player games."
 msgid ""
@@ -25063,34 +25146,34 @@ msgid ""
 msgstr "Pelaat Freeciviä yksinpelin perinteisillä säännöillä."
 
 #. TRANS: Sell _Goods (100% chance of success).
-#: data/classic/game.ruleset:328
+#: data/classic/game.ruleset:338
 #, c-format
 msgid "Sell %sGoods%s"
 msgstr "%sMyy kauppatavarat%s"
 
 #. TRANS: year label (Common Era)
-#: data/classic/game.ruleset:1065 data/sandbox/game.ruleset:1374
-#: data/civ2civ3/game.ruleset:1217 data/multiplayer/game.ruleset:1061
+#: data/classic/game.ruleset:1080 data/sandbox/game.ruleset:1389
+#: data/civ2civ3/game.ruleset:1232 data/multiplayer/game.ruleset:1076
 msgid "CE"
 msgstr "jaa."
 
 #. TRANS: year label (Before Common Era)
-#: data/classic/game.ruleset:1067 data/sandbox/game.ruleset:1376
-#: data/civ2civ3/game.ruleset:1219 data/multiplayer/game.ruleset:1063
+#: data/classic/game.ruleset:1082 data/sandbox/game.ruleset:1391
+#: data/civ2civ3/game.ruleset:1234 data/multiplayer/game.ruleset:1078
 msgid "BCE"
 msgstr "eaa."
 
-#: data/classic/game.ruleset:1094
+#: data/classic/game.ruleset:1109
 msgid "Pestilence"
 msgstr "Kulkutauti"
 
-#: data/classic/game.ruleset:1104 data/sandbox/game.ruleset:1425
-#: data/civ2civ3/game.ruleset:1268
+#: data/classic/game.ruleset:1119 data/sandbox/game.ruleset:1440
+#: data/civ2civ3/game.ruleset:1283
 msgid "Industrial Accident"
 msgstr "Tehdasonnettomuus"
 
-#: data/classic/game.ruleset:1113 data/sandbox/game.ruleset:1434
-#: data/civ2civ3/game.ruleset:1277
+#: data/classic/game.ruleset:1128 data/sandbox/game.ruleset:1449
+#: data/civ2civ3/game.ruleset:1292
 msgid "Nuclear Accident"
 msgstr "Ydinonnettomuus"
 
@@ -25238,15 +25321,15 @@ msgstr "Öljyporaustorneja voidaan rakentaa kun tunnetaan öljynjalostus."
 msgid "Oil wells can be built when Construction is known."
 msgstr "Öljynporaustorneja voidaan rakentaa kun tunnetaan rakennustaito."
 
-#: data/classic/terrain.ruleset:999 data/multiplayer/terrain.ruleset:973
+#: data/classic/terrain.ruleset:1001 data/multiplayer/terrain.ruleset:975
 msgid "?gui_type:Build Fortress/Buoy"
 msgstr "Rakenna linnoitus/poiju"
 
-#: data/classic/terrain.ruleset:1000 data/multiplayer/terrain.ruleset:974
+#: data/classic/terrain.ruleset:1004 data/multiplayer/terrain.ruleset:978
 msgid "?gui_type:Build Airbase"
 msgstr "Rakenna lentotukikohta"
 
-#: data/classic/terrain.ruleset:1139 data/multiplayer/terrain.ruleset:1113
+#: data/classic/terrain.ruleset:1145 data/multiplayer/terrain.ruleset:1119
 #, fuzzy
 #| msgid ""
 #| "Building an irrigation system on a suitable tile causes it to produce "
@@ -25267,15 +25350,15 @@ msgstr ""
 "rinnalla. Kun kasteluverkosto on kaivettu, ruutu pysyy kasteltuna vaikka "
 "vedenlähde poistettaisiin."
 
-#: data/classic/terrain.ruleset:1146 data/sandbox/terrain.ruleset:1170
-#: data/civ2civ3/terrain.ruleset:1169 data/multiplayer/terrain.ruleset:1120
+#: data/classic/terrain.ruleset:1152 data/sandbox/terrain.ruleset:1176
+#: data/civ2civ3/terrain.ruleset:1175 data/multiplayer/terrain.ruleset:1126
 msgid "Building irrigation on a tile with a mine or oil well will destroy it."
 msgstr ""
 "Ruudussa ennestään oleva kaivos tai öljynporaustorni tuhoutuu kastelukanavan "
 "rakentamisen yhteydessä."
 
-#: data/classic/terrain.ruleset:1148 data/sandbox/terrain.ruleset:1172
-#: data/civ2civ3/terrain.ruleset:1171 data/multiplayer/terrain.ruleset:1122
+#: data/classic/terrain.ruleset:1154 data/sandbox/terrain.ruleset:1178
+#: data/civ2civ3/terrain.ruleset:1177 data/multiplayer/terrain.ruleset:1128
 msgid ""
 "City center tiles get their terrain's irrigation bonus automatically, if "
 "there is no conflicting mine or oil well on the tile; however, this does not "
@@ -25290,12 +25373,12 @@ msgstr ""
 "johtaa muihin ruutuihin kasteluverkostoja varten, mutta tällöin se ei anna "
 "ruudusta lisäetua."
 
-#: data/classic/terrain.ruleset:1186 data/sandbox/terrain.ruleset:1212
-#: data/civ2civ3/terrain.ruleset:1211 data/multiplayer/terrain.ruleset:1160
+#: data/classic/terrain.ruleset:1192 data/sandbox/terrain.ruleset:1218
+#: data/civ2civ3/terrain.ruleset:1217 data/multiplayer/terrain.ruleset:1166
 msgid "Oil Well"
 msgstr "Öljynporaustorni"
 
-#: data/classic/terrain.ruleset:1204 data/multiplayer/terrain.ruleset:1178
+#: data/classic/terrain.ruleset:1210 data/multiplayer/terrain.ruleset:1184
 msgid ""
 "Oil wells behave like mines (giving an extra production point), but require "
 "more technology. Oil wells can be built on Desert with knowledge of "
@@ -25306,13 +25389,13 @@ msgstr ""
 "rakentaa aavikolle kun rakennustaito tunnetaan, ja jäätikölle kun "
 "öljynjalostus tunnetaan."
 
-#: data/classic/terrain.ruleset:1208 data/multiplayer/terrain.ruleset:1182
+#: data/classic/terrain.ruleset:1214 data/multiplayer/terrain.ruleset:1188
 msgid "Building an oil well on an irrigated tile will destroy the irrigation."
 msgstr ""
 "Öljynporaustornin rakentaminen ruutuun jossa on kasteluverkosto tuhoaa "
 "kasteluverkoston."
 
-#: data/classic/terrain.ruleset:1230
+#: data/classic/terrain.ruleset:1236
 msgid ""
 "Pollution appears on land tiles around cities with high production or "
 "population, or when a Mfg. Plant suffers an industrial accident. It halves "
@@ -25323,7 +25406,7 @@ msgstr ""
 "onnettomuus. Se puolittaa kaiken ruudun hyödyntämisen, ja lisää "
 "ilmastonmuutoksen riskiä."
 
-#: data/classic/terrain.ruleset:1235 data/multiplayer/terrain.ruleset:1209
+#: data/classic/terrain.ruleset:1241 data/multiplayer/terrain.ruleset:1215
 msgid ""
 "The pollution can only be cleared by dispatching Workers, Settlers, or "
 "Engineers with the \"clean pollution\" order."
@@ -25331,8 +25414,8 @@ msgstr ""
 "Saaste voidaan hävittää vain määräämällä työläisjoukko, uudisraivaaja tai "
 "teknikkoryhmä puhdistamaan se komennolla \\\"siivoa saasteita\\\"."
 
-#: data/classic/terrain.ruleset:1254 data/sandbox/terrain.ruleset:1310
-#: data/civ2civ3/terrain.ruleset:1309 data/multiplayer/terrain.ruleset:1229
+#: data/classic/terrain.ruleset:1260 data/sandbox/terrain.ruleset:1316
+#: data/civ2civ3/terrain.ruleset:1315 data/multiplayer/terrain.ruleset:1235
 #, fuzzy
 #| msgid ""
 #| "When an unused tile becomes polluted, there is the temptation to avoid "
@@ -25358,14 +25441,14 @@ msgstr ""
 "ja sisämaassa ruudut muuttuvat aavikoksi. Tällä on taipumus autioittaa "
 "kaupunkeja ja johtaa maailmanlaajuiseen kurjistumiseen."
 
-#: data/classic/terrain.ruleset:1326 data/sandbox/terrain.ruleset:1416
-#: data/civ2civ3/terrain.ruleset:1385 data/multiplayer/terrain.ruleset:1301
+#: data/classic/terrain.ruleset:1332 data/sandbox/terrain.ruleset:1421
+#: data/civ2civ3/terrain.ruleset:1391 data/multiplayer/terrain.ruleset:1307
 msgid "Like irrigation, farmland is incompatible with mines and oil wells."
 msgstr ""
 "Kasteluverkoston tapaan peltomaa ei sovi yhteen kaivosten tai "
 "öljynporaustornien kanssa."
 
-#: data/classic/terrain.ruleset:1348
+#: data/classic/terrain.ruleset:1354
 msgid ""
 "Nuclear fallout can appear on land tiles when a Nuclear unit is detonated, "
 "or when a city's Nuclear Plant has an accident. It halves all output from "
@@ -25375,8 +25458,8 @@ msgstr ""
 "kaupungin ydinvoimalassa tapahtuu onnettomuus; se puolittaa kaiken ruudun "
 "hyödyntämisen."
 
-#: data/classic/terrain.ruleset:1352 data/sandbox/terrain.ruleset:1442
-#: data/civ2civ3/terrain.ruleset:1411 data/multiplayer/terrain.ruleset:1326
+#: data/classic/terrain.ruleset:1358 data/sandbox/terrain.ruleset:1447
+#: data/civ2civ3/terrain.ruleset:1417 data/multiplayer/terrain.ruleset:1332
 msgid ""
 "Every tile with nuclear fallout also increases the risk of global nuclear "
 "winter. If nuclear winter occurs, land across the globe changes into desert, "
@@ -25386,11 +25469,11 @@ msgstr ""
 "maasto muuttuu maailmanlaajuisesti aavikoksi, tundraksi ja jäätiköksi. "
 "Uudisraivaajat voivat neutraloida ydinlaskeumia."
 
-#: data/classic/terrain.ruleset:1356 data/multiplayer/terrain.ruleset:1330
+#: data/classic/terrain.ruleset:1362 data/multiplayer/terrain.ruleset:1336
 msgid "Settlers, Workers, and Engineers can clean up nuclear fallout."
 msgstr "Uudisraivaajat, Työläiset ja Teknikot voivat puhdistaa ydinlaskeumaa."
 
-#: data/classic/terrain.ruleset:1384 data/multiplayer/terrain.ruleset:1358
+#: data/classic/terrain.ruleset:1390 data/multiplayer/terrain.ruleset:1364
 msgid ""
 "Fortresses improve defense for land units outside cities. Among other "
 "effects, a land unit remaining in a fortress for a whole turn without moving "
@@ -25403,13 +25486,13 @@ msgstr ""
 "voimapisteistään. Keksintöteknologian myötä maayksiköiden näkökenttä "
 "laajenee linnoitusten vartiotorneista käsin."
 
-#: data/classic/terrain.ruleset:1426 data/sandbox/terrain.ruleset:1611
-#: data/civ2civ3/terrain.ruleset:1578 data/multiplayer/terrain.ruleset:1400
+#: data/classic/terrain.ruleset:1432 data/sandbox/terrain.ruleset:1616
+#: data/civ2civ3/terrain.ruleset:1584 data/multiplayer/terrain.ruleset:1406
 msgid "Buoy"
 msgstr "poiju"
 
-#: data/classic/terrain.ruleset:1447 data/sandbox/terrain.ruleset:1634
-#: data/civ2civ3/terrain.ruleset:1600 data/multiplayer/terrain.ruleset:1421
+#: data/classic/terrain.ruleset:1453 data/sandbox/terrain.ruleset:1639
+#: data/civ2civ3/terrain.ruleset:1606 data/multiplayer/terrain.ruleset:1427
 msgid ""
 "Buoys may be built in the ocean (by units on a sea-going vessel) to allow "
 "their owner to see the surrounding tiles."
@@ -25417,13 +25500,13 @@ msgstr ""
 "Poijuja voi rakentaa merelle (käyttäen laivojen kuljettamia yksiköitä), "
 "jolloin niiden omistaja näkee ruudut niiden ympärillä."
 
-#: data/classic/terrain.ruleset:1453 data/sandbox/terrain.ruleset:1643
-#: data/civ2civ3/terrain.ruleset:1606 data/multiplayer/terrain.ruleset:1427
+#: data/classic/terrain.ruleset:1459 data/sandbox/terrain.ruleset:1648
+#: data/civ2civ3/terrain.ruleset:1612 data/multiplayer/terrain.ruleset:1433
 msgid "Ruins"
 msgstr "rauniot"
 
-#: data/classic/terrain.ruleset:1472 data/sandbox/terrain.ruleset:1662
-#: data/civ2civ3/terrain.ruleset:1625 data/multiplayer/terrain.ruleset:1446
+#: data/classic/terrain.ruleset:1478 data/sandbox/terrain.ruleset:1667
+#: data/civ2civ3/terrain.ruleset:1631 data/multiplayer/terrain.ruleset:1452
 msgid ""
 "Ruins mark the former site of a city that was destroyed or abandoned. They "
 "have no effect on gameplay."
@@ -25431,7 +25514,7 @@ msgstr ""
 "Rauniot ovat tuhotun tai hylätyn kaupungin jäänteitä. Niillä ei ole "
 "vaikutusta peliin."
 
-#: data/classic/terrain.ruleset:1503 data/multiplayer/terrain.ruleset:1477
+#: data/classic/terrain.ruleset:1509 data/multiplayer/terrain.ruleset:1483
 msgid ""
 "Building roads on river tiles requires knowledge of Bridge Building. City "
 "center tiles automatically get roads (unless they are on a river tile and "
@@ -25455,14 +25538,14 @@ msgid "AttFromNonNative"
 msgstr "Mistä hyvänsä hyökkäävä"
 
 #: data/classic/units.ruleset:59 data/sandbox/units.ruleset:67
-#: data/sandbox/units.ruleset:2106 data/civ2civ3/units.ruleset:62
-#: data/civ2civ3/units.ruleset:2089 data/multiplayer/units.ruleset:58
+#: data/sandbox/units.ruleset:2109 data/civ2civ3/units.ruleset:62
+#: data/civ2civ3/units.ruleset:2092 data/multiplayer/units.ruleset:58
 msgid "hardened"
 msgstr "karaistunut"
 
 #: data/classic/units.ruleset:59 data/sandbox/units.ruleset:67
-#: data/sandbox/units.ruleset:2106 data/civ2civ3/units.ruleset:62
-#: data/civ2civ3/units.ruleset:2089 data/multiplayer/units.ruleset:58
+#: data/sandbox/units.ruleset:2109 data/civ2civ3/units.ruleset:62
+#: data/civ2civ3/units.ruleset:2092 data/multiplayer/units.ruleset:58
 msgid "elite"
 msgstr "eliitti"
 
@@ -25472,8 +25555,8 @@ msgstr "eliitti"
 msgid "?unitclass:Trireme"
 msgstr "soutulaivaston"
 
-#: data/classic/units.ruleset:474 data/sandbox/units.ruleset:508
-#: data/civ2civ3/units.ruleset:498 data/multiplayer/units.ruleset:473
+#: data/classic/units.ruleset:477 data/sandbox/units.ruleset:511
+#: data/civ2civ3/units.ruleset:501 data/multiplayer/units.ruleset:476
 msgid ""
 "Settlers are one of the key units in the game, as they are your main means "
 "of founding new cities."
@@ -25481,7 +25564,7 @@ msgstr ""
 "Uudisasukkaat ovat yksi pelin avainyksiköistä koska he ovat yleisin tapa "
 "saada uusia kaupunkeja perustettua."
 
-#: data/classic/units.ruleset:477 data/multiplayer/units.ruleset:476
+#: data/classic/units.ruleset:480 data/multiplayer/units.ruleset:479
 msgid ""
 "Settlers can also perform most of the same terrain alterations as Workers "
 "(but cannot build Airbases or Buoys)."
@@ -25489,13 +25572,13 @@ msgstr ""
 "Uudisasukkaat voivat myös tehdä samat maastonmuokkaukset kuin työläiset "
 "(paitsi lentotukikohdan tai poijun rakentamisen).\""
 
-#: data/classic/units.ruleset:487 data/sandbox/units.ruleset:563
-#: data/civ2civ3/units.ruleset:553 data/multiplayer/units.ruleset:487
+#: data/classic/units.ruleset:490 data/sandbox/units.ruleset:566
+#: data/civ2civ3/units.ruleset:556 data/multiplayer/units.ruleset:490
 msgid "?unit:Workers"
 msgstr "Työläisjoukko"
 
-#: data/classic/units.ruleset:519 data/sandbox/units.ruleset:595
-#: data/civ2civ3/units.ruleset:585 data/multiplayer/units.ruleset:519
+#: data/classic/units.ruleset:522 data/sandbox/units.ruleset:598
+#: data/civ2civ3/units.ruleset:588 data/multiplayer/units.ruleset:522
 msgid ""
 "Workers have the ability to improve terrain tiles. See the help on Terrain "
 "and Terrain Alterations for the effects of their actions."
@@ -25504,7 +25587,7 @@ msgstr ""
 "toimintojen vaikutuksista kohdista \\\"Maasto\\\" ja \\\"Maastonmuokkaukset\\"
 "\"."
 
-#: data/classic/units.ruleset:522 data/multiplayer/units.ruleset:522
+#: data/classic/units.ruleset:525 data/multiplayer/units.ruleset:525
 msgid ""
 "Workers can build airbases and buoys, which Settlers cannot. Workers must be "
 "on board a ship to build buoys."
@@ -25513,7 +25596,7 @@ msgstr ""
 "uudisasukkaat. Työläisten täytyy olla laivan kyydissä voidakseen rakentaa "
 "poijuja."
 
-#: data/classic/units.ruleset:560 data/multiplayer/units.ruleset:560
+#: data/classic/units.ruleset:563 data/multiplayer/units.ruleset:563
 msgid ""
 "Engineers are similar to Workers, but they work twice as fast and move twice "
 "as fast. Engineers may also perform major terrain transformations which are "
@@ -25530,7 +25613,7 @@ msgstr ""
 "kyytiin, ja ympäröivissä ruuduissa on riittävästi maata). Lisätietoja "
 "kappaleesta Maastonmuokkaus."
 
-#: data/classic/units.ruleset:568 data/multiplayer/units.ruleset:568
+#: data/classic/units.ruleset:571 data/multiplayer/units.ruleset:571
 msgid ""
 "TIP 1:  Upgrade Workers to Engineers when possible, as Engineers require the "
 "same resources as ordinary Workers."
@@ -25539,7 +25622,7 @@ msgstr ""
 "mahdollista, koska teknikkojen ylläpitokustannukset ovat samat kuin "
 "työläisten."
 
-#: data/classic/units.ruleset:571 data/multiplayer/units.ruleset:571
+#: data/classic/units.ruleset:574 data/multiplayer/units.ruleset:574
 msgid ""
 "TIP 2:  If you manage to build Leonardo's Workshop, research Explosives "
 "before the Workshop becomes obsolete.  This way, your Workers units will be "
@@ -25549,7 +25632,7 @@ msgstr ""
 "räjähteitä ennenkuin työpaja vanhentuu. Näin työläisesi ajanmukaistetaan "
 "ilman kustannuksia."
 
-#: data/classic/units.ruleset:1516 data/multiplayer/units.ruleset:1614
+#: data/classic/units.ruleset:1519 data/multiplayer/units.ruleset:1617
 msgid ""
 "The Trireme is your first boat unit. It can act as a transport ship and has "
 "rudimentary offensive capabilities, but may not enter deep ocean tiles."
@@ -25558,13 +25641,13 @@ msgstr ""
 "kykenee jossain määrin myös hyökkäykseen; sen sijaan se ei kykene liikkumaan "
 "syvänmeren ruuduilla."
 
-#: data/classic/units.ruleset:1550 data/multiplayer/units.ruleset:1648
+#: data/classic/units.ruleset:1553 data/multiplayer/units.ruleset:1651
 msgid "The Caravel replaces the Trireme and can enter any ocean tile."
 msgstr ""
 "Karaveli korvaa kaleerin ja kykenee liikkumaan myös avomeren ruuduilla."
 
-#: data/classic/units.ruleset:1965 data/sandbox/units.ruleset:2200
-#: data/civ2civ3/units.ruleset:2183 data/multiplayer/units.ruleset:2063
+#: data/classic/units.ruleset:1968 data/sandbox/units.ruleset:2203
+#: data/civ2civ3/units.ruleset:2186 data/multiplayer/units.ruleset:2066
 msgid ""
 "On impact, the blast will destroy any unit in an area 3 tiles wide (3x3 "
 "squares for rectangular grids), including friendly units. Any city within "
@@ -25576,8 +25659,8 @@ msgstr ""
 "vaikutusalueella menettävät puolet asukasluvustaan, kaupunkien ulkopuolelle "
 "voi jäädä ydinlaskeumaa."
 
-#: data/classic/units.ruleset:1970 data/sandbox/units.ruleset:2205
-#: data/civ2civ3/units.ruleset:2188 data/multiplayer/units.ruleset:2068
+#: data/classic/units.ruleset:1973 data/sandbox/units.ruleset:2208
+#: data/civ2civ3/units.ruleset:2191 data/multiplayer/units.ruleset:2071
 msgid ""
 "Nuclear fallout reduces tile output and increases the risk of global nuclear "
 "winter; see the help on Fallout."
@@ -25585,7 +25668,7 @@ msgstr ""
 "Ydinlaskeuma heikentää ruudun hyödyntämistä ja lisää maailmanlaajuisen "
 "ydintalven riskiä. Katso ohjeen kohta \\\"Laskeuma\\\"."
 
-#: data/classic/units.ruleset:1977 data/multiplayer/units.ruleset:2075
+#: data/classic/units.ruleset:1980 data/multiplayer/units.ruleset:2078
 msgid ""
 "TIP 2:  You may be involved in a situation where you've invaded an enemy "
 "country en masse, but the enemy cities are too strong. Before using a "
@@ -25601,31 +25684,31 @@ msgstr ""
 "ympäristöystävällisesti!"
 
 #. TRANS: diplomatic rank.
-#: data/classic/units.ruleset:2014 data/sandbox/units.ruleset:2250
-#: data/civ2civ3/units.ruleset:2230 data/multiplayer/units.ruleset:2112
+#: data/classic/units.ruleset:2017 data/sandbox/units.ruleset:2253
+#: data/civ2civ3/units.ruleset:2233 data/multiplayer/units.ruleset:2115
 msgid "?diplomatic_rank:attaché"
 msgstr "virkailija"
 
 #. TRANS: diplomatic rank
-#: data/classic/units.ruleset:2016 data/sandbox/units.ruleset:2252
-#: data/civ2civ3/units.ruleset:2232 data/multiplayer/units.ruleset:2114
+#: data/classic/units.ruleset:2019 data/sandbox/units.ruleset:2255
+#: data/civ2civ3/units.ruleset:2235 data/multiplayer/units.ruleset:2117
 msgid "?diplomatic_rank:secretary"
 msgstr "sihteeri"
 
 #. TRANS: diplomatic rank
-#: data/classic/units.ruleset:2018 data/sandbox/units.ruleset:2254
-#: data/civ2civ3/units.ruleset:2234 data/multiplayer/units.ruleset:2116
+#: data/classic/units.ruleset:2021 data/sandbox/units.ruleset:2257
+#: data/civ2civ3/units.ruleset:2237 data/multiplayer/units.ruleset:2119
 msgid "?diplomatic_rank:envoy"
 msgstr "lähettiläs"
 
 #. TRANS: diplomatic rank
-#: data/classic/units.ruleset:2020 data/sandbox/units.ruleset:2256
-#: data/civ2civ3/units.ruleset:2236 data/multiplayer/units.ruleset:2118
+#: data/classic/units.ruleset:2023 data/sandbox/units.ruleset:2259
+#: data/civ2civ3/units.ruleset:2239 data/multiplayer/units.ruleset:2121
 msgid "?diplomatic_rank:ambassador"
 msgstr "suurlähettiläs"
 
-#: data/classic/units.ruleset:2043 data/sandbox/units.ruleset:2281
-#: data/civ2civ3/units.ruleset:2261 data/multiplayer/units.ruleset:2141
+#: data/classic/units.ruleset:2046 data/sandbox/units.ruleset:2284
+#: data/civ2civ3/units.ruleset:2264 data/multiplayer/units.ruleset:2144
 msgid ""
 "Diplomats can also perform a number of actions in another player's city, "
 "although each Diplomat may attempt only one action. Most of these actions "
@@ -25643,7 +25726,7 @@ msgstr ""
 "Hallitsija, se voittaa aina. Jos puolustava yksikkö tuhoutuu, menetät yhden "
 "liikepisteen ja voit yrittää uudelleen."
 
-#: data/classic/units.ruleset:2088 data/multiplayer/units.ruleset:2186
+#: data/classic/units.ruleset:2091 data/multiplayer/units.ruleset:2189
 msgid ""
 "Diplomats built under a Communist government will start at the first veteran "
 "level (secretary)."
@@ -25652,30 +25735,30 @@ msgstr ""
 "ylennettyinä ensimmäiselle kokemustasolle (sihteeri)."
 
 #. TRANS: Spy veteran level
-#: data/classic/units.ruleset:2122 data/sandbox/units.ruleset:2363
-#: data/civ2civ3/units.ruleset:2343 data/multiplayer/units.ruleset:2220
+#: data/classic/units.ruleset:2125 data/sandbox/units.ruleset:2366
+#: data/civ2civ3/units.ruleset:2346 data/multiplayer/units.ruleset:2223
 msgid "?spy_level:informant"
 msgstr "informoija"
 
 #. TRANS: Spy veteran level
-#: data/classic/units.ruleset:2124 data/sandbox/units.ruleset:2365
-#: data/civ2civ3/units.ruleset:2345 data/multiplayer/units.ruleset:2222
+#: data/classic/units.ruleset:2127 data/sandbox/units.ruleset:2368
+#: data/civ2civ3/units.ruleset:2348 data/multiplayer/units.ruleset:2225
 msgid "?spy_level:handler"
 msgstr "toimija"
 
 #. TRANS: Spy veteran level
-#: data/classic/units.ruleset:2126 data/sandbox/units.ruleset:2367
-#: data/civ2civ3/units.ruleset:2347 data/multiplayer/units.ruleset:2224
+#: data/classic/units.ruleset:2129 data/sandbox/units.ruleset:2370
+#: data/civ2civ3/units.ruleset:2350 data/multiplayer/units.ruleset:2227
 msgid "?spy_level:agent"
 msgstr "agentti"
 
 #. TRANS: Spy veteran level
-#: data/classic/units.ruleset:2128 data/sandbox/units.ruleset:2369
-#: data/civ2civ3/units.ruleset:2349 data/multiplayer/units.ruleset:2226
+#: data/classic/units.ruleset:2131 data/sandbox/units.ruleset:2372
+#: data/civ2civ3/units.ruleset:2352 data/multiplayer/units.ruleset:2229
 msgid "?spy_level:spymaster"
 msgstr "mestarivakooja"
 
-#: data/classic/units.ruleset:2158 data/multiplayer/units.ruleset:2256
+#: data/classic/units.ruleset:2161 data/multiplayer/units.ruleset:2259
 msgid ""
 "Spies built under a Communist government will start at the first veteran "
 "level (handler)."
@@ -25683,7 +25766,7 @@ msgstr ""
 "Kommunistisen hallinnon alla rakennetut vakoojat aloittavat valmiiksi "
 "ylennettynä ensimmäiselle kokemustasolle (toimija)."
 
-#: data/classic/units.ruleset:2193
+#: data/classic/units.ruleset:2196
 msgid ""
 "Caravans can establish trade routes with your own cities or those of other "
 "nations (even enemies) by traveling to them. A route's ongoing revenue is "
@@ -25703,7 +25786,7 @@ msgstr ""
 "päätepisteet vai vain toisen niistä: jos omistat vain yhden kaupungeista, "
 "saat vain sen tuoton mutta sen tuotto on kaksinkertainen."
 
-#: data/classic/units.ruleset:2202
+#: data/classic/units.ruleset:2205
 msgid ""
 "Initially cities can support a maximum of two trade routes. Knowledge of the "
 "technologies Magnetism and The Corporation each increase this limit by one; "
@@ -25713,30 +25796,30 @@ msgstr ""
 "magnetismin että osakeyhtiöiden tuntemus mahdollistaa yhden lisäkauppareitin "
 "perustamisen. Jos ne tunnetaan molemmat, kauppareittejä voi perustaa neljä."
 
-#: data/classic/units.ruleset:2279 data/sandbox/units.ruleset:2532
-#: data/civ2civ3/units.ruleset:2511 data/multiplayer/units.ruleset:2365
+#: data/classic/units.ruleset:2282 data/sandbox/units.ruleset:2535
+#: data/civ2civ3/units.ruleset:2514 data/multiplayer/units.ruleset:2368
 msgid "?unit:Leader"
 msgstr "Hallitsija"
 
-#: data/classic/units.ruleset:2313 data/sandbox/units.ruleset:2566
-#: data/civ2civ3/units.ruleset:2545 data/multiplayer/units.ruleset:2399
+#: data/classic/units.ruleset:2316 data/sandbox/units.ruleset:2569
+#: data/civ2civ3/units.ruleset:2548 data/multiplayer/units.ruleset:2402
 msgid "This is you. If you lose this unit, you lose the game. So don't."
 msgstr ""
 "Tämä yksikkö edustaa sinua. Häviät pelin jos menetät tämän yksikön; "
 "ymmärtänet miksi."
 
-#: data/classic/units.ruleset:2315 data/sandbox/units.ruleset:2568
-#: data/civ2civ3/units.ruleset:2547 data/multiplayer/units.ruleset:2401
+#: data/classic/units.ruleset:2318 data/sandbox/units.ruleset:2571
+#: data/civ2civ3/units.ruleset:2550 data/multiplayer/units.ruleset:2404
 msgid "Won't unleash barbarians from huts."
 msgstr "· Ei vapauta barbaareita mökeistä."
 
-#: data/classic/units.ruleset:2362 data/sandbox/units.ruleset:2615
-#: data/civ2civ3/units.ruleset:2594 data/multiplayer/units.ruleset:2448
+#: data/classic/units.ruleset:2365 data/sandbox/units.ruleset:2618
+#: data/civ2civ3/units.ruleset:2597 data/multiplayer/units.ruleset:2451
 msgid "AWACS"
 msgstr "Tutkakone"
 
-#: data/classic/units.ruleset:2388 data/sandbox/units.ruleset:2641
-#: data/civ2civ3/units.ruleset:2620 data/multiplayer/units.ruleset:2474
+#: data/classic/units.ruleset:2391 data/sandbox/units.ruleset:2644
+#: data/civ2civ3/units.ruleset:2623 data/multiplayer/units.ruleset:2477
 msgid ""
 "The AWACS (Airborne Warning and Control System) is an airplane with an "
 "advanced radar that can determine the location of enemy units over a wide "
@@ -26349,13 +26432,7 @@ msgstr ""
 "ympärillä tuottavat yhden yksikön enemmän tiedettä."
 
 #: data/sandbox/buildings.ruleset:1435 data/civ2civ3/buildings.ruleset:1432
-#, fuzzy, no-c-format
-#| msgid ""
-#| "This stunning technological achievement makes one content citizen happy "
-#| "in each of your cities (2 extra luxury per city). It further reduces the "
-#| "risk of plague in the city (by 10% of the base chance); together with an "
-#| "Aqueduct, a Sewer System, and knowledge of Medicine, it entirely "
-#| "eliminates the risk of plague."
+#, no-c-format
 msgid ""
 "This stunning technological achievement makes one content citizen happy in "
 "each of your cities (2 extra luxury per city). It further reduces your risk "
@@ -26365,8 +26442,8 @@ msgid ""
 msgstr ""
 "Tämä saavutus tekee yhdestä tyytyväisestä kansalaisesta onnellisen kussakin "
 "kaupungissasi. Se vähentää myös ruton mahdollisuutta 10% "
-"perusmahdollisuudesta; yhdessä vesijohtojen, viemäröinnin ja lääketieteen "
-"tuntemuksen kanssa se poistaa ruton mahdollisuuden kokonaan."
+"perusmahdollisuudesta; lääketieteen tuntemuksen kanssa kaikki vesijohdoin ja "
+"viemäröinnein varustetut kaupungit ovat täysin turvassa rutolta."
 
 #: data/sandbox/buildings.ruleset:1460 data/civ2civ3/buildings.ruleset:1457
 msgid ""
@@ -26712,7 +26789,7 @@ msgstr "Hiekkalaatikko sääntökokoelma"
 
 #. TRANS: In the client, this is displayed alongside the contents of
 #. ;    README.sandbox, which are not localized.
-#: data/sandbox/game.ruleset:34
+#: data/sandbox/game.ruleset:40
 msgid ""
 "You are playing Freeciv with sandbox ruleset. This showcases new or unusual "
 "features available in Freeciv without regard for strict game balancing, "
@@ -26733,139 +26810,139 @@ msgstr ""
 "civ2civ3, pohjalta, sellaisena kuin se oli Freecivin versiossa 2.6."
 
 #. TRANS: Steal _Map Fragments and Escape (3% chance of success).
-#: data/sandbox/game.ruleset:322
+#: data/sandbox/game.ruleset:332
 #, fuzzy, c-format
 #| msgid "Steal %sGold%s"
 msgid "Steal %sMap Fragments and Escape%s"
 msgstr "%sVarasta kultaa%s"
 
 #. TRANS: _Bombard (100% chance of success).
-#: data/sandbox/game.ruleset:355 data/civ2civ3/game.ruleset:354
-#: data/alien/game.ruleset:318
+#: data/sandbox/game.ruleset:365 data/civ2civ3/game.ruleset:364
+#: data/alien/game.ruleset:328
 #, fuzzy, c-format
 #| msgid "Bombarder"
 msgid "%sBombard%s"
 msgstr "Pommittaja"
 
-#: data/sandbox/game.ruleset:1467 data/civ2civ3/game.ruleset:1310
+#: data/sandbox/game.ruleset:1482 data/civ2civ3/game.ruleset:1325
 msgid "Spaceship Launch"
 msgstr "Avaruusalus laukaistu"
 
-#: data/sandbox/game.ruleset:1471 data/civ2civ3/game.ruleset:1314
+#: data/sandbox/game.ruleset:1486 data/civ2civ3/game.ruleset:1329
 msgid "You're the first one to launch a spaceship towards Alpha Centauri!"
 msgstr "Olet ensimmäinen avaruusaluksen kohti Alpha Centauria laukaissut!"
 
-#: data/sandbox/game.ruleset:1472 data/civ2civ3/game.ruleset:1315
+#: data/sandbox/game.ruleset:1487 data/civ2civ3/game.ruleset:1330
 msgid "You have launched a spaceship towards Alpha Centauri!"
 msgstr "Olet laukaissut avaruusaluksen kohti Alpha Centauria!"
 
-#: data/sandbox/game.ruleset:1475 data/civ2civ3/game.ruleset:1318
+#: data/sandbox/game.ruleset:1490 data/civ2civ3/game.ruleset:1333
 msgid "Entire Map Known"
 msgstr "Koko kartta tunnettu"
 
-#: data/sandbox/game.ruleset:1480 data/civ2civ3/game.ruleset:1323
+#: data/sandbox/game.ruleset:1495 data/civ2civ3/game.ruleset:1338
 msgid "You're the first one to have mapped the entire world!"
 msgstr "Ensimmäisenä olet kartoittanut koko maailman!"
 
-#: data/sandbox/game.ruleset:1481 data/civ2civ3/game.ruleset:1324
+#: data/sandbox/game.ruleset:1496 data/civ2civ3/game.ruleset:1339
 msgid "You have mapped the entire world!"
 msgstr "Olet kartoittanut koko maailman!"
 
-#: data/sandbox/game.ruleset:1484 data/civ2civ3/game.ruleset:1327
+#: data/sandbox/game.ruleset:1499 data/civ2civ3/game.ruleset:1342
 msgid "Land Ahoy"
 msgstr "Maata näkyvissä"
 
-#: data/sandbox/game.ruleset:1489 data/civ2civ3/game.ruleset:1332
+#: data/sandbox/game.ruleset:1504 data/civ2civ3/game.ruleset:1347
 msgid "As the first people in history, your people sight a foreign shore!"
 msgstr "Ensimmäisenä löydät itsellesi vieraan rannan!"
 
-#: data/sandbox/game.ruleset:1490 data/civ2civ3/game.ruleset:1333
+#: data/sandbox/game.ruleset:1505 data/civ2civ3/game.ruleset:1348
 msgid "You sight your first foreign shore!"
 msgstr "Näet ensi kertaa vieraan saaren rannan!"
 
-#: data/sandbox/game.ruleset:1493 data/civ2civ3/game.ruleset:1336
+#: data/sandbox/game.ruleset:1508 data/civ2civ3/game.ruleset:1351
 msgid "Literate"
 msgstr "Lukutaitoisuus"
 
-#: data/sandbox/game.ruleset:1499 data/civ2civ3/game.ruleset:1342
+#: data/sandbox/game.ruleset:1514 data/civ2civ3/game.ruleset:1357
 #, no-c-format
 msgid "Your nation is the first to reach 100% literacy!"
 msgstr "Kansasi on ensimmäisenä saavuttanut 100% lukutaidon!"
 
-#: data/sandbox/game.ruleset:1501 data/civ2civ3/game.ruleset:1344
+#: data/sandbox/game.ruleset:1516 data/civ2civ3/game.ruleset:1359
 #, no-c-format
 msgid "Your nation has reached 100% literacy!"
 msgstr "Kansasi on saavuttanut 100% lukutaidon!"
 
-#: data/sandbox/game.ruleset:1504 data/civ2civ3/game.ruleset:1347
+#: data/sandbox/game.ruleset:1519 data/civ2civ3/game.ruleset:1362
 msgid "Multicultural"
 msgstr "Monikulttuurinen"
 
-#: data/sandbox/game.ruleset:1509 data/civ2civ3/game.ruleset:1352
+#: data/sandbox/game.ruleset:1524 data/civ2civ3/game.ruleset:1367
 msgid ""
 "You're the first nation with a city containing 2 different nationalities!"
 msgstr ""
 "Olette ensimmäisiä, joilla on kaupunki jossa on kahta eri kansalaisuutta!"
 
-#: data/sandbox/game.ruleset:1510 data/civ2civ3/game.ruleset:1353
+#: data/sandbox/game.ruleset:1525 data/civ2civ3/game.ruleset:1368
 msgid "One of your cities has 2 different nationalities!"
 msgstr "Yhdessä kaupungissasi on kahta eri kansalaisuutta!"
 
-#: data/sandbox/game.ruleset:1513 data/civ2civ3/game.ruleset:1356
+#: data/sandbox/game.ruleset:1528 data/civ2civ3/game.ruleset:1371
 msgid "Metropolis"
 msgstr "Metropoli"
 
-#: data/sandbox/game.ruleset:1518 data/civ2civ3/game.ruleset:1361
+#: data/sandbox/game.ruleset:1533 data/civ2civ3/game.ruleset:1376
 msgid "Your nation is the first with a city of population 20!"
 msgstr "Yksi kaupungeistasi saavuttaa ensimmäisenä maailmassa koon 20!"
 
-#: data/sandbox/game.ruleset:1519 data/civ2civ3/game.ruleset:1362
+#: data/sandbox/game.ruleset:1534 data/civ2civ3/game.ruleset:1377
 msgid "One of your cities has reached population 20!"
 msgstr "Yksi kaupungeistasi on saavuttanut koon 20!"
 
-#: data/sandbox/game.ruleset:1522 data/civ2civ3/game.ruleset:1365
+#: data/sandbox/game.ruleset:1537 data/civ2civ3/game.ruleset:1380
 msgid "Cultured City"
 msgstr "Kulttuurikaupunki"
 
-#: data/sandbox/game.ruleset:1527 data/civ2civ3/game.ruleset:1370
+#: data/sandbox/game.ruleset:1542 data/civ2civ3/game.ruleset:1385
 msgid "Your nation is the first with a city of 1000 culture points!"
 msgstr ""
 "Yksi kaupungeistasi on ensimmäinen 1000 kultturipistettä saavuttanut "
 "kaupunki maailmassa!"
 
-#: data/sandbox/game.ruleset:1528 data/civ2civ3/game.ruleset:1371
+#: data/sandbox/game.ruleset:1543 data/civ2civ3/game.ruleset:1386
 msgid "One of your cities has 1000 culture points!"
 msgstr "Yksi kaupungeistasi on saavuttanut 1000 kulttuuripistettä!"
 
-#: data/sandbox/game.ruleset:1531 data/civ2civ3/game.ruleset:1374
+#: data/sandbox/game.ruleset:1546 data/civ2civ3/game.ruleset:1389
 msgid "Cultured Nation"
 msgstr "Kulttuurivaltio"
 
-#: data/sandbox/game.ruleset:1535 data/civ2civ3/game.ruleset:1378
+#: data/sandbox/game.ruleset:1550 data/civ2civ3/game.ruleset:1393
 msgid "Your nation is the first one to achieve 10000 culture points!"
 msgstr "Valtiosi on ensimmäinen 10000 kultturipistettä saavuttanut valtio!"
 
-#: data/sandbox/game.ruleset:1536 data/civ2civ3/game.ruleset:1379
+#: data/sandbox/game.ruleset:1551 data/civ2civ3/game.ruleset:1394
 msgid "Your nation has achieved 10000 culture points!"
 msgstr "Valtiosi on saavuttanut 10000 kulttuuripistettä!"
 
-#: data/sandbox/game.ruleset:1608
+#: data/sandbox/game.ruleset:1623
 msgid "Wares"
 msgstr "Tuotteet"
 
-#: data/sandbox/game.ruleset:1632
+#: data/sandbox/game.ruleset:1647
 msgid "Jewelry"
 msgstr "Korut"
 
-#: data/sandbox/game.ruleset:1642
+#: data/sandbox/game.ruleset:1657
 msgid "Ore"
 msgstr "Malmi"
 
-#: data/sandbox/game.ruleset:1650
+#: data/sandbox/game.ruleset:1665
 msgid "Metal"
 msgstr "Metalli"
 
-#: data/sandbox/game.ruleset:1671
+#: data/sandbox/game.ruleset:1686
 msgid "Equipment"
 msgstr "Välineistö"
 
@@ -27309,7 +27386,7 @@ msgid "Travertine Terraces"
 msgstr "Marmoritasanteet"
 
 #: data/sandbox/script.lua:230 data/civ2civ3/script.lua:193
-#: data/alien/terrain.ruleset:1224
+#: data/alien/terrain.ruleset:1230
 msgid "Thermal Vent"
 msgstr "Hydroterminen purkausaukko"
 
@@ -27679,15 +27756,15 @@ msgstr ""
 "Suot ovat liian märkiä tuottoisaan viljelyyn. Järeät maayksiköt eivät voi "
 "liikkua tiettömällä suolla."
 
-#: data/sandbox/terrain.ruleset:1017 data/civ2civ3/terrain.ruleset:1016
+#: data/sandbox/terrain.ruleset:1019 data/civ2civ3/terrain.ruleset:1018
 msgid "?gui_type:Build Fort/Fortress/Buoy"
 msgstr "Rakenna linnaka, linnoitus tai poiju"
 
-#: data/sandbox/terrain.ruleset:1018 data/civ2civ3/terrain.ruleset:1017
+#: data/sandbox/terrain.ruleset:1022 data/civ2civ3/terrain.ruleset:1021
 msgid "?gui_type:Build Airstrip/Airbase"
 msgstr "Rakenna kiitorata tai lentotukikohta"
 
-#: data/sandbox/terrain.ruleset:1158 data/civ2civ3/terrain.ruleset:1157
+#: data/sandbox/terrain.ruleset:1164 data/civ2civ3/terrain.ruleset:1163
 msgid ""
 "Building an irrigation system on a suitable tile causes it to produce some "
 "extra food each turn. Most tiles yield one extra food; a desert with a river "
@@ -27698,7 +27775,7 @@ msgstr ""
 "lisää ruoantuotantoon; aavikkoruutu jossa on joki saa kaksi, ellei se saa "
 "etua jo keitaasta."
 
-#: data/sandbox/terrain.ruleset:1163 data/civ2civ3/terrain.ruleset:1162
+#: data/sandbox/terrain.ruleset:1169 data/civ2civ3/terrain.ruleset:1168
 msgid ""
 "Without knowledge of Electricity, irrigation requires a nearby source of "
 "water: an ocean, lake, or river tile, or another tile with an irrigation "
@@ -27713,7 +27790,7 @@ msgstr ""
 "vedenlähde poistettaisiin. Kun sähkö on keksitty, kaikki soveltuvat ruudut "
 "voidaan kastella ilman viereistä veden lähdettä."
 
-#: data/sandbox/terrain.ruleset:1202 data/civ2civ3/terrain.ruleset:1201
+#: data/sandbox/terrain.ruleset:1208 data/civ2civ3/terrain.ruleset:1207
 msgid ""
 "Mines can be built on some types of terrain, which increases the number of "
 "production points produced by that tile. Hills and Mountains get an extra 2 "
@@ -27724,7 +27801,7 @@ msgstr ""
 "ylimääräistä tuotantopistettä ruudulta, muut maastotyypit saavat 1 "
 "lisäpisteen."
 
-#: data/sandbox/terrain.ruleset:1233 data/civ2civ3/terrain.ruleset:1232
+#: data/sandbox/terrain.ruleset:1239 data/civ2civ3/terrain.ruleset:1238
 msgid ""
 "Once Refining is known, mines on Desert and Glacier tiles can be upgraded to "
 "oil wells for an extra production point."
@@ -27733,11 +27810,11 @@ msgstr ""
 "voidaan korottaa öljynporaustorneiksi, jolloin ne tuottavat yhden "
 "lisäpisteen verran enemmän."
 
-#: data/sandbox/terrain.ruleset:1239 data/civ2civ3/terrain.ruleset:1238
+#: data/sandbox/terrain.ruleset:1245 data/civ2civ3/terrain.ruleset:1244
 msgid "Oil Platform"
 msgstr "porauspiste"
 
-#: data/sandbox/terrain.ruleset:1258 data/civ2civ3/terrain.ruleset:1257
+#: data/sandbox/terrain.ruleset:1264 data/civ2civ3/terrain.ruleset:1263
 msgid ""
 "Oil platforms allow cities with Offshore Platforms to get an extra "
 "production point from Deep Ocean tiles."
@@ -27745,7 +27822,7 @@ msgstr ""
 "Porauspisteet sallivat kaupunkien joissa on öljynporauslautta saada yhden "
 "ylimääräisen tuotantopisteen syvänmeren ruuduista."
 
-#: data/sandbox/terrain.ruleset:1261 data/civ2civ3/terrain.ruleset:1260
+#: data/sandbox/terrain.ruleset:1267 data/civ2civ3/terrain.ruleset:1266
 msgid ""
 "Oil platforms can be built by Workers and similar units on board ships, or "
 "directly by Transport units."
@@ -27753,7 +27830,7 @@ msgstr ""
 "Työläiset ja samankaltaiset yksiköt voivat rakentaa porauspisteitä laivojen "
 "kyydissä. Kuljetusalukset voivat myös rakentaa niitä itsenäisesti."
 
-#: data/sandbox/terrain.ruleset:1284 data/civ2civ3/terrain.ruleset:1283
+#: data/sandbox/terrain.ruleset:1290 data/civ2civ3/terrain.ruleset:1289
 msgid ""
 "Pollution appears on tiles around cities with high production or population, "
 "or when a Mfg. Plant suffers an industrial accident. It halves all output "
@@ -27764,7 +27841,7 @@ msgstr ""
 "onnettomuus. Se puolittaa kaiken tuotannon ruudultaan, ja lisää "
 "ilmastonmuutoksen riskiä."
 
-#: data/sandbox/terrain.ruleset:1289 data/civ2civ3/terrain.ruleset:1288
+#: data/sandbox/terrain.ruleset:1295 data/civ2civ3/terrain.ruleset:1294
 msgid ""
 "The pollution can only be cleared by dispatching Workers, Migrants, "
 "Settlers, Engineers, or a Transport with the \"clean pollution\" order."
@@ -27772,7 +27849,7 @@ msgstr ""
 "Saasteen voi puhdistaa vain komentamalla työläiset, siirtolaiset, "
 "uudisraivaajat, teknikot tai kuljetusalukset siivoamaan saastetta."
 
-#: data/sandbox/terrain.ruleset:1299 data/civ2civ3/terrain.ruleset:1298
+#: data/sandbox/terrain.ruleset:1305 data/civ2civ3/terrain.ruleset:1304
 msgid ""
 "The city's population starts adding to pollution with the Factory, Super "
 "Highways, Offshore Platform, and Mfg. Plant buildings; each building causes "
@@ -27786,11 +27863,11 @@ msgstr ""
 "kaupungin parannuksesta, ja Eiffel-torni (ihme) kumoaa vaikutuksen yhdestä "
 "rakennuksesta kaikissa omistajansa kaupungeissa."
 
-#: data/sandbox/terrain.ruleset:1358
+#: data/sandbox/terrain.ruleset:1364
 msgid "Hermit's Place"
 msgstr "erakon maja"
 
-#: data/sandbox/terrain.ruleset:1379
+#: data/sandbox/terrain.ruleset:1384
 #, no-c-format
 msgid ""
 "One can explore Hermit's Places once the philosopher has abandoned them. In "
@@ -27804,12 +27881,12 @@ msgstr ""
 "tutkimushinnasta. Vuoden 1000 jälkeen kokonaisten uusien teknologioiden "
 "keksiminen on mahdotonta yksittäisille erakoille."
 
-#: data/sandbox/terrain.ruleset:1414 data/civ2civ3/terrain.ruleset:1383
+#: data/sandbox/terrain.ruleset:1419 data/civ2civ3/terrain.ruleset:1389
 msgid "Farmland on a tile prevents any trade bonus from Super Highways."
 msgstr ""
 "Viljelysmaa ruudulla estää kauppaedut jotka moottoritie muuten aiheuttaisi."
 
-#: data/sandbox/terrain.ruleset:1438 data/civ2civ3/terrain.ruleset:1407
+#: data/sandbox/terrain.ruleset:1443 data/civ2civ3/terrain.ruleset:1413
 msgid ""
 "Nuclear fallout can appear on tiles when a Nuclear unit is detonated, or "
 "when a city's Nuclear Plant has an accident. It halves all output from its "
@@ -27819,7 +27896,7 @@ msgstr ""
 "kaupungin ydinvoimalassa tapahtuu onnettomuus. Se puolittaa kaiken ruudun "
 "hyödyntämisen."
 
-#: data/sandbox/terrain.ruleset:1446 data/civ2civ3/terrain.ruleset:1415
+#: data/sandbox/terrain.ruleset:1451 data/civ2civ3/terrain.ruleset:1421
 msgid ""
 "Settlers, Workers, Migrants, Engineers, and Transport units can all clean up "
 "nuclear fallout."
@@ -27827,11 +27904,11 @@ msgstr ""
 "Uudisraivaajat, työläiset, siirtolaiset, teknikot ja kuljetusalukset voivat "
 "puhdistaa ydinlaskeumaa."
 
-#: data/sandbox/terrain.ruleset:1452 data/civ2civ3/terrain.ruleset:1421
+#: data/sandbox/terrain.ruleset:1457 data/civ2civ3/terrain.ruleset:1427
 msgid "Fort"
 msgstr "linnake"
 
-#: data/sandbox/terrain.ruleset:1478 data/civ2civ3/terrain.ruleset:1447
+#: data/sandbox/terrain.ruleset:1483 data/civ2civ3/terrain.ruleset:1453
 #, no-c-format
 msgid ""
 "Forts are rapidly-built fortifications providing some defense (+50%) against "
@@ -27841,7 +27918,7 @@ msgstr ""
 "puolustusbonuksen maayksiköiden ja laivojen hyökkäyksiä vastaan. Linnake "
 "tarvitaan ennen kuin paikalle voidaan rakentaa täysimittainen linnoitus."
 
-#: data/sandbox/terrain.ruleset:1512 data/civ2civ3/terrain.ruleset:1480
+#: data/sandbox/terrain.ruleset:1517 data/civ2civ3/terrain.ruleset:1486
 msgid ""
 "Fortresses are more permanent forts; construction on them can only begin "
 "once the underlying fort is complete. Forts on River tiles cannot be "
@@ -27851,7 +27928,7 @@ msgstr ""
 "aloittaa ennen kuin paikalle on rakennettu pohjaksi linnake. Jokiruutujen "
 "linnakkeita ei voi laajentaa linnoituksiksi."
 
-#: data/sandbox/terrain.ruleset:1518 data/civ2civ3/terrain.ruleset:1486
+#: data/sandbox/terrain.ruleset:1523 data/civ2civ3/terrain.ruleset:1492
 #, no-c-format
 msgid ""
 "Compared to a fort, units in a fortress receive extra defense (+50%) against "
@@ -27868,7 +27945,7 @@ msgstr ""
 "liikkumattomina linnoituksessa kierroksen ajan, paranevat neljänneksen "
 "osumapisteitään."
 
-#: data/sandbox/terrain.ruleset:1524 data/civ2civ3/terrain.ruleset:1492
+#: data/sandbox/terrain.ruleset:1529 data/civ2civ3/terrain.ruleset:1498
 msgid ""
 "With Astronomy, fortresses gain watchtowers from which units can see further "
 "afield."
@@ -27876,11 +27953,11 @@ msgstr ""
 "Astronomian tuntemuksen myötä linnoituksissa voidaan käyttää "
 "tähystystorneja, joista yksiköt näkevät kauemmas."
 
-#: data/sandbox/terrain.ruleset:1530 data/civ2civ3/terrain.ruleset:1498
+#: data/sandbox/terrain.ruleset:1535 data/civ2civ3/terrain.ruleset:1504
 msgid "Airstrip"
 msgstr "Kiitotie"
 
-#: data/sandbox/terrain.ruleset:1554 data/civ2civ3/terrain.ruleset:1522
+#: data/sandbox/terrain.ruleset:1559 data/civ2civ3/terrain.ruleset:1528
 msgid ""
 "Airstrips are rapidly-built runways allowing air units to land, refuel, and "
 "recover outside cities; an aircraft remaining on an airstrip for a whole "
@@ -27895,7 +27972,7 @@ msgstr ""
 "viettäessään kierroksen vaihdon ilmassa). Kiitoradalla olevat ilmayksiköt "
 "ovat kuitenkin maayksiköidenkin hyökkäysten armoilla."
 
-#: data/sandbox/terrain.ruleset:1562 data/civ2civ3/terrain.ruleset:1530
+#: data/sandbox/terrain.ruleset:1567 data/civ2civ3/terrain.ruleset:1536
 #, no-c-format
 msgid ""
 "Any units on an airstrip receive extra defense (+50%) against enemy aircraft."
@@ -27903,13 +27980,13 @@ msgstr ""
 "Kiitotiellä olevilla yksiköillä on 50% puolustusbonus vihollisen "
 "lentokoneiden hyökkäyksiä vastaan."
 
-#: data/sandbox/terrain.ruleset:1565 data/civ2civ3/terrain.ruleset:1533
+#: data/sandbox/terrain.ruleset:1570 data/civ2civ3/terrain.ruleset:1539
 msgid "An airstrip is necessary to start building an airbase."
 msgstr ""
 "Kiitotie tarvitaan ennen kuin ruutuun voidaan alkaa rakentamaan "
 "lentotukikohtaa."
 
-#: data/sandbox/terrain.ruleset:1596 data/civ2civ3/terrain.ruleset:1563
+#: data/sandbox/terrain.ruleset:1601 data/civ2civ3/terrain.ruleset:1569
 msgid ""
 "Airbases are more permanent airstrips; construction on them can only begin "
 "once the underlying airstrip is complete. Airstrips on River tiles cannot be "
@@ -27919,7 +27996,7 @@ msgstr ""
 "rakentaminen voidaan aloittaa vasta kun paikalla on jo kiitotie. "
 "Jokiruutujen kiitoteitä ei voi päivittää lentotukikohdaksi."
 
-#: data/sandbox/terrain.ruleset:1602 data/civ2civ3/terrain.ruleset:1569
+#: data/sandbox/terrain.ruleset:1607 data/civ2civ3/terrain.ruleset:1575
 #, no-c-format
 msgid ""
 "Compared to an airstrip, units in an airbase receive extra defense (+50%) "
@@ -27936,13 +28013,13 @@ msgstr ""
 "pidemmälle. Ilmayksiköt myös palautuvat nopeammin (kolmanneksen "
 "kierroksessa, saman määrän kuin lentokentättömässä kaupungissa)."
 
-#: data/sandbox/terrain.ruleset:1637
+#: data/sandbox/terrain.ruleset:1642
 msgid ""
 "Only those players that already know Radio can see Buoys of any players."
 msgstr ""
 "Vain ne pelaajat, jotka tuntevat radion, voivat nähdä kenenkään poijuja."
 
-#: data/sandbox/terrain.ruleset:1691
+#: data/sandbox/terrain.ruleset:1696
 msgid ""
 "Roads allow your land units to move more quickly, allow wheeled Big Land "
 "units such as Chariots and Catapults to travel through otherwise difficult "
@@ -27955,11 +28032,11 @@ msgstr ""
 "viidakossa tai suolla. Kaupankäyntiyksiköt, eli karavaanit ja rekka-autot, "
 "voivat kulkea vain teitä, rautateitä ja jokia pitkin tai laivan kyydissä."
 
-#: data/sandbox/terrain.ruleset:1697 data/civ2civ3/terrain.ruleset:1658
+#: data/sandbox/terrain.ruleset:1702 data/civ2civ3/terrain.ruleset:1664
 msgid "On some terrains, roads also provide a trade bonus."
 msgstr "Joillakin maastotyypeillä tiet antavat bonuksen myös kauppaan."
 
-#: data/sandbox/terrain.ruleset:1699 data/civ2civ3/terrain.ruleset:1660
+#: data/sandbox/terrain.ruleset:1704 data/civ2civ3/terrain.ruleset:1666
 msgid ""
 "Building roads on river tiles requires knowledge of Bridge Building. City "
 "center tiles automatically get roads (even on a river tile)."
@@ -27968,7 +28045,7 @@ msgstr ""
 "Kaupungin keskusruudut saavat tiet aina automaattisesti, jopa silloin kun "
 "sillanrakennusta ei tunneta."
 
-#: data/sandbox/terrain.ruleset:1730 data/civ2civ3/terrain.ruleset:1691
+#: data/sandbox/terrain.ruleset:1735 data/civ2civ3/terrain.ruleset:1697
 msgid ""
 "Once you learn the Railroad technology, you may upgrade your roads to "
 "railroads. Units travel considerably faster along railroads than along roads."
@@ -27977,12 +28054,12 @@ msgstr ""
 "rautatiet. Liikkuminen rautatietä pitkin on huomattavasti nopeampaa kuin "
 "tietä pitkin."
 
-#: data/sandbox/terrain.ruleset:1744 data/civ2civ3/terrain.ruleset:1705
-#: data/alien/techs.ruleset:435 data/alien/terrain.ruleset:1032
+#: data/sandbox/terrain.ruleset:1749 data/civ2civ3/terrain.ruleset:1711
+#: data/alien/techs.ruleset:435 data/alien/terrain.ruleset:1038
 msgid "Maglev"
 msgstr "Maglev"
 
-#: data/sandbox/terrain.ruleset:1768 data/civ2civ3/terrain.ruleset:1729
+#: data/sandbox/terrain.ruleset:1773 data/civ2civ3/terrain.ruleset:1735
 msgid ""
 "With sufficient technology, you may build magnetic levitation systems along "
 "your railroad routes. Land and Small Land units expend no movement points "
@@ -27993,7 +28070,7 @@ msgstr ""
 "eivät kuluta liikepisteitä kulkiessaan maglevillä, niitä pitkin voi liikkua "
 "rajattomasti (pätee myös niitä käyttäviin vihollisiin!)"
 
-#: data/sandbox/terrain.ruleset:1773 data/civ2civ3/terrain.ruleset:1734
+#: data/sandbox/terrain.ruleset:1778 data/civ2civ3/terrain.ruleset:1740
 msgid ""
 "Your regular railroads are still used to carry heavy Big Land and Merchant "
 "units for which the maglev system is unsuitable, and they continue to "
@@ -28004,7 +28081,7 @@ msgstr ""
 "kuljettaminen tapahtuu tavallisia rautateitä käyttäen. Rautatiet jatkavat "
 "myös tuotanto- ja kauppabonustensa tarjoamisen."
 
-#: data/sandbox/terrain.ruleset:1777 data/civ2civ3/terrain.ruleset:1738
+#: data/sandbox/terrain.ruleset:1782 data/civ2civ3/terrain.ruleset:1744
 msgid ""
 "City center tiles with railroads are automatically upgraded to maglev when "
 "you learn about Superconductors."
@@ -28012,7 +28089,7 @@ msgstr ""
 "Kaupunkien keskusruudut, joissa on jo rautatie, saavat maglevit "
 "automaattisesti kun suprajohteet teknologia opitaan."
 
-#: data/sandbox/terrain.ruleset:1799 data/civ2civ3/terrain.ruleset:1760
+#: data/sandbox/terrain.ruleset:1804 data/civ2civ3/terrain.ruleset:1766
 #, no-c-format
 msgid ""
 "Any land terrain type may have a River on it. A River adds 1 trade to the "
@@ -28022,7 +28099,7 @@ msgstr ""
 "Kaikkien maaruutujen läpi voi virrata joki. Joki lisää ruudun tuottamaa "
 "kauppaa yhden yksikön verran. Se myös nostaa ruudun puolustuskerrointa 25%."
 
-#: data/sandbox/terrain.ruleset:1803
+#: data/sandbox/terrain.ruleset:1808
 msgid ""
 "Land units may move along rivers for faster travel (but not diagonally), and "
 "Merchant units (Caravans and Freight) may require rivers to travel along in "
@@ -28034,7 +28111,7 @@ msgstr ""
 "autot, voivat teiden puutteessa kulkea jokia pitkin. Kaleerit, toisin kuin "
 "myöhemmät alukset, voivat myös kulkea jokia pitkin."
 
-#: data/sandbox/terrain.ruleset:1808 data/civ2civ3/terrain.ruleset:1767
+#: data/sandbox/terrain.ruleset:1813 data/civ2civ3/terrain.ruleset:1773
 msgid ""
 "Roads and railroads can only be built on River tiles if your civilization "
 "has learned Bridge Building technology. Fortresses and Airbases cannot be "
@@ -28044,7 +28121,7 @@ msgstr ""
 "sivilisaatiosi on oppinut sillanrakennustaidon. Linnoituksia ja "
 "lentotukikohtia ei voida rakentaa jokiruutuihin."
 
-#: data/sandbox/terrain.ruleset:1812 data/civ2civ3/terrain.ruleset:1771
+#: data/sandbox/terrain.ruleset:1817 data/civ2civ3/terrain.ruleset:1777
 msgid ""
 "Cities built on or next to rivers incur a small risk of flooding, which will "
 "destroy stored food."
@@ -28145,7 +28222,7 @@ msgstr "järeiden maavoimien"
 msgid "?unitclass:Merchant"
 msgstr "kaupankävijöiden"
 
-#: data/sandbox/units.ruleset:511 data/civ2civ3/units.ruleset:501
+#: data/sandbox/units.ruleset:514 data/civ2civ3/units.ruleset:504
 msgid ""
 "Settlers can also perform some of the same terrain alterations as Workers "
 "(but cannot build airstrips, airbases, or buoys)."
@@ -28153,7 +28230,7 @@ msgstr ""
 "Uudisasukkaat voivat myös tehdä samat maastonmuokkaukset kuin työläiset "
 "(paitsi kiitoteiden, lentotukikohdan tai poijun rakentamisen)."
 
-#: data/sandbox/units.ruleset:514 data/civ2civ3/units.ruleset:504
+#: data/sandbox/units.ruleset:517 data/civ2civ3/units.ruleset:507
 msgid ""
 "TIP: optimal production of Settlers occurs in cities of at most size 4, or "
 "cities with a Granary of at most size 6."
@@ -28162,11 +28239,11 @@ msgstr ""
 "viljosiilon sisältävien kaupunkien tapauksessa korkeintaan koon kuusi, "
 "kaupungeissa."
 
-#: data/sandbox/units.ruleset:520 data/civ2civ3/units.ruleset:510
+#: data/sandbox/units.ruleset:523 data/civ2civ3/units.ruleset:513
 msgid "Migrants"
 msgstr "Siirtolaiset"
 
-#: data/sandbox/units.ruleset:552 data/civ2civ3/units.ruleset:542
+#: data/sandbox/units.ruleset:555 data/civ2civ3/units.ruleset:545
 msgid ""
 "Migrants can be used to transfer population to other cities, but may not "
 "found new cities. They can also perform some of the same terrain alterations "
@@ -28177,7 +28254,7 @@ msgstr ""
 "joitakin samoista maastonmuokkauksista kuin uudisasukkaat (mutta eivät voi "
 "rakentaa kiitoteitä, lentotukikohtia tai poijuja)."
 
-#: data/sandbox/units.ruleset:557 data/civ2civ3/units.ruleset:547
+#: data/sandbox/units.ruleset:560 data/civ2civ3/units.ruleset:550
 msgid ""
 "TIP: Migrants can be a good alternative to Workers in overpopulated cities, "
 "as they benefit from free food upkeep."
@@ -28185,7 +28262,7 @@ msgstr ""
 "VIHJE: Siirotlaiset voivat olla hyvä vaihtoehto työläisille kaupungeissa "
 "joissa on turhan suuri väestö, koska ne hyötyvät ilmaisesta ruokaylläpidosta."
 
-#: data/sandbox/units.ruleset:598 data/civ2civ3/units.ruleset:588
+#: data/sandbox/units.ruleset:601 data/civ2civ3/units.ruleset:591
 msgid ""
 "Workers can build airstrips, airbases, and buoys, which Settlers and "
 "Migrants cannot. Workers must be on board a ship to build buoys."
@@ -28194,23 +28271,23 @@ msgstr ""
 "kuin uudisasukkaat tai siirtolaiset. Poijujen rakentamiseksi yksikön täytyy "
 "olla laivan kyydissä."
 
-#: data/sandbox/units.ruleset:629 data/civ2civ3/units.ruleset:619
+#: data/sandbox/units.ruleset:632 data/civ2civ3/units.ruleset:622
 msgid "beginner"
 msgstr "aloittelija"
 
-#: data/sandbox/units.ruleset:629 data/civ2civ3/units.ruleset:619
+#: data/sandbox/units.ruleset:632 data/civ2civ3/units.ruleset:622
 msgid "seasoned"
 msgstr "kokenut"
 
-#: data/sandbox/units.ruleset:629 data/civ2civ3/units.ruleset:619
+#: data/sandbox/units.ruleset:632 data/civ2civ3/units.ruleset:622
 msgid "senior"
 msgstr "vanhempi tekijä"
 
-#: data/sandbox/units.ruleset:629 data/civ2civ3/units.ruleset:619
+#: data/sandbox/units.ruleset:632 data/civ2civ3/units.ruleset:622
 msgid "expert"
 msgstr "asiantuntija"
 
-#: data/sandbox/units.ruleset:635 data/civ2civ3/units.ruleset:625
+#: data/sandbox/units.ruleset:638 data/civ2civ3/units.ruleset:628
 msgid ""
 "Engineers are similar to Workers, but they work twice as fast, move twice as "
 "fast, and may gain experience from work enabling them to work even faster."
@@ -28220,7 +28297,7 @@ msgstr ""
 "työkokemuksen myötä saada entistä nopeamman työskentelyn mahdollistavia "
 "ylennyksiä."
 
-#: data/sandbox/units.ruleset:639 data/civ2civ3/units.ruleset:629
+#: data/sandbox/units.ruleset:642 data/civ2civ3/units.ruleset:632
 msgid ""
 "With knowledge of Fusion Power, Engineers may also perform more radical "
 "terrain transformations than Workers, Settlers, or Migrants, with the "
@@ -28236,11 +28313,11 @@ msgstr ""
 "paljon maaruutuja valmiiksi ruudun ympärillä). Lue lisää kappaleesta "
 "Maastonmuokkaukset."
 
-#: data/sandbox/units.ruleset:739 data/civ2civ3/units.ruleset:729
+#: data/sandbox/units.ruleset:742 data/civ2civ3/units.ruleset:732
 msgid "Archers fight with bows and arrows and have a good offensive value."
 msgstr "Jousimiehet taistelevat jousin ja nuolin. Niiden hyökkäysteho on hyvä."
 
-#: data/sandbox/units.ruleset:940 data/civ2civ3/units.ruleset:930
+#: data/sandbox/units.ruleset:943 data/civ2civ3/units.ruleset:933
 msgid ""
 "A number of Partisans are granted free when an enemy conquers your city -- "
 "they automatically assume defensive positions in the surrounding countryside "
@@ -28259,7 +28336,7 @@ msgstr ""
 " - Olet saavuttanut edistysaskeleet Kommunismi ja Ruuti.\n"
 " - Valtiomuotosi on joko demokratia tai kommunismi."
 
-#: data/sandbox/units.ruleset:982 data/civ2civ3/units.ruleset:972
+#: data/sandbox/units.ruleset:985 data/civ2civ3/units.ruleset:975
 msgid ""
 "Fundamentalist nations can maintain Fanatic units without having to pay any "
 "upkeep nor causing military unhappiness.  Instead, each unit reduces the "
@@ -28268,7 +28345,7 @@ msgstr ""
 "Fundamentalistivaltioiden ei tarvitse huolehtia fanaatikkoyksiköiden "
 "ylläpidosta. Sen sijaan jokainen yksikkö pienentää kaupungin kokoa yhdellä."
 
-#: data/sandbox/units.ruleset:1050 data/civ2civ3/units.ruleset:1040
+#: data/sandbox/units.ruleset:1053 data/civ2civ3/units.ruleset:1043
 msgid ""
 "Paratroopers are experts at airborne attacks. From a friendly city, airbase, "
 "or airstrip, Paratroopers who have not expended any movement points can "
@@ -28284,11 +28361,11 @@ msgstr ""
 "alueelle johon sinulla ei ole näköyhteyttä, sillä vihollisyksiköiden "
 "miehittämään ruutuun hypätessään laskuvarjojoukot ovat helppoja kohteita!)"
 
-#: data/sandbox/units.ruleset:1057
+#: data/sandbox/units.ruleset:1060
 msgid "Veteran Paratroopers can land on forest and jungle tiles."
 msgstr "Konkarilaskuvarjojääkärit voivat hypätä metsä- ja viidakkoruutuihin."
 
-#: data/sandbox/units.ruleset:1089 data/civ2civ3/units.ruleset:1079
+#: data/sandbox/units.ruleset:1092 data/civ2civ3/units.ruleset:1082
 msgid ""
 "The Mechanized Infantry has the strongest inherent defensive strength of any "
 "land unit, and is very fast on roads and easy terrain, but it is hindered "
@@ -28300,7 +28377,7 @@ msgstr ""
 "(vuoret, suot, viidakot) se ei voi liikkua ja se on käytettävissä vasta "
 "aivan pelin loppuvaiheessa."
 
-#: data/sandbox/units.ruleset:1157 data/civ2civ3/units.ruleset:1147
+#: data/sandbox/units.ruleset:1160 data/civ2civ3/units.ruleset:1150
 msgid ""
 "Chariots are horse-pulled war wagons. They have a stronger attack than "
 "Horsemen, but their speed comes at a cost: they are more expensive to build, "
@@ -28314,7 +28391,7 @@ msgstr ""
 "(vuoret, rämeent ja viidakot) jollei siellä ole teitä. Alkupelin alukset "
 "(kaleeri ja karaveli) eivät kykene kuljettamaan niitä."
 
-#: data/sandbox/units.ruleset:1193 data/civ2civ3/units.ruleset:1183
+#: data/sandbox/units.ruleset:1196 data/civ2civ3/units.ruleset:1186
 msgid ""
 "Elephants are towering animals trained for war that are often used as "
 "powerful shock troops."
@@ -28322,7 +28399,7 @@ msgstr ""
 "Sotanorsupartiossa on jättiläismäisiä sotaan koulutettuja eläimiä. Niitä "
 "käytetään usein voimakkaina rynnäkköyksikköinä."
 
-#: data/sandbox/units.ruleset:1351 data/civ2civ3/units.ruleset:1341
+#: data/sandbox/units.ruleset:1354 data/civ2civ3/units.ruleset:1344
 msgid ""
 "Armors are motorized war wagons that are faster, stronger, and can take more "
 "damage than any mounted unit. However, they are less adaptable to very rough "
@@ -28335,7 +28412,7 @@ msgstr ""
 "viidakossa muutoin kuin teitä pitkin, eikä maasto tarjoa niille "
 "puolustusbonuksia."
 
-#: data/sandbox/units.ruleset:1390 data/civ2civ3/units.ruleset:1380
+#: data/sandbox/units.ruleset:1393 data/civ2civ3/units.ruleset:1383
 msgid ""
 "While powerful, Catapults (and their successors) are bulky and awkward; they "
 "require roads to move in rough terrain (mountains, swamps, and jungles), are "
@@ -28347,7 +28424,7 @@ msgstr ""
 "heikko, ja ne ovat liian suuria varhaisten laivojen (kaleerit ja karavelit) "
 "kuljettaa."
 
-#: data/sandbox/units.ruleset:1424 data/civ2civ3/units.ruleset:1414
+#: data/sandbox/units.ruleset:1427 data/civ2civ3/units.ruleset:1417
 msgid ""
 "Cannons are large firearms that can fire heavy projectiles over long "
 "distances. As with the catapults they replace, they are very strong "
@@ -28359,7 +28436,7 @@ msgstr ""
 "tarvitsevat siksi saattojoukkoja toimiakseen tehokkaasti, eivätkä ne voi "
 "kulkea missä hyvänsä maastossa."
 
-#: data/sandbox/units.ruleset:1458 data/civ2civ3/units.ruleset:1448
+#: data/sandbox/units.ruleset:1461 data/civ2civ3/units.ruleset:1451
 msgid ""
 "The artillery is an upgraded cannon. As with its predecessors, it is a very "
 "strong attacker but equally weak defender and will need an escort to be "
@@ -28369,7 +28446,7 @@ msgstr ""
 "mutta toivoton puolustaja ja tarvitsee siksi saattojoukon toimiakseen "
 "tehokkaasti, eivätkä ne voi kulkea missä hyvänsä maastossa."
 
-#: data/sandbox/units.ruleset:1491 data/civ2civ3/units.ruleset:1481
+#: data/sandbox/units.ruleset:1494 data/civ2civ3/units.ruleset:1484
 msgid ""
 "Howitzers are upgraded artillery with improved defensive as well as "
 "offensive capabilities. However, they still have the limited mobility of "
@@ -28379,7 +28456,7 @@ msgstr ""
 "Tykistöön verrattuna. Niillä on silti yhä rajoituksensa hankalissa "
 "maastoissa liikkumisessa."
 
-#: data/sandbox/units.ruleset:1530 data/civ2civ3/units.ruleset:1520
+#: data/sandbox/units.ruleset:1533 data/civ2civ3/units.ruleset:1523
 #, no-c-format
 msgid ""
 "Fighters and other aircraft lose 10% of their hitpoints for every turn not "
@@ -28389,7 +28466,7 @@ msgstr ""
 "kierroksella, jota ne eivät vietä kaupungissa, kiitotiellä, "
 "lentotukikohdassa tai tukialuksella."
 
-#: data/sandbox/units.ruleset:1566 data/civ2civ3/units.ruleset:1556
+#: data/sandbox/units.ruleset:1569 data/civ2civ3/units.ruleset:1559
 msgid ""
 "A Bomber's attack against units on land is a bombard attack; against units "
 "on water it has a regular attack."
@@ -28397,7 +28474,7 @@ msgstr ""
 "Maaruutuja vastaan hyökkäävän pommikoneen hyökkäys on pommitushyökkäys. "
 "Meriruutuihin se hyökää tavallisen hyökkäyksen säännöin."
 
-#: data/sandbox/units.ruleset:1571 data/civ2civ3/units.ruleset:1561
+#: data/sandbox/units.ruleset:1574 data/civ2civ3/units.ruleset:1564
 #, no-c-format
 msgid ""
 "As with other aircraft, Bombers lose 10% of their hitpoints for every turn "
@@ -28407,7 +28484,7 @@ msgstr ""
 "jokaisella kierroksen vaihdolla, jonka ne viettävät ilmassa, eivätkä "
 "kaupungissa, kiitotiellä, lentotukikohdassa tai lentotukialuksella."
 
-#: data/sandbox/units.ruleset:1606 data/civ2civ3/units.ruleset:1596
+#: data/sandbox/units.ruleset:1609 data/civ2civ3/units.ruleset:1599
 msgid ""
 "A Helicopter's attack against units on land is a bombard attack; against "
 "units on water it has a regular attack."
@@ -28415,7 +28492,7 @@ msgstr ""
 "Maaruutuja vastaan hyökkäävän helikopterin hyökkäys on pommitushyökkäys. "
 "Meriruutuihin se hyökää tavallisen hyökkäyksen säännöin."
 
-#: data/sandbox/units.ruleset:1609 data/civ2civ3/units.ruleset:1599
+#: data/sandbox/units.ruleset:1612 data/civ2civ3/units.ruleset:1602
 msgid ""
 "Helicopters can also transport one military land unit; while most troops "
 "must load or unload in a city, airstrip, or airbase (and not in the field or "
@@ -28430,7 +28507,7 @@ msgstr ""
 "alppijääkäreille, merijalkaväelle, sissijoukoille ja fanaatikoille) se "
 "voidaan tehdä missä vain."
 
-#: data/sandbox/units.ruleset:1615 data/civ2civ3/units.ruleset:1605
+#: data/sandbox/units.ruleset:1618 data/civ2civ3/units.ruleset:1608
 msgid ""
 "Unlike other aircraft, Helicopters are not required to return to a city, "
 "base, or Carrier to refuel after a set number of turns; however, care must "
@@ -28442,7 +28519,7 @@ msgstr ""
 "tarkkana, sillä lennosa ollessaan ne menettävät terveyttään tasaiseen "
 "tahtiin."
 
-#: data/sandbox/units.ruleset:1718 data/civ2civ3/units.ruleset:1708
+#: data/sandbox/units.ruleset:1721 data/civ2civ3/units.ruleset:1711
 msgid ""
 "The Trireme is your first boat unit. It can act as a transport ship and has "
 "rudimentary offensive capabilities, and unlike later boats can travel on "
@@ -28453,14 +28530,14 @@ msgstr ""
 "pystyy kulkemaan jokia pitkin. Syvänmeren ruuduilla se sen sijaan ei pysty "
 "liikkumaan."
 
-#: data/sandbox/units.ruleset:1754
+#: data/sandbox/units.ruleset:1757
 msgid ""
 "The Caravel is a sailing ship that can enter any ocean tile, but have to "
 "spend at least every third turn change next to land to load supplies for the "
 "crew."
 msgstr ""
 
-#: data/sandbox/units.ruleset:1788 data/civ2civ3/units.ruleset:1777
+#: data/sandbox/units.ruleset:1791 data/civ2civ3/units.ruleset:1780
 msgid ""
 "The Galleon is a pure transport ship, the first which can transport large "
 "wheeled units. It cannot attack other ships, though it may still defend "
@@ -28470,7 +28547,7 @@ msgstr ""
 "kuljettamiseen kykenevä. Se ei voi hyökätä toisten laivojen kimppuun; se "
 "kykenee silti tosin puolustautumaan hyökkäykseltä."
 
-#: data/sandbox/units.ruleset:1821 data/civ2civ3/units.ruleset:1810
+#: data/sandbox/units.ruleset:1824 data/civ2civ3/units.ruleset:1813
 msgid ""
 "The Frigate is a specialized ship with a strong offensive value, and can "
 "attack units on land, but it cannot transport units."
@@ -28478,12 +28555,12 @@ msgstr ""
 "Fregatti on vahva hyökkääjä, kykenevä hyökkäämään rannallakin olevia "
 "yksiköitä vastaan. Se ei kykene kuljettamaan muita yksiköitä."
 
-#: data/sandbox/units.ruleset:1853 data/civ2civ3/units.ruleset:1842
+#: data/sandbox/units.ruleset:1856 data/civ2civ3/units.ruleset:1845
 msgid "The Ironclad is an armored ship, more sturdy than the Frigate."
 msgstr ""
 "Panssarilaiva on panssaroitu alus joka on paljon kestävämpi kuin fregatti."
 
-#: data/sandbox/units.ruleset:1889 data/civ2civ3/units.ruleset:1878
+#: data/sandbox/units.ruleset:1892 data/civ2civ3/units.ruleset:1881
 msgid ""
 "An improved Ironclad, with better move rate and vision. Anti-submarine "
 "weapons double its defense against Submarines."
@@ -28491,7 +28568,7 @@ msgstr ""
 "Kehittyneempi panssarilaiva, jolla on parempi liikkuvuus ja näkökenttä. "
 "Erityisaseistus kaksinkertaistaa sen puolustusarvon sukellusveneitä vastaan."
 
-#: data/sandbox/units.ruleset:1892 data/civ2civ3/units.ruleset:1881
+#: data/sandbox/units.ruleset:1895 data/civ2civ3/units.ruleset:1884
 msgid ""
 "TIP:  A very fast unit, which is very useful for hunting down enemy "
 "Transports and Submarines."
@@ -28499,7 +28576,7 @@ msgstr ""
 "VIHJE: Erittäin nopea alus, joka sopii hyvin vihollisen kuljetusalusten ja "
 "sukellusveneiden metsästämiseen."
 
-#: data/sandbox/units.ruleset:2068 data/civ2civ3/units.ruleset:2051
+#: data/sandbox/units.ruleset:2071 data/civ2civ3/units.ruleset:2054
 msgid ""
 "It can transport aircraft and military land units (not wheeled), although "
 "land units cannot always be transferred to and from Helicopters while "
@@ -28509,7 +28586,7 @@ msgstr ""
 "varustettuja), vaikkakaan yksköitä ei aina voi siirtää kannelle "
 "laskeutuneesta helikopterista tai helikopteriin (Ks. Helikopteri)"
 
-#: data/sandbox/units.ruleset:2115 data/civ2civ3/units.ruleset:2098
+#: data/sandbox/units.ruleset:2118 data/civ2civ3/units.ruleset:2101
 #, fuzzy
 #| msgid ""
 #| "Transports can also clean pollution and fallout on water tiles, and with "
@@ -28524,7 +28601,7 @@ msgstr ""
 "Pientekniikan keksimisestä lähtien ne voivat rakentaa porauspisteitä syvän "
 "meren ruutuihin, porauslauttojen käytettäväksi."
 
-#: data/sandbox/units.ruleset:2192 data/civ2civ3/units.ruleset:2175
+#: data/sandbox/units.ruleset:2195 data/civ2civ3/units.ruleset:2178
 msgid ""
 "You can build Nuclear units when you have the required advance, and the "
 "Manhattan Project wonder has been built by any player. However, without "
@@ -28535,7 +28612,7 @@ msgstr ""
 "valmiiksi. Ilman lisäteknologiaa ne eivät voi kuitenkaan liikkua "
 "itsenäisesti."
 
-#: data/sandbox/units.ruleset:2196 data/civ2civ3/units.ruleset:2179
+#: data/sandbox/units.ruleset:2199 data/civ2civ3/units.ruleset:2182
 msgid ""
 "With Advanced Flight, all Nuclear units (including those already built) gain "
 "a range of 8 movement points, and Rocketry increases this to 16."
@@ -28544,7 +28621,7 @@ msgstr ""
 "ennemmin rakennetut) liikkua 8 liikepisteen verran, rakettitiede kasvattaa "
 "tämän 16 pisteeseen."
 
-#: data/sandbox/units.ruleset:2208
+#: data/sandbox/units.ruleset:2211
 msgid ""
 "Make sure that the upkeep (gold and shield) of your Nuclear is payed. A non "
 "maintained nuke will detonate in place."
@@ -28552,7 +28629,7 @@ msgstr ""
 "Pidä huolta että ydinkärkiesi ylläpito (sekä rahalliset kustannukset että "
 "tuotanto) tulee maksetuksi. Laiminlyöty ydinase räjähtää siellä missä on."
 
-#: data/sandbox/units.ruleset:2211 data/civ2civ3/units.ruleset:2191
+#: data/sandbox/units.ruleset:2214 data/civ2civ3/units.ruleset:2194
 msgid ""
 "TIP:  You may be involved in a situation where you've invaded an enemy "
 "country en masse, but the enemy cities are too strong. Before using a "
@@ -28567,7 +28644,7 @@ msgstr ""
 "se syntyy! Minimoit ydintalven syntymahdollisuuden ja käytät ydinaseitasi "
 "ympäristöystävällisesti!"
 
-#: data/sandbox/units.ruleset:2268 data/civ2civ3/units.ruleset:2248
+#: data/sandbox/units.ruleset:2271 data/civ2civ3/units.ruleset:2251
 msgid ""
 "Many covert actions may be attempted even in peacetime, but the more "
 "aggressive actions will be discovered and cause diplomatic incidents, giving "
@@ -28580,7 +28657,7 @@ msgstr ""
 "niitä sitovat sopimukset. Myös ydinasevallat vapautuvat Yhdistyneiden "
 "Kansakuntien asettamista rajoituksista."
 
-#: data/sandbox/units.ruleset:2274 data/civ2civ3/units.ruleset:2254
+#: data/sandbox/units.ruleset:2277 data/civ2civ3/units.ruleset:2257
 msgid ""
 "If a foreign unit is alone on a tile, you may attempt to bribe it with your "
 "Diplomat. By paying a sum of gold the unit will immediately become yours; "
@@ -28595,8 +28672,8 @@ msgstr ""
 "ei voi kuitenkaan lahjoa. Lahjonta muutoin kuin sodan osana aiheuttaa "
 "diplomaatisen selkkauksen."
 
-#: data/sandbox/units.ruleset:2291 data/sandbox/units.ruleset:2519
-#: data/civ2civ3/units.ruleset:2271 data/civ2civ3/units.ruleset:2498
+#: data/sandbox/units.ruleset:2294 data/sandbox/units.ruleset:2522
+#: data/civ2civ3/units.ruleset:2274 data/civ2civ3/units.ruleset:2501
 msgid ""
 " - \"Establish Embassy\": This action always succeeds, and gives permanent "
 "contact with the city's owner, as well as intelligence on their tax rates "
@@ -28609,7 +28686,7 @@ msgstr ""
 "jonka kanssa pelaajalla on lähetystö, laskee pelaajan kustannuksia tutkia "
 "teknologia itsekin."
 
-#: data/sandbox/units.ruleset:2314 data/civ2civ3/units.ruleset:2294
+#: data/sandbox/units.ruleset:2317 data/civ2civ3/units.ruleset:2297
 msgid ""
 " - \"Incite a Revolt\": In return for gold a foreign city will change "
 "allegiance and join your empire, bringing along all nearby units that call "
@@ -28629,7 +28706,7 @@ msgstr ""
 "federaatiolle tai demokratialle kuuluvassa kaupungissa. Kapinan lietsontaa "
 "voi yrittää rauhan aikana, mutta se aiheuttaa diplomaattisen selkkauksen."
 
-#: data/sandbox/units.ruleset:2328 data/civ2civ3/units.ruleset:2308
+#: data/sandbox/units.ruleset:2331 data/civ2civ3/units.ruleset:2311
 msgid ""
 "Diplomats built under Communist or Federation governments will start at the "
 "first veteran level (secretary)."
@@ -28637,7 +28714,7 @@ msgstr ""
 "Kommunistisen tai federaation hallinnon alla rakennetut diplomaatit "
 "aloittavat valmiiksi ylennettyinä ensimmäiselle kokemustasolle (sihteeri)."
 
-#: data/sandbox/units.ruleset:2399 data/civ2civ3/units.ruleset:2379
+#: data/sandbox/units.ruleset:2402 data/civ2civ3/units.ruleset:2382
 msgid ""
 "Spies built under Communist or Federation governments will start at the "
 "first veteran level (handler)."
@@ -28645,7 +28722,7 @@ msgstr ""
 "Kommunistisen tai federaation hallinnon alla rakennetut vakoojat aloittavat "
 "valmiiksi ylennettynä ensimmäiselle kokemustasolle (toimija)."
 
-#: data/sandbox/units.ruleset:2431 data/civ2civ3/units.ruleset:2411
+#: data/sandbox/units.ruleset:2434 data/civ2civ3/units.ruleset:2414
 msgid ""
 "A Caravan carries goods or material for trading with other nations, or to "
 "help build wonders in your own cities."
@@ -28653,7 +28730,7 @@ msgstr ""
 "Karavaani toimittaa tuotteita tai raaka-aineita myytäväksi muille kansoille, "
 "tai käytettäväksi ihmeen rakennusaineina omissa kaupungeissasi."
 
-#: data/sandbox/units.ruleset:2434
+#: data/sandbox/units.ruleset:2437
 msgid ""
 "Caravans can only travel on roads, railroads, rivers or ships. (Caravans "
 "cannot take advantage of maglevs, but may travel on the railroads that "
@@ -28663,7 +28740,7 @@ msgstr ""
 "kuljettamana. Karavaanien nopeuteen eivät maglevit vaikuta, vaan ne "
 "liikkuvat maglev-ruuduissakin vain alla olevan rautatien mukaista nopeutta."
 
-#: data/sandbox/units.ruleset:2438 data/civ2civ3/units.ruleset:2417
+#: data/sandbox/units.ruleset:2441 data/civ2civ3/units.ruleset:2420
 msgid ""
 "A Caravan sent to a foreign city (one not owned by an enemy) can establish a "
 "trade route. The route's ongoing revenue is doubled if the two cities "
@@ -28675,7 +28752,7 @@ msgstr ""
 "eri mantereilla. Kullakin kaupungilla voi olla korkeintaan kaksi "
 "kauppareittiä."
 
-#: data/sandbox/units.ruleset:2443 data/civ2civ3/units.ruleset:2422
+#: data/sandbox/units.ruleset:2446 data/civ2civ3/units.ruleset:2425
 msgid ""
 "A Caravan sent to one of your own cities that is building a wonder can add "
 "50 shields towards its production. If your city is not building a wonder, "
@@ -28685,7 +28762,7 @@ msgstr ""
 "auttaa ihmeen rakentamisessa 50 kilven verran. Omistajansa kaupunkeja, jotka "
 "eivät ole rakentamassa ihmettä, karavaani ei voi auttaa."
 
-#: data/sandbox/units.ruleset:2480 data/civ2civ3/units.ruleset:2459
+#: data/sandbox/units.ruleset:2483 data/civ2civ3/units.ruleset:2462
 msgid ""
 "The Freight unit replaces the Caravan, and moves at twice the speed. It has "
 "the same behavior and movement restrictions."
@@ -28693,7 +28770,7 @@ msgstr ""
 "Rekka korvaa karavaanin ja liikkuu kaksinkertaisella nopeudella. Sillä on "
 "samat liikkumisrajoitukset kuin karavaanilla."
 
-#: data/sandbox/units.ruleset:2515 data/civ2civ3/units.ruleset:2494
+#: data/sandbox/units.ruleset:2518 data/civ2civ3/units.ruleset:2497
 msgid ""
 "Explorers can also perform some actions in another player's city, and like "
 "Diplomats and Spies, the unit is not consumed by these harmless actions:"
@@ -28720,7 +28797,7 @@ msgstr "Civ2Civ3-sääntökokoelma"
 
 #. TRANS: In the client, this is displayed alongside the contents of
 #. ;    README.civ2civ3, which are not localized.
-#: data/civ2civ3/game.ruleset:34
+#: data/civ2civ3/game.ruleset:40
 #, fuzzy
 #| msgid ""
 #| "You are playing Freeciv with civ2civ3 rules:\n"
@@ -28753,7 +28830,7 @@ msgstr ""
 "Tarkat erot klassisiin sääntöihin nähden on selitetty tiedostossa README."
 "civ2civ3."
 
-#: data/civ2civ3/terrain.ruleset:1654
+#: data/civ2civ3/terrain.ruleset:1660
 msgid ""
 "Roads allow your land units to move more quickly, and allow wheeled Big Land "
 "units such as Chariots and Catapults to travel through otherwise difficult "
@@ -28764,7 +28841,7 @@ msgstr ""
 "pitkin niille muuten kulkukelvottomassa maastossa, kuten vuorilla, "
 "viidakossa tai suolla."
 
-#: data/civ2civ3/terrain.ruleset:1764
+#: data/civ2civ3/terrain.ruleset:1770
 msgid ""
 "Land units may move along rivers for faster travel (but not diagonally). "
 "Triremes may also travel up rivers (although later boats cannot)."
@@ -28783,12 +28860,12 @@ msgstr "Lennätettävä"
 msgid "Can be airlifted from a suitable city."
 msgstr "  · Voidaan lennättää sopivasta kaupungista.\n"
 
-#: data/civ2civ3/units.ruleset:1744
+#: data/civ2civ3/units.ruleset:1747
 msgid "The Caravel is a sailing ship that can enter any ocean tile."
 msgstr ""
 "Karaveli on purjealus, joka kykenee liikkumaan millaisella merellä hyvänsä."
 
-#: data/civ2civ3/units.ruleset:2414
+#: data/civ2civ3/units.ruleset:2417
 msgid ""
 "Caravans cannot take advantage of maglevs, but may travel on the railroads "
 "that accompany them."
@@ -29177,7 +29254,7 @@ msgstr "Vieras maailma"
 
 #. TRANS: In the client, this is displayed alongside the contents of
 #. ;    README.alien, which are not localized.
-#: data/alien/game.ruleset:36
+#: data/alien/game.ruleset:42
 msgid ""
 "One of the design goals of this ruleset was that it has to provide gameplay "
 "different from standard rules. Do not assume that any rules you know from "
@@ -29194,54 +29271,61 @@ msgstr ""
 "Alien_World ja http://www.cazfi.net/freeciv/alien/"
 
 #. TRANS: Copy Research _Data (3% chance of success).
-#: data/alien/game.ruleset:288
+#: data/alien/game.ruleset:298
 #, c-format
 msgid "Copy Research %sData%s"
 msgstr "Kopioi tutkimus%sdata%s"
 
 #. TRANS: Monetize Containers (100% chance of success).
-#: data/alien/game.ruleset:297
+#: data/alien/game.ruleset:307
 #, c-format
 msgid "Monetize %sContainers%s"
 msgstr "Myy %skollit%s"
 
-#: data/alien/game.ruleset:916
+#. TRANS: Transform by _Irrigate (3% chance of success).
+#: data/alien/game.ruleset:355
+#, fuzzy, c-format
+#| msgid "Transform to %s"
+msgid "Transform by %sIrrigate%s"
+msgstr "Muokkaa tästä %s"
+
+#: data/alien/game.ruleset:931
 msgid "Q1"
 msgstr "Kausi 1"
 
-#: data/alien/game.ruleset:917
+#: data/alien/game.ruleset:932
 msgid "Q2"
 msgstr "Kausi 2"
 
-#: data/alien/game.ruleset:918
+#: data/alien/game.ruleset:933
 msgid "Q3"
 msgstr "Kausi 3"
 
-#: data/alien/game.ruleset:919
+#: data/alien/game.ruleset:934
 msgid "Q4"
 msgstr "Kausi 4"
 
-#: data/alien/game.ruleset:922
+#: data/alien/game.ruleset:937
 msgid "GE"
 msgstr "ga"
 
-#: data/alien/game.ruleset:923
+#: data/alien/game.ruleset:938
 msgid "BGE"
 msgstr "ega"
 
-#: data/alien/game.ruleset:955
+#: data/alien/game.ruleset:970
 msgid "Radiation Burst"
 msgstr "Säteilypurske"
 
-#: data/alien/game.ruleset:960
+#: data/alien/game.ruleset:975
 msgid "Rebels"
 msgstr "Kapinallisia"
 
-#: data/alien/game.ruleset:965
+#: data/alien/game.ruleset:980
 msgid "Alien Microbes"
 msgstr "Vieraita mikrobeja"
 
-#: data/alien/game.ruleset:1065
+#: data/alien/game.ruleset:1080
 msgid "Commodities"
 msgstr "Tuotteet"
 
@@ -30275,11 +30359,11 @@ msgstr ""
 "Kaupungit voivat käyttää näitä ruutuja vasta kun lämmönhallintamoduli "
 "tunnetaan, eikä kaupunkia voi koskaan sijoittaa kiehuvalle merelle."
 
-#: data/alien/terrain.ruleset:738
+#: data/alien/terrain.ruleset:744
 msgid "Greenhouses"
 msgstr "Kasvihuoneita"
 
-#: data/alien/terrain.ruleset:754
+#: data/alien/terrain.ruleset:760
 msgid ""
 "Greenhouses can be built on certain terrain types to give a food bonus. "
 "Building Greenhouses requires the tile to have a water source:\n"
@@ -30293,36 +30377,36 @@ msgid ""
 "allowing Greenhouses to be built anywhere."
 msgstr ""
 
-#: data/alien/terrain.ruleset:782
+#: data/alien/terrain.ruleset:788
 msgid ""
 "Mines can be built on Hills for an extra production point. Once Burrowing is "
 "known, Thick Mountains can also be mined."
 msgstr ""
 
-#: data/alien/terrain.ruleset:805
+#: data/alien/terrain.ruleset:811
 msgid ""
 "Pollution appears on tiles around cities with high production. It halves all "
 "output from its tile."
 msgstr ""
 
-#: data/alien/terrain.ruleset:808
+#: data/alien/terrain.ruleset:814
 msgid ""
 "The pollution can only be cleared by dispatching Engineer or Hunter units "
 "with the \"clean pollution\" order."
 msgstr ""
 
-#: data/alien/terrain.ruleset:811
+#: data/alien/terrain.ruleset:817
 msgid ""
 "The contribution of production to pollution can be seen in the city dialog; "
 "once it exceeds a threshold, the excess is the percent chance of pollution "
 "appearing each turn."
 msgstr ""
 
-#: data/alien/terrain.ruleset:818
+#: data/alien/terrain.ruleset:824
 msgid "Space Capsule"
 msgstr "Avaruuskapseli"
 
-#: data/alien/terrain.ruleset:833
+#: data/alien/terrain.ruleset:839
 msgid ""
 "Space Capsules have landed to the surface of Deneb Seven. Any unit can enter "
 "tile with a capsule to open it. Capsule disappears from the map in the "
@@ -30332,11 +30416,11 @@ msgid ""
 "the capsule, and are there ready to kill anybody who enters."
 msgstr ""
 
-#: data/alien/terrain.ruleset:844
+#: data/alien/terrain.ruleset:850
 msgid "Protein Houses"
 msgstr "Proteiinihuoneita"
 
-#: data/alien/terrain.ruleset:865
+#: data/alien/terrain.ruleset:871
 #, no-c-format
 msgid ""
 "Once Protein Modifications are understood, Greenhouses can be upgraded to "
@@ -30345,31 +30429,31 @@ msgid ""
 "Protein Houses as soon as they are available."
 msgstr ""
 
-#: data/alien/terrain.ruleset:890
+#: data/alien/terrain.ruleset:896
 msgid ""
 "Fallout appears after Rebels strike a city. It halves all output from its "
 "tile."
 msgstr ""
 
-#: data/alien/terrain.ruleset:893
+#: data/alien/terrain.ruleset:899
 msgid ""
 "Fallout can only be cleared by dispatching Engineer or Hunter units with the "
 "\"clean fallout\" order."
 msgstr ""
 
-#: data/alien/terrain.ruleset:899
+#: data/alien/terrain.ruleset:905
 msgid "Tower"
 msgstr "Torni"
 
-#: data/alien/terrain.ruleset:925
+#: data/alien/terrain.ruleset:931
 msgid "Force Fortress"
 msgstr "Voimalinnoitus"
 
-#: data/alien/terrain.ruleset:950
+#: data/alien/terrain.ruleset:956
 msgid "Antigrav Base"
 msgstr "Antigravitaatiotukikohta"
 
-#: data/alien/terrain.ruleset:997
+#: data/alien/terrain.ruleset:1003
 msgid ""
 "Basic Road is available for building from the beginning of the game.\n"
 "\n"
@@ -30379,15 +30463,15 @@ msgstr ""
 "\n"
 "Ruohomaaruuduissa tie antaa yhden pisteen bonuksen kauppaan."
 
-#: data/alien/terrain.ruleset:1004
+#: data/alien/terrain.ruleset:1010
 msgid "Highway"
 msgstr "Valtatie"
 
-#: data/alien/terrain.ruleset:1027
+#: data/alien/terrain.ruleset:1033
 msgid "You can upgrade Roads to Highways."
 msgstr "Tavalliset tiet voidaan parantaa valtateiksi."
 
-#: data/alien/terrain.ruleset:1055
+#: data/alien/terrain.ruleset:1061
 #, no-c-format
 msgid ""
 "You can upgrade Highways to Maglevs.\n"
@@ -30400,22 +30484,22 @@ msgstr ""
 "Yksiköt voivat liikkua magleveja pitkin rajattomasti. Maglevit antavat 50% "
 "bonuksen ruudun tuotantoon."
 
-#: data/alien/terrain.ruleset:1063
+#: data/alien/terrain.ruleset:1069
 msgid "Tunnel"
 msgstr "Tunneli"
 
-#: data/alien/terrain.ruleset:1087
+#: data/alien/terrain.ruleset:1093
 #, no-c-format
 msgid ""
 "Earthly units can travel on radiating tiles with tunnel built on them. "
 "Tunnel provides no increase to unit speed, but they give 35% defense bonus."
 msgstr ""
 
-#: data/alien/terrain.ruleset:1093
+#: data/alien/terrain.ruleset:1099
 msgid "Burrow Tube"
 msgstr "Kaivuuputki"
 
-#: data/alien/terrain.ruleset:1114
+#: data/alien/terrain.ruleset:1120
 msgid ""
 "Burrow Tubes provide the only way for burrowing units to cross oceans. They "
 "can be built on oceanic terrains only, but first part of the tube must be "
@@ -30426,11 +30510,11 @@ msgstr ""
 "ensimmäisenä asennettavan pätkän täytyy olla maan rinnalla, ja putket täytyy "
 "asentaa siitä eteenpäin järjestyksessä."
 
-#: data/alien/terrain.ruleset:1122
+#: data/alien/terrain.ruleset:1128
 msgid "Green River"
 msgstr "Vihreä joki"
 
-#: data/alien/terrain.ruleset:1138 data/alien/terrain.ruleset:1162
+#: data/alien/terrain.ruleset:1144 data/alien/terrain.ruleset:1168
 #, fuzzy, no-c-format
 #| msgid ""
 #| "Any land terrain type may have a River on it.  A River adds 1 trade to "
@@ -30446,19 +30530,19 @@ msgstr ""
 "Maavoimien yksiköt voivat kulkea jokea pitkin, mutta eivät kulmittain "
 "olevien jokiruutujen välillä, tavallista nopeammin."
 
-#: data/alien/terrain.ruleset:1141
+#: data/alien/terrain.ruleset:1147
 msgid "Green River increases also tile's food production by 1."
 msgstr "Vihreä joki kasvattaa myös ruudun ruoan tuotantoa yhdellä pisteellä."
 
-#: data/alien/terrain.ruleset:1146
+#: data/alien/terrain.ruleset:1152
 msgid "Brown River"
 msgstr "Ruskea joki"
 
-#: data/alien/terrain.ruleset:1165
+#: data/alien/terrain.ruleset:1171
 msgid "Brown River increases also tile's shield production by 1."
 msgstr "Ruskea joki kasvattaa myös ruudun tuotantoa yhdellä pisteellä."
 
-#: data/alien/terrain.ruleset:1182
+#: data/alien/terrain.ruleset:1188
 #, fuzzy, no-c-format
 #| msgid ""
 #| "There is more than avarage amount of various resources, but nothing "
@@ -30469,11 +30553,11 @@ msgstr ""
 "Täällä on keskimääräistä enemmän luonnonvaroja, mutta ei mitään erityisen "
 "mielenkiintoista."
 
-#: data/alien/terrain.ruleset:1188
+#: data/alien/terrain.ruleset:1194
 msgid "Alien Mine"
 msgstr "Avaruusolentojen kaivos"
 
-#: data/alien/terrain.ruleset:1200
+#: data/alien/terrain.ruleset:1206
 #, no-c-format
 msgid ""
 "Mine run by superior alien technology ready to operate. We have no idea who "
@@ -30482,11 +30566,11 @@ msgstr ""
 "Tuntemattomalla teknologialla toimiva kaivos. Meillä ei ole aavistustakaan "
 "kuka laitteet on rakentanut tai minne he ovat menneet."
 
-#: data/alien/terrain.ruleset:1206
+#: data/alien/terrain.ruleset:1212
 msgid "Huge Plant"
 msgstr "Valtava kasvi"
 
-#: data/alien/terrain.ruleset:1218
+#: data/alien/terrain.ruleset:1224
 #, no-c-format
 msgid ""
 "Entire forest seems to be of the single fast-growing organism with huge "
@@ -30495,36 +30579,36 @@ msgstr ""
 "Koko metsä näyttää olevan yhtä ainoaa nopeasti kasvavaa kasvia, jolla on "
 "valtava keskuskukinto."
 
-#: data/alien/terrain.ruleset:1236
+#: data/alien/terrain.ruleset:1242
 #, no-c-format
 msgid "Where the heat from inside the planet escapes, mineral rich hills form."
 msgstr ""
 
-#: data/alien/terrain.ruleset:1254
+#: data/alien/terrain.ruleset:1260
 #, no-c-format
 msgid ""
 "Weird alien fish might look like something escaped from nightmares, but are "
 "in fact very tasty."
 msgstr ""
 
-#: data/alien/terrain.ruleset:1260
+#: data/alien/terrain.ruleset:1266
 msgid "Glowing Rocks"
 msgstr "Hehkuvia kiviä"
 
-#: data/alien/terrain.ruleset:1272
+#: data/alien/terrain.ruleset:1278
 #, no-c-format
 msgid "Rocks in the area have unusually bright glow."
 msgstr "Tämän alueen kivillä on poikkeuksellisen voimakas hehku."
 
-#: data/alien/units.ruleset:51 data/alien/units.ruleset:1413
+#: data/alien/units.ruleset:51 data/alien/units.ruleset:1416
 msgid "Regular"
 msgstr "Tavallinen"
 
-#: data/alien/units.ruleset:51 data/alien/units.ruleset:1413
+#: data/alien/units.ruleset:51 data/alien/units.ruleset:1416
 msgid "Elite"
 msgstr "Eliitti"
 
-#: data/alien/units.ruleset:51 data/alien/units.ruleset:1413
+#: data/alien/units.ruleset:51 data/alien/units.ruleset:1416
 msgid "Superb"
 msgstr "Erinomainen"
 
@@ -30548,7 +30632,7 @@ msgstr "antigravitaatio"
 msgid "?unitclass:Burrowing"
 msgstr "kaivautuvien"
 
-#: data/alien/units.ruleset:463
+#: data/alien/units.ruleset:466
 msgid ""
 "This is Earth technology settler. Most military enemy units can capture it "
 "instead of killing it."
@@ -30556,11 +30640,11 @@ msgstr ""
 "Tämä on maasta peräisin olevaa teknologiaa käyttävä uudisasukas. Useimmat "
 "vihollisen sotilasyksiköt voivat kaapata sen tappamisen sijaan."
 
-#: data/alien/units.ruleset:469
+#: data/alien/units.ruleset:472
 msgid "Native Settlers"
 msgstr "Luontainen uudisasukasjoukko"
 
-#: data/alien/units.ruleset:494
+#: data/alien/units.ruleset:497
 msgid ""
 "This is native Settler that can enter radiating areas. Most military enemy "
 "units can capture it instead of killing it."
@@ -30569,27 +30653,27 @@ msgstr ""
 "kulkea myös säteilevässä maastossa. Useimmat vihollisen sotilasyksiköt "
 "voivat vangita sen tappamisen sijaan."
 
-#: data/alien/units.ruleset:500
+#: data/alien/units.ruleset:503
 msgid "Engineer"
 msgstr "Teknikko"
 
-#: data/alien/units.ruleset:526
+#: data/alien/units.ruleset:529
 msgid "This is Earth technology engineer."
 msgstr "Tämän on maan teknologialla varustettu teknikko."
 
-#: data/alien/units.ruleset:531
+#: data/alien/units.ruleset:534
 msgid "Native Engineer"
 msgstr "Luontainen teknikkoryhmä"
 
-#: data/alien/units.ruleset:557
+#: data/alien/units.ruleset:560
 msgid "Native version of the Engineer unit."
 msgstr "Paikallisista olennoista muodostuva versio teknikkoryhmästä."
 
-#: data/alien/units.ruleset:562
+#: data/alien/units.ruleset:565
 msgid "Water Engineer"
 msgstr "Vesiteknikko"
 
-#: data/alien/units.ruleset:589
+#: data/alien/units.ruleset:592
 msgid ""
 "Amphibious Engineer that can also establish new cities on Ocean. Cities "
 "cannot be located on Boiling Ocean."
@@ -30597,11 +30681,11 @@ msgstr ""
 "Amfibinen teknikkoryhmä, joka voi myös perustaa kaupunkeja, myös merelle. "
 "Kiehuvan meren ruutuihin kaupunkeja ei voi perustaa."
 
-#: data/alien/units.ruleset:595
+#: data/alien/units.ruleset:598
 msgid "Star Marines"
 msgstr "Tähtijalkaväki"
 
-#: data/alien/units.ruleset:621
+#: data/alien/units.ruleset:624
 msgid ""
 "This unit may be built from the start of the game.  It is the weakest "
 "military unit."
@@ -30609,45 +30693,45 @@ msgstr ""
 "Näitä yksiköitä voi valmistaa heti pelin alussa. Se on kaikkein heikoin "
 "sotilasyksikkö."
 
-#: data/alien/units.ruleset:627
+#: data/alien/units.ruleset:630
 msgid "Cyborgs"
 msgstr "Cyborgit"
 
-#: data/alien/units.ruleset:653
+#: data/alien/units.ruleset:656
 msgid "Attack power to the early game."
 msgstr "Hyökkäysvoimaa pelin alkupuolelle."
 
-#: data/alien/units.ruleset:658
+#: data/alien/units.ruleset:661
 msgid "Tank"
 msgstr "Tankki"
 
-#: data/alien/units.ruleset:684
+#: data/alien/units.ruleset:687
 msgid "This is the most powerful Earth technology unit."
 msgstr "Tämä on voimakkain maasta perityn teknologian yksikkö."
 
-#: data/alien/units.ruleset:689
+#: data/alien/units.ruleset:692
 msgid "War Monster"
 msgstr "Sotahirviö"
 
-#: data/alien/units.ruleset:715
+#: data/alien/units.ruleset:718
 msgid "As a native unit, this can move and fight on radiating areas too."
 msgstr ""
 "Paikallisena olentona tämä voi liikkua ja taistella myös säteilevillä "
 "alueilla."
 
-#: data/alien/units.ruleset:720
+#: data/alien/units.ruleset:723
 msgid "Crusher"
 msgstr "Murskaaja"
 
-#: data/alien/units.ruleset:746
+#: data/alien/units.ruleset:749
 msgid "Alien lifeform trained to be fast."
 msgstr "Nopeaksi treenattu vieras eliömuoto."
 
-#: data/alien/units.ruleset:751
+#: data/alien/units.ruleset:754
 msgid "Cyber Alien"
 msgstr "Kybereliö"
 
-#: data/alien/units.ruleset:777
+#: data/alien/units.ruleset:780
 msgid ""
 "Alien lifeform with cybernetic implants. Good in combat, and has better "
 "vision than any purely organic unit."
@@ -30656,35 +30740,35 @@ msgstr ""
 "näkökyvyn kuin yksikään puhtaasti orgaaninen yksikkö."
 
 #. TRANS: Alien lifeform. Name refers to Tyrannosaurus Rex, not "King" role
-#: data/alien/units.ruleset:783
+#: data/alien/units.ruleset:786
 msgid "Rex"
 msgstr "Rex"
 
-#: data/alien/units.ruleset:808
+#: data/alien/units.ruleset:811
 msgid "Most powerful alien lifeform, like one from Earth's Jurassic period."
 msgstr "Kaikkein voimakkain vieras olento, kuin suoraan maan jurakaudelta."
 
-#: data/alien/units.ruleset:813
+#: data/alien/units.ruleset:816
 msgid "Paradropper"
 msgstr "Tiputtautuja"
 
-#: data/alien/units.ruleset:841
+#: data/alien/units.ruleset:844
 msgid "Alien lifeform able to paradrop."
 msgstr "Vieras eliömuoto, joka kykenee tiputtautumaan taistelukentälle."
 
-#: data/alien/units.ruleset:846
+#: data/alien/units.ruleset:849
 msgid "Turtle Defender"
 msgstr "Kilpikonnapuolustaja"
 
-#: data/alien/units.ruleset:872
+#: data/alien/units.ruleset:875
 msgid "This is excellent defense vehicle."
 msgstr "Tämä on erinomainen puolustusajoneuvo."
 
-#: data/alien/units.ruleset:877
+#: data/alien/units.ruleset:880
 msgid "Earth Sub"
 msgstr "Maasukeltaja"
 
-#: data/alien/units.ruleset:903
+#: data/alien/units.ruleset:906
 msgid ""
 "Burrow through earth. Only some special units can attack against Earth Sub. "
 "These can pass ocean tiles only through Burrow Tubes."
@@ -30692,11 +30776,11 @@ msgstr ""
 "Kaivautuu maan läpi. Vain jotkut erikoisyksiköt voivat hyökätä maasukeltajan "
 "kimppuun. Nämä pääsevät meren ylitse vain kaivuuputkia pitkin."
 
-#: data/alien/units.ruleset:908
+#: data/alien/units.ruleset:911
 msgid "Hunter"
 msgstr "Metsästäjä"
 
-#: data/alien/units.ruleset:935
+#: data/alien/units.ruleset:938
 msgid ""
 "Burrowing unit that also has capability to attack Antigravity units with its "
 "own minimissiles.\n"
@@ -30705,21 +30789,21 @@ msgid ""
 "itself."
 msgstr ""
 
-#: data/alien/units.ruleset:942
+#: data/alien/units.ruleset:945
 msgid "Light Saucer"
 msgstr "Kevyt lautanen"
 
-#: data/alien/units.ruleset:968
+#: data/alien/units.ruleset:971
 msgid ""
 "Nobody, but some of the other Antigravity units and Hunters can attack this "
 "unit. This unit itself can attack other Antigravity units."
 msgstr ""
 
-#: data/alien/units.ruleset:973
+#: data/alien/units.ruleset:976
 msgid "Bomb Saucer"
 msgstr "Pommilautanen"
 
-#: data/alien/units.ruleset:999
+#: data/alien/units.ruleset:1002
 msgid ""
 "Nobody, but some of the other Antigravity and Hunters units can attack this "
 "unit."
@@ -30727,20 +30811,20 @@ msgstr ""
 "Ainoastaan jotkin toiset antigravitaatioyksiköt ja metsästäjät voivat "
 "hyökätä tämän yksikön kimppuun."
 
-#: data/alien/units.ruleset:1003
+#: data/alien/units.ruleset:1006
 msgid "Spitter"
 msgstr "Sylkijä"
 
-#: data/alien/units.ruleset:1029
+#: data/alien/units.ruleset:1032
 msgid "This alien lifeform is first bombarding unit."
 msgstr ""
 "Tämä vieras eliömuoto on ensimmäinen pommitushyökkäykseen pystyvä yksikkö."
 
-#: data/alien/units.ruleset:1034
+#: data/alien/units.ruleset:1037
 msgid "Heavy Spitter"
 msgstr "Raskas sylkijä"
 
-#: data/alien/units.ruleset:1061
+#: data/alien/units.ruleset:1064
 msgid ""
 "This improved spitter can both make bombard attacks, and transport missiles "
 "next to targets."
@@ -30748,111 +30832,111 @@ msgstr ""
 "Tämä paranneltu sylkijä voi sekä tehdä pommitushyökkäyksiä että kuljettaa "
 "ohjuksia riittävän lähelle niiden maalia."
 
-#: data/alien/units.ruleset:1066
+#: data/alien/units.ruleset:1069
 msgid "Biomass"
 msgstr "Biomassa"
 
-#: data/alien/units.ruleset:1092
+#: data/alien/units.ruleset:1095
 msgid ""
 "Just let the biomass to engulf your tank and pick it up, then enjoy the ride "
 "in the radiation-safe inside of the slimy being."
 msgstr ""
 
-#: data/alien/units.ruleset:1123
+#: data/alien/units.ruleset:1126
 msgid ""
 "Like all Earthly units, Explorer are unable to enter radiating tiles. They "
 "can maintain themselves, no upkeep cost to homecity."
 msgstr ""
 
-#: data/alien/units.ruleset:1129
+#: data/alien/units.ruleset:1132
 msgid "Scout Animal"
 msgstr "Tiedustelueläin"
 
-#: data/alien/units.ruleset:1155
+#: data/alien/units.ruleset:1158
 msgid "This is native scout animal that can enter any land terrain."
 msgstr "Vieras eliömuoto, joka voi liikkua missä hyvänsä maaruuduissa."
 
-#: data/alien/units.ruleset:1160
+#: data/alien/units.ruleset:1163
 msgid "Raft"
 msgstr "Lautta"
 
-#: data/alien/units.ruleset:1187
+#: data/alien/units.ruleset:1190
 msgid "  This vessel allows coastal travel, but not on Boiling Seas."
 msgstr ""
 
-#: data/alien/units.ruleset:1192
+#: data/alien/units.ruleset:1195
 msgid "Ship"
 msgstr "Laiva"
 
-#: data/alien/units.ruleset:1219
+#: data/alien/units.ruleset:1222
 msgid ""
 "  This is basic ship type. It has no any special equipment, so it cannot "
 "enter boiling seas."
 msgstr ""
 
-#: data/alien/units.ruleset:1250
+#: data/alien/units.ruleset:1253
 msgid "This vessel is for battle! Too bad it cannot enter boiling oceans."
 msgstr ""
 "Tämä alus on taistelua varten! Harmillisesti se ei kuitenkaan voi kulkea "
 "kiehuvalla merellä."
 
-#: data/alien/units.ruleset:1255
+#: data/alien/units.ruleset:1258
 msgid "Battle Unit"
 msgstr "Taisteluyksikkö"
 
-#: data/alien/units.ruleset:1280
+#: data/alien/units.ruleset:1283
 msgid "Amphibious battle machine."
 msgstr "Amfibinen taistelukone."
 
-#: data/alien/units.ruleset:1284
+#: data/alien/units.ruleset:1287
 msgid "Amphibious Transport"
 msgstr "Amfibikuljetusalus"
 
-#: data/alien/units.ruleset:1311
+#: data/alien/units.ruleset:1314
 msgid "This is first unit that can enter boiling oceans - and more."
 msgstr ""
 "Tämä on ensimmäinen yksikkö, joka voi kulkea kiehuvalla merellä - ja lähes "
 "kaikkialla muuallakin."
 
-#: data/alien/units.ruleset:1342
+#: data/alien/units.ruleset:1345
 msgid ""
 "Earth technology unit that can establish trade routes and transfer goods to "
 "help build wonders in other cities."
 msgstr ""
 
-#: data/alien/units.ruleset:1345 data/alien/units.ruleset:1380
+#: data/alien/units.ruleset:1348 data/alien/units.ruleset:1383
 msgid ""
 "Trade routes with other factions provide three times as much ongoing trade "
 "as routes within your faction. Each city can support up to four trade routes."
 msgstr ""
 
-#: data/alien/units.ruleset:1378
+#: data/alien/units.ruleset:1381
 msgid "Native caravan unit, that can move on all land terrains."
 msgstr "Luontainen karavaaniyksikkö, joka voi liikkua kaikilla maaruuduilla."
 
-#: data/alien/units.ruleset:1387
+#: data/alien/units.ruleset:1390
 msgid "Stealth Spy"
 msgstr "Häivevakooja"
 
-#: data/alien/units.ruleset:1419
+#: data/alien/units.ruleset:1422
 msgid ""
 "Stealth Spy can make diplomatic actions, and is invisible until next to "
 "enemy unit or city."
 msgstr ""
 
-#: data/alien/units.ruleset:1424
+#: data/alien/units.ruleset:1427
 msgid "Teleporting Missile"
 msgstr "Teleporttaava ohjus"
 
-#: data/alien/units.ruleset:1448
+#: data/alien/units.ruleset:1451
 msgid "Teleporting Missile can teleport and attack to neighbour tile."
 msgstr "Teleporttaava ohjus voi teleportata hyökätäkseen viereiseen ruutuun."
 
-#: data/alien/units.ruleset:1452
+#: data/alien/units.ruleset:1455
 msgid "Antiburrow Missile"
 msgstr "Antikaivautujaohjus"
 
-#: data/alien/units.ruleset:1477
+#: data/alien/units.ruleset:1480
 msgid ""
 "Missile that can attack also against burrowing units. Since more expensive "
 "than normal Teleporting Missile, does not completely replace it."
@@ -34145,22 +34229,6 @@ msgstr ""
 "  9: liiku koilliseen\n"
 
 #: data/helpdata.txt:1675
-#, fuzzy
-#| msgid ""
-#| "Main Map (Keys):\n"
-#| "================\n"
-#| "  c: (c)enter view on active unit\n"
-#| "    Shift-home: center view on capital\n"
-#| "  Shift-arrows: scroll map\n"
-#| "\n"
-#| "  Ctrl-B: show/hide national borders\n"
-#| "  Ctrl-D: show/hide city trade routes\n"
-#| "  Ctrl-G: show/hide map grid lines\n"
-#| "  Ctrl-N: show/hide city names\n"
-#| "  Ctrl-P: show/hide city production\n"
-#| "  Ctrl-R: show/hide city growth\n"
-#| "  Ctrl-W: show/hide city output\n"
-#| "  Ctrl-Y: show/hide city outlines\n"
 msgid ""
 "Main Map (Keys):\n"
 "================\n"
@@ -34181,6 +34249,8 @@ msgid ""
 msgstr ""
 "Pääkartta (näppäimet):\n"
 "======================\n"
+"  Jotkin asiakasohjelmat tukevat kartan zoomaamista/skaalaamista + ja - "
+"näppäimillä.\n"
 "  c: keskitä näkymä aktiiviseen yksikköön\n"
 "    Shift-Home: keskitä pääkaupunkiin\n"
 "  Shift-nuolet: liikuta karttaa\n"
@@ -35134,7 +35204,7 @@ msgstr "Sääntökokoelma moninpeliin"
 
 #. TRANS: In the client, this is displayed alongside the contents of
 #. ;    README.multiplayer, which are not localized.
-#: data/multiplayer/game.ruleset:34
+#: data/multiplayer/game.ruleset:40
 msgid ""
 "You are playing Freeciv with rules designed for multiplayer gaming. The "
 "biggest differences from the classic ruleset are that trade routes are "
@@ -35152,163 +35222,163 @@ msgstr ""
 #. TRANS: With this and other color team names, uniqueness is more
 #. TRANS: important than precise translation. To see the colors, start a
 #. TRANS: multiplayer game with 32 players and look at the Nations report.
-#: data/multiplayer/game.ruleset:1280
+#: data/multiplayer/game.ruleset:1295
 msgid "?team name:Red"
 msgstr "Punaiset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1282
+#: data/multiplayer/game.ruleset:1297
 msgid "?team name:Yellow"
 msgstr "Keltaiset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1284
+#: data/multiplayer/game.ruleset:1299
 msgid "?team name:Blue"
 msgstr "Siniset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1286
+#: data/multiplayer/game.ruleset:1301
 msgid "?team name:Purple"
 msgstr "Purppurat"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1288
+#: data/multiplayer/game.ruleset:1303
 msgid "?team name:Orange"
 msgstr "Oranssit"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1290
+#: data/multiplayer/game.ruleset:1305
 msgid "?team name:Magenta"
 msgstr "Magentat"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1292
+#: data/multiplayer/game.ruleset:1307
 msgid "?team name:Cornflower"
 msgstr "Ruiskaunokinsiniset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1294
+#: data/multiplayer/game.ruleset:1309
 msgid "?team name:Emerald"
 msgstr "Smaragdinvihreät"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1296
+#: data/multiplayer/game.ruleset:1311
 msgid "?team name:Salmon"
 msgstr "Lohenpunaiset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1298
+#: data/multiplayer/game.ruleset:1313
 msgid "?team name:Green"
 msgstr "Vihreät"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1300
+#: data/multiplayer/game.ruleset:1315
 msgid "?team name:Burgundy"
 msgstr "Burgundinpunaiset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1302
+#: data/multiplayer/game.ruleset:1317
 msgid "?team name:Pink"
 msgstr "Pinkit"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1304
+#: data/multiplayer/game.ruleset:1319
 msgid "?team name:Silver"
 msgstr "Hopeanväriset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1306
+#: data/multiplayer/game.ruleset:1321
 msgid "?team name:Heliotrope"
 msgstr "Auringonkeltaiset"
 
 # Ei jumalauta
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1308
+#: data/multiplayer/game.ruleset:1323
 msgid "?team name:Fuchsia"
 msgstr "Fuksiat"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1310
+#: data/multiplayer/game.ruleset:1325
 msgid "?team name:Azure"
 msgstr "Taivaansiniset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1312
+#: data/multiplayer/game.ruleset:1327
 msgid "?team name:Gold"
 msgstr "Kullanväriset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1314
+#: data/multiplayer/game.ruleset:1329
 msgid "?team name:Khaki"
 msgstr "Khakinruskeat"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1316
+#: data/multiplayer/game.ruleset:1331
 msgid "?team name:Butter"
 msgstr "Voinkeltaiset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1318
+#: data/multiplayer/game.ruleset:1333
 msgid "?team name:Mint"
 msgstr "Mintunvihreät"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1320
+#: data/multiplayer/game.ruleset:1335
 msgid "?team name:Lime"
 msgstr "Limetinvihreät"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1322
+#: data/multiplayer/game.ruleset:1337
 msgid "?team name:Peach"
 msgstr "Persikanväriset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1324
+#: data/multiplayer/game.ruleset:1339
 msgid "?team name:Vermilion"
 msgstr "Oranssinpunaiset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1326
+#: data/multiplayer/game.ruleset:1341
 msgid "?team name:Puce"
 msgstr "Punaisenruskeat"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1328
+#: data/multiplayer/game.ruleset:1343
 msgid "?team name:Mustard"
 msgstr "Sinapinkeltaiset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1330
+#: data/multiplayer/game.ruleset:1345
 msgid "?team name:Aubergine"
 msgstr "Munakoisonvioletit"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1332
+#: data/multiplayer/game.ruleset:1347
 msgid "?team name:Brown"
 msgstr "Ruskeat"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1334
+#: data/multiplayer/game.ruleset:1349
 msgid "?team name:Pumpkin"
 msgstr "Kurpitsanoranssit"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1336
+#: data/multiplayer/game.ruleset:1351
 msgid "?team name:Turquoise"
 msgstr "Turkoosit"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1338
+#: data/multiplayer/game.ruleset:1353
 msgid "?team name:Crimson"
 msgstr "Crimsoninpunaiset"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1340
+#: data/multiplayer/game.ruleset:1355
 msgid "?team name:Lavender"
 msgstr "Laventelit"
 
 #. TRANS: Name of a color; used as unique identifier for a team
-#: data/multiplayer/game.ruleset:1342
+#: data/multiplayer/game.ruleset:1357
 msgid "?team name:Cream"
 msgstr "Kermanväriset"
 
@@ -35383,7 +35453,7 @@ msgstr ""
 "Saavutat tämän teknologian vain kun ensi kerran rakennat Darwinin "
 "tutkimusretket."
 
-#: data/multiplayer/terrain.ruleset:1204
+#: data/multiplayer/terrain.ruleset:1210
 msgid ""
 "Pollution appears on land tiles around cities with high production or "
 "population. It halves all output from its tile, and contributes to the risk "
@@ -35393,7 +35463,7 @@ msgstr ""
 "korkea tuotanto tai asukasluku. Se puolittaa kaiken ruudun hyödyntämisen, ja "
 "lisää ilmastonmuutoksen riskiä."
 
-#: data/multiplayer/terrain.ruleset:1212
+#: data/multiplayer/terrain.ruleset:1218
 msgid ""
 "Pollution from production is likely to start becoming important as your "
 "civilization becomes more industrialized, giving you buildings such as "
@@ -35409,7 +35479,7 @@ msgstr ""
 "aurinkovoimalalla - vähentää saastetta tuotannosta, samoin kuin "
 "kierrätyskeskus tai ympäristötietoisuuden edistysaskel."
 
-#: data/multiplayer/terrain.ruleset:1297
+#: data/multiplayer/terrain.ruleset:1303
 #, no-c-format
 msgid ""
 "Once Refrigeration is known, irrigation systems can be upgraded to farmland "
@@ -35420,7 +35490,7 @@ msgstr ""
 "viljelysmaaksi kastelemalla ne toiseen kertaan; jos ruutua työstävällä "
 "kaupungilla on supermarketti, ruutu tuottaa kaksinkertaisen määrän ruokaa."
 
-#: data/multiplayer/terrain.ruleset:1323
+#: data/multiplayer/terrain.ruleset:1329
 msgid ""
 "Nuclear fallout can appear on land tiles when a Nuclear unit is detonated. "
 "It halves all output from its tile."
@@ -35428,7 +35498,7 @@ msgstr ""
 "Ydinlaskeumaa ilmaantuu maaruuduille kun ydinase räjäytetään. Se puolittaa "
 "ruudun hyödyntämisen."
 
-#: data/multiplayer/units.ruleset:479
+#: data/multiplayer/units.ruleset:482
 msgid ""
 "Upkeep for Settlers is in food as well as production, and a Settler can die "
 "if its supporting city runs out of food. Settlers in a Republic or Democracy "
@@ -35440,7 +35510,7 @@ msgstr ""
 "Tasavallassa ja Demokratiassa Uudisraivaajat vaativat kaksinkertaisen määrän "
 "ruokaa, Fundamentalismissa kolminkertaisen."
 
-#: data/multiplayer/units.ruleset:1505
+#: data/multiplayer/units.ruleset:1508
 msgid ""
 "The Helicopter is a very powerful unit, as it can both fly and conquer "
 "cities.  Care must be exercised, because Helicopters lose a small amount of "
@@ -35452,14 +35522,14 @@ msgstr ""
 "hieman joka pelivuorolla, jota ne eivät vietä kaupungissa, lentotukikohdassa "
 "tai tukialuksella, ja lisäksi maayksiköt voivat hyökätä niiden kimppuun."
 
-#: data/multiplayer/units.ruleset:2288
+#: data/multiplayer/units.ruleset:2291
 msgid ""
 "A Caravan carries goods or material to help build wonders in your cities."
 msgstr ""
 "Karavaani toimittaa tuotteita tai raaka-aineita käytettäväksi ihmeen "
 "rakennusaineina muissa kaupungeissa."
 
-#: data/multiplayer/units.ruleset:2291
+#: data/multiplayer/units.ruleset:2294
 msgid ""
 "Every Caravan that is used to build a wonder will add 30 shields towards the "
 "production of the wonder."
@@ -35467,7 +35537,7 @@ msgstr ""
 "Ihmeen rakentamiseen käytettävä Karavaani edistää sen valmistumista 30 "
 "yksiköllä."
 
-#: data/multiplayer/units.ruleset:2327
+#: data/multiplayer/units.ruleset:2330
 msgid ""
 "The Freight unit replaces the Caravan, and moves at twice the speed. Each "
 "Freight used to build a wonder will add 50 shields."
@@ -38455,47 +38525,47 @@ msgid "%s gain a leader by the name %s. Dangerous times may lie ahead."
 msgstr ""
 "Vaaralliset ajat uhkaavat, %s ovat saaneet uuden hallitsijan nimeltään %s."
 
-#: server/barbarian.c:682
+#: server/barbarian.c:683
 #, c-format
 msgid "Native unrest near %s led by %s."
 msgstr "%s raportoi levottomuuksia lähistöllä, %s johtaa rähinöijiä."
 
-#: server/barbarian.c:687
+#: server/barbarian.c:688
 #, c-format
 msgid "Sea raiders seen near %s!"
 msgstr "%s on havainnut merirosvoja!"
 
-#: server/cityhand.c:248
+#: server/cityhand.c:250
 msgid "You have already sold something here this turn."
 msgstr "Olet jo myynyt jotain tällä vuorolla."
 
-#: server/cityhand.c:259
+#: server/cityhand.c:261
 #, c-format
 msgid "You sell %s in %s for %d gold."
 msgid_plural "You sell %s in %s for %d gold."
 msgstr[0] "Myyty %s kaupungissa %s hintaan %d."
 msgstr[1] "Myyty %s kaupungissa %s hintaan %d."
 
-#: server/cityhand.c:301
+#: server/cityhand.c:303
 msgid "Cannot buy in city created this turn."
 msgstr "Tällä vuorolla luotuun kaupunkiin ei voi ostaa mitään."
 
-#: server/cityhand.c:307
+#: server/cityhand.c:309
 msgid "You have already bought this turn."
 msgstr "Olet jo ostanut jotain tällä vuorolla."
 
-#: server/cityhand.c:313
+#: server/cityhand.c:315
 #, c-format
 msgid "You don't buy %s!"
 msgstr "%s ei ole ostettavissa!"
 
-#: server/cityhand.c:320
+#: server/cityhand.c:322
 msgid "Can't buy units when city is in disorder."
 msgstr "Yksikköjä ei voi ostaa kun kaupungissa mellakoidaan."
 
 #. TRANS: This whole string is only ever used when included in one
 #. * other string (search for this string to find it).
-#: server/cityhand.c:336
+#: server/cityhand.c:338
 #, c-format
 msgid "%d gold required."
 msgid_plural "%d gold required."
@@ -38504,7 +38574,7 @@ msgstr[1] "Tarvitset %d kultaa."
 
 #. TRANS: %s is a pre-pluralised string:
 #. * "%d gold required."
-#: server/cityhand.c:342
+#: server/cityhand.c:344
 #, c-format
 msgid "%s You only have %d gold."
 msgid_plural "%s You only have %d gold."
@@ -38512,18 +38582,18 @@ msgstr[0] "%s Sinulla on vain yksi (%d) kulta."
 msgstr[1] "%s Sinulla on vain %d kultaa."
 
 #. TRANS: bought an unit.
-#: server/cityhand.c:361
+#: server/cityhand.c:363
 #, c-format
 msgid "?unit:You bought %s in %s."
 msgstr "Ostit hankkeen %s kaupungissa %s."
 
 #. TRANS: bought an improvement .
-#: server/cityhand.c:367
+#: server/cityhand.c:369
 #, c-format
 msgid "?improvement:You bought %s in %s."
 msgstr "Ostit hankkeen %s kaupungissa %s."
 
-#: server/cityhand.c:467
+#: server/cityhand.c:469
 msgid "You have bought this turn, can't change."
 msgstr "Olet jo ostanut tällä vuorolla, et voi vaihtaa."
 
@@ -38702,51 +38772,51 @@ msgstr "Olet vapauttanut kaupungin %s!"
 msgid "%s liberated %s."
 msgstr "%s vapautti kaupungin %s."
 
-#: server/citytools.c:2641
+#: server/citytools.c:2656
 #, c-format
 msgid "Trade between %s and %s lost along with city."
 msgstr ""
 "Kauppareitti kaupunkien %s ja %s välillä on peruttu kaupungin menettämisen "
 "myötä."
 
-#: server/citytools.c:2646
+#: server/citytools.c:2661
 #, c-format
 msgid "Trade route between %s and %s canceled."
 msgstr "Kauppareitti kaupunkien %s ja %s välillä on peruttu."
 
 #. TRANS: "...between Spanish city Madrid and Paris..."
-#: server/citytools.c:2654
+#: server/citytools.c:2669
 #, c-format
 msgid "Trade between %s city %s and %s lost along with their city."
 msgstr ""
 "Kauppareitti %s kaupungin %s ja kaupungin %s välillä menetetty kaupungin "
 "myötä."
 
-#: server/citytools.c:2662
+#: server/citytools.c:2677
 #, c-format
 msgid "Sorry, the %s canceled the trade route from %s to your city %s."
 msgstr "%s on perunut kauppareitin kaupungista %s kaupunkiisi %s."
 
 #. TRANS: "...from Paris to Spanish city Madrid."
-#: server/citytools.c:2668
+#: server/citytools.c:2683
 #, c-format
 msgid "We canceled the trade route from %s to %s city %s."
 msgstr "Peruimme kauppareitin kaupungista %s %s kaupunkiin %s."
 
-#: server/citytools.c:2926
+#: server/citytools.c:2941
 #, c-format
 msgid "The %s have stopped building The %s in %s."
 msgstr "%s ovat keskeyttäneet hankkeensa %s kaupungissa %s."
 
 #. TRANS: Possible 'source' of the production change
 #. * (in "<city> is building ..." sentence).
-#: server/citytools.c:2948
+#: server/citytools.c:2963
 msgid " from the worklist"
 msgstr " työlistalta"
 
 #. TRANS: Possible 'source' of the production change
 #. * (in "<city> is building ..." sentence).
-#: server/citytools.c:2953
+#: server/citytools.c:2968
 msgid " as suggested by the advisor"
 msgstr " neuvontantajan ohjaamana"
 
@@ -38754,17 +38824,17 @@ msgstr " neuvontantajan ohjaamana"
 #. TRANS: "<city> is building <production><source>."
 #. * 'source' might be an empty string, or a clause like
 #. * " from the worklist".
-#: server/citytools.c:2970
+#: server/citytools.c:2985
 #, c-format
 msgid "%s is building %s%s."
 msgstr "%s aloitti hankkeen %s%s."
 
-#: server/citytools.c:2979
+#: server/citytools.c:2994
 #, c-format
 msgid "The %s have started building The %s in %s."
 msgstr "%s tavoittelevat taivaita: %s rakenteilla kaupungissa %s."
 
-#: server/citytools.c:3139
+#: server/citytools.c:3154
 #, c-format
 msgid "You sell %s in %s (now landlocked) for %d gold."
 msgid_plural "You sell %s in %s (now landlocked) for %d gold."
@@ -38773,16 +38843,16 @@ msgstr[0] ""
 msgstr[1] ""
 "Myyt vesiyhteyttä vaativan parannuksen %s kaupungissa %s %d kullasta."
 
-#: server/citytools.c:3273
+#: server/citytools.c:3288
 #, c-format
 msgid "The size of the city map of %s is %s."
 msgstr "Kaupungin %s alueen koko %s."
 
-#: server/citytools.c:3275
+#: server/citytools.c:3290
 msgid "increased"
 msgstr "laajeni"
 
-#: server/citytools.c:3276
+#: server/citytools.c:3291
 msgid "reduced"
 msgstr "supistui"
 
@@ -39306,81 +39376,81 @@ msgstr ""
 "väkilukukustannus: %d)"
 
 #. TRANS: <city> is finished building <unit/building>.
-#: server/cityturn.c:2411
+#: server/cityturn.c:2422
 #, c-format
 msgid "%s is finished building %s."
 msgstr "%s sai valmiiksi hankkeensa %s."
 
 #. TRANS: "<unit> cost... <city> shrinks..."
 #. * Plural in "%d population", not "size %d".
-#: server/cityturn.c:2420
+#: server/cityturn.c:2431
 #, c-format
 msgid "%s cost %d population. %s shrinks to size %d."
 msgid_plural "%s cost %d population. %s shrinks to size %d."
 msgstr[0] "%s vaatii väestöä %d kokoluokan, %s kutistuu kokoon %d."
 msgstr[1] "%s vaatii väestöä %d kokoluokkaa, %s kutistuu kokoon %d."
 
-#: server/cityturn.c:2503
+#: server/cityturn.c:2522
 #, c-format
 msgid "Can't afford to maintain %s in %s, building sold!"
 msgstr "%s myyty kaupungissa %s, koska ylläpitoon ei ollut varaa!"
 
-#: server/cityturn.c:2644
+#: server/cityturn.c:2663
 #, c-format
 msgid "Not enough gold. %s disbanded."
 msgstr "Rahasi eivät riitä. %s hajotettiin."
 
-#: server/cityturn.c:2885 server/cityturn.c:3697
+#: server/cityturn.c:2904 server/cityturn.c:3716
 #, c-format
 msgid "Pollution near %s."
 msgstr "%s raportoi saasteista lähistöllään."
 
-#: server/cityturn.c:3057
+#: server/cityturn.c:3076
 #, c-format
 msgid "Celebrations in your honor in %s."
 msgstr "%s järjestää villiä juhlintaa kunniaksesi."
 
-#: server/cityturn.c:3063
+#: server/cityturn.c:3082
 #, c-format
 msgid "Celebrations canceled in %s."
 msgstr "%s palaa arkeen, juhlallisuudet peruttu."
 
-#: server/cityturn.c:3080
+#: server/cityturn.c:3099
 #, c-format
 msgid "%s has been struck by a plague! Population lost!"
 msgstr "%s on ruton riipimä! Väestöä kuolee!"
 
 #. TRANS: preserve leading space; this string will be appended to
 #. * another sentence
-#: server/cityturn.c:3144
+#: server/cityturn.c:3163
 msgid " Unrest threatens to spread beyond the city."
 msgstr " Levottomuudet uhkaavat levittäytyä kaupungin ulkopuolelle."
 
 #. TRANS: second %s is an optional extra sentence
-#: server/cityturn.c:3151
+#: server/cityturn.c:3170
 #, c-format
 msgid "Civil disorder in %s.%s"
 msgstr "%s kärsii levottomuuksista.%s"
 
 #. TRANS: second %s is an optional extra sentence
-#: server/cityturn.c:3156
+#: server/cityturn.c:3175
 #, c-format
 msgid "CIVIL DISORDER CONTINUES in %s.%s"
 msgstr "%s: LEVOTTOMUUDET JATKUVAT.%s"
 
-#: server/cityturn.c:3162
+#: server/cityturn.c:3181
 #, c-format
 msgid "Order restored in %s."
 msgstr "%s: Järjestys on palannut kaupunkiin."
 
 # government - e.g. Yksinvalta
 #. TRANS: %s - government form, e.g., Democracy
-#: server/cityturn.c:3174
+#: server/cityturn.c:3193
 #, c-format
 msgid "The people have overthrown your %s, your country is in turmoil."
 msgstr "%s kaatui kansannousussa, valtio natisee liitoksissaan."
 
-#: server/cityturn.c:3216
+#: server/cityturn.c:3235
 #, c-format
 msgid "%s can't build %s yet, and we can't disband our only city."
 msgstr ""
@@ -39388,13 +39458,13 @@ msgstr ""
 "lakkauttaa."
 
 #. TRANS: "<city> is disbanded into Settler."
-#: server/cityturn.c:3243
+#: server/cityturn.c:3262
 #, c-format
 msgid "%s is disbanded into %s."
 msgstr "%s lakkautettiin, kun %s koottiin."
 
 #. TRANS: From <city1> to <city2>.
-#: server/cityturn.c:3442
+#: server/cityturn.c:3461
 #, c-format
 msgid ""
 "Migrants from %s can't go to %s because there is not enough food available!"
@@ -39403,7 +39473,7 @@ msgstr ""
 "syödään jo pettua!"
 
 #. TRANS: From <city1> to <city2> (<city2 nation adjective>).
-#: server/cityturn.c:3449
+#: server/cityturn.c:3468
 #, c-format
 msgid ""
 "Migrants from %s can't go to %s (%s) because there is not enough food "
@@ -39413,7 +39483,7 @@ msgstr ""
 "(%s) syödään jo pettua!"
 
 #. TRANS: From <city1> (<city1 nation adjective>) to <city2>.
-#: server/cityturn.c:3454
+#: server/cityturn.c:3473
 #, c-format
 msgid ""
 "Migrants from %s (%s) can't go to %s because there is not enough food "
@@ -39423,7 +39493,7 @@ msgstr ""
 "%s syödään jo pettua!"
 
 #. TRANS: From <city1> to <city2>.
-#: server/cityturn.c:3469
+#: server/cityturn.c:3488
 #, c-format
 msgid ""
 "Migrants from %s can't go to %s because it needs an improvement to grow!"
@@ -39432,7 +39502,7 @@ msgstr ""
 "parannuksen kasvaakseen!"
 
 #. TRANS: From <city1> to <city2> of <city2 nation adjective>.
-#: server/cityturn.c:3476
+#: server/cityturn.c:3495
 #, c-format
 msgid ""
 "Migrants from %s can't go to %s (%s) because it needs an improvement to grow!"
@@ -39441,7 +39511,7 @@ msgstr ""
 "vaatii parannuksen kasvaakseen!"
 
 #. TRANS: From <city1> (<city1 nation adjective>) to <city2>.
-#: server/cityturn.c:3481
+#: server/cityturn.c:3500
 #, c-format
 msgid ""
 "Migrants from %s (%s) can't go to %s because it needs an improvement to grow!"
@@ -39449,77 +39519,77 @@ msgstr ""
 "Siirtolaiset kaupungista %s (%s) eivät voi muuttaa, koska kohdekaupunki %s "
 "vaatii parannuksen kasvaakseen!"
 
-#: server/cityturn.c:3530
+#: server/cityturn.c:3549
 #, c-format
 msgid "%s was disbanded by its citizens."
 msgstr "%s on tyhjentynyt asukkaista."
 
 #. TRANS: From <city1> to <city2>.
-#: server/cityturn.c:3568
+#: server/cityturn.c:3587
 #, c-format
 msgid "Migrants from %s moved to %s in search of a better life."
 msgstr "Siirtolaisia kaupungista %1$s on saapunut kaupunkiin %2$s."
 
 #. TRANS: From <city1> to <city2> (<city2 nation adjective>).
-#: server/cityturn.c:3574
+#: server/cityturn.c:3593
 #, c-format
 msgid "Migrants from %s moved to %s (%s) in search of a better life."
 msgstr "Siirtolaisia kaupungistasi %1$s on päätynyt %3$s kaupunkiin %2$s."
 
 #. TRANS: From <city1> (<city1 nation adjective>) to <city2>.
-#: server/cityturn.c:3579
+#: server/cityturn.c:3598
 #, c-format
 msgid "Migrants from %s (%s) moved to %s in search of a better life."
 msgstr "Siirtolaisia %2$s kaupungista %1$s on saapunut kaupunkiisi %3$s."
 
 #. TRANS: %s is a city name
-#: server/cityturn.c:3669
+#: server/cityturn.c:3688
 #, c-format
 msgid "All stored food destroyed in %s."
 msgstr "Kaikki ruokavarastot tuhoutuivat kaupungissa %s."
 
 #. TRANS: Disasters such as Earthquake
-#: server/cityturn.c:3691
+#: server/cityturn.c:3710
 #, c-format
 msgid "%s was hit by %s."
 msgstr "%2$s iski kaupunkiin %1$s."
 
-#: server/cityturn.c:3705
+#: server/cityturn.c:3724
 #, c-format
 msgid "Fallout near %s."
 msgstr "Ydinlaskeumaa lähellä kaupunkia %s."
 
 #. TRANS: "Industrial Accident destroys Bogota entirely."
-#: server/cityturn.c:3716
+#: server/cityturn.c:3735
 #, c-format
 msgid "%s destroys %s entirely."
 msgstr "%s aiheuttaa kaupungin %s tuhon."
 
 #. TRANS: "Nuclear Accident ... Montreal."
-#: server/cityturn.c:3722
+#: server/cityturn.c:3741
 #, c-format
 msgid "%s causes population loss in %s."
 msgstr "%s vähensi väkilukua kaupungissa %s."
 
 #. TRANS: second %s is the name of a city improvement
-#: server/cityturn.c:3747
+#: server/cityturn.c:3766
 #, c-format
 msgid "%s destroys %s in %s."
 msgstr "%s tuhosi kohteen %s kaupungissa %s."
 
 #. TRANS: "Production of Colossus in Rhodes destroyed."
-#: server/cityturn.c:3772
+#: server/cityturn.c:3791
 #, c-format
 msgid "Production of %s in %s destroyed."
 msgstr "Kohteen %s tuotanto tuhoutui kaupungissa %s."
 
-#: server/cityturn.c:3942
+#: server/cityturn.c:3961
 #, c-format
 msgid "Citizens of %s are thinking about migrating to %s for a better life."
 msgstr "%s ei houkuta. Sen asukkaat harkitsevat muuttoa kaupunkiin %s."
 
 #. TRANS: <city1> to <city2> (<city2 nation adjective>).
-#: server/cityturn.c:3964
+#: server/cityturn.c:3983
 #, c-format
 msgid ""
 "Citizens of %s are thinking about migrating to %s (%s) for a better life."
@@ -41257,76 +41327,76 @@ msgstr "%s ja sinä keskeytitte neuvottelut."
 msgid "Your diplomatic envoy was decapitated!"
 msgstr "Lähettiläältäsi katkaistiin kaula!"
 
-#: server/diplomats.c:129
+#: server/diplomats.c:132
 #, c-format
 msgid "Your %s poisoned the water supply of %s."
 msgstr "Lähettämäsi %s myrkytti vesivarastot kaupungissa %s."
 
-#: server/diplomats.c:133
+#: server/diplomats.c:136
 #, c-format
 msgid "%s is suspected of poisoning the water supply of %s."
 msgstr "Huhutaan että %s myrkytti veden kaupungissa %s."
 
-#: server/diplomats.c:147
+#: server/diplomats.c:150
 #, c-format
 msgid "Your %s destroyed %s by poisoning its water supply."
 msgstr "Lähettämäsi %s tuhosi kaupungin %s myrkyttämällä väen."
 
-#: server/diplomats.c:151
+#: server/diplomats.c:154
 #, c-format
 msgid "%s is suspected of destroying %s by poisoning its water supply."
 msgstr "Huhutaan että %s tuhosi kaupungin %s myrkyttämällä sen veden."
 
-#: server/diplomats.c:331
+#: server/diplomats.c:334
 #, c-format
 msgid "You have established an embassy in %s."
 msgstr "Olet perustanut lähetystön kaupunkiin %s."
 
-#: server/diplomats.c:335
+#: server/diplomats.c:338
 #, c-format
 msgid "The %s have established an embassy in %s."
 msgstr "%s ovat perustaneet lähetystön kaupunkiin %s."
 
-#: server/diplomats.c:409
+#: server/diplomats.c:412
 #, c-format
 msgid "Your %s's successful sabotage killed the %s %s."
 msgstr "Lähettämäsi %s sabotoi %s yksikön %s hengiltä."
 
 #. TRANS: ... the Poles!
-#: server/diplomats.c:416
+#: server/diplomats.c:419
 #, c-format
 msgid "Your %s was killed by %s sabotage!"
 msgstr "Yksikkösi %s tuhoutui %s sabotoimana!"
 
-#: server/diplomats.c:427
+#: server/diplomats.c:430
 #, c-format
 msgid "Your %s succeeded in sabotaging the %s %s."
 msgstr "Lähettämäsi %s sabotoi %s yksikön %s."
 
 #. TRANS: ... the Poles!
-#: server/diplomats.c:434
+#: server/diplomats.c:437
 #, c-format
 msgid "Your %s was sabotaged by the %s!"
 msgstr "Yksikkösi %s on sabotoitu – mokomat %s!"
 
-#: server/diplomats.c:502
+#: server/diplomats.c:505
 #, c-format
 msgid "You don't have enough gold to bribe the %s %s."
 msgstr "Sinulla ei ole tarpeeksi varoja lahjoa %s yksikköä %s."
 
 #. TRANS: <diplomat> ... <unit>
-#: server/diplomats.c:534
+#: server/diplomats.c:537
 #, c-format
 msgid "Your %s succeeded in bribing the %s."
 msgstr "Lähettämäsi %s onnistui lahjomaan yksikön %s."
 
 #. TRANS: <unit> ... <Poles>
-#: server/diplomats.c:541
+#: server/diplomats.c:544
 #, c-format
 msgid "Your %s was bribed by the %s."
 msgstr "Yksikkösi, %s, lahjottiin vihollisen (%s) puolelle."
 
-#: server/diplomats.c:740
+#: server/diplomats.c:743
 #, c-format
 msgid ""
 "%s was expecting your attempt to steal technology again. Your %s was caught "
@@ -41335,7 +41405,7 @@ msgstr ""
 "%s osasi odottaa sinun yrittävän teknologiavarkautta uudelleen; yksikkösi %s "
 "jäi kiinni ja teloitettiin."
 
-#: server/diplomats.c:746
+#: server/diplomats.c:749
 #, fuzzy, c-format
 #| msgid "The %s %s failed to steal technology from %s."
 msgid ""
@@ -41343,118 +41413,129 @@ msgid ""
 "attempt."
 msgstr "%s %s ei saanut varastettua teknologiaa – %s pitävät salaisuutensa."
 
-#: server/diplomats.c:754
+#: server/diplomats.c:757
 #, c-format
 msgid "Your %s was caught in the attempt of stealing technology from %s."
 msgstr ""
 "Lähettämäsi %s jäi kiinni yrittäessään varastaa teknologiaa kaupungissa %s."
 
-#: server/diplomats.c:760
+#: server/diplomats.c:763
 #, c-format
 msgid "The %s %s failed to steal technology from %s."
 msgstr "%s %s ei saanut varastettua teknologiaa – %s pitävät salaisuutensa."
 
-#: server/diplomats.c:778
+#: server/diplomats.c:781
 #, c-format
 msgid "No new technology found in %s."
 msgstr "Kaupungista %s ei löytynyt uutta teknologiaa."
 
-#: server/diplomats.c:853
+#: server/diplomats.c:824
+#, fuzzy, c-format
+#| msgid "Your %s paradropped into the %s and was lost."
+msgid "Your %d gold prepared to incite the revolt was lost!"
+msgstr "Yksikkösi %s menetettiin maahanlaskupaikassa %s."
+
+#: server/diplomats.c:834
+#, c-format
+msgid "Your security service captured %d gold prepared to incite your town!"
+msgstr ""
+
+#: server/diplomats.c:899
 #, c-format
 msgid "You don't have enough gold to subvert %s."
 msgstr "Rahasi eivät riitä kaupungin %s käännyttämiseen."
 
-#: server/diplomats.c:873
+#: server/diplomats.c:920
 #, c-format
 msgid "Your %s was caught in the attempt of inciting a revolt!"
 msgstr "Lähettämäsi %s jäi kiinni kapinan lietsonnasta!"
 
-#: server/diplomats.c:877
+#: server/diplomats.c:924
 #, c-format
 msgid "You caught %s %s attempting to incite a revolt in %s!"
 msgstr "%s %s jäi kiinni yrittäessään lietsoa kapinaa kaupungissa %s!"
 
-#: server/diplomats.c:904
+#: server/diplomats.c:953
 #, c-format
 msgid "Revolt incited in %s, you now rule the city!"
 msgstr "%s kapinoi ja liittyy valtakuntaasi!"
 
-#: server/diplomats.c:907
+#: server/diplomats.c:956
 #, c-format
 msgid "%s has revolted, %s influence suspected."
 msgstr "%s kapinoi, %s lähettiläs on luultavasti syypää."
 
-#: server/diplomats.c:993
+#: server/diplomats.c:1042
 #, c-format
 msgid "Your %s was caught in the attempt of industrial sabotage!"
 msgstr "Lähettämäsi %s jäi kiinni teollisuussabotaasin yrityksestä!"
 
-#: server/diplomats.c:998
+#: server/diplomats.c:1047
 #, c-format
 msgid "You caught %s %s attempting sabotage in %s!"
 msgstr "%s %s jäi kiinni yrittäessään sabotaasia kaupungissa %s!"
 
-#: server/diplomats.c:1035
+#: server/diplomats.c:1084
 #, c-format
 msgid "Your %s could not find anything to sabotage in %s."
 msgstr "Lähettämäsi %s ei löytänyt mitään sabotoitavaa kaupungista %s."
 
-#: server/diplomats.c:1092
+#: server/diplomats.c:1141
 #, c-format
 msgid "You cannot sabotage a %s!"
 msgstr "Ihmeet ja %s ovat immuuneja sabotaasille!"
 
-#: server/diplomats.c:1103
+#: server/diplomats.c:1152
 #, c-format
 msgid "Your %s could not find the %s to sabotage in %s."
 msgstr ""
 "Lähettämäsi %s ei löytänyt suunniteltua sabotaasikohdetta %s kaupungista %s."
 
 # Hard.
-#: server/diplomats.c:1128
+#: server/diplomats.c:1177
 #, c-format
 msgid "Your %s succeeded in destroying the production of %s in %s."
 msgstr "Lähettämäsi %s onnistui! %s ei valmistu aikataulussa kaupungissa %s."
 
-#: server/diplomats.c:1135
+#: server/diplomats.c:1184
 #, c-format
 msgid "The production of %s was destroyed in %s, %s are suspected."
 msgstr ""
 "%s ei valmistu aikataulussa kaupungissa %s, %s saattavat olla syypäitä."
 
-#: server/diplomats.c:1159
+#: server/diplomats.c:1208
 #, c-format
 msgid "Your %s was caught in the attempt of sabotage!"
 msgstr "Lähettämäsi %s jäi kiinni kesken sabotointiyrityksen!"
 
-#: server/diplomats.c:1163
+#: server/diplomats.c:1212
 #, c-format
 msgid "You caught %s %s attempting to sabotage the %s in %s!"
 msgstr "%s %s yritti sabotaasia – kohteenaan %s kaupungissa %s!"
 
-#: server/diplomats.c:1182
+#: server/diplomats.c:1231
 #, c-format
 msgid "Your %s destroyed the %s in %s."
 msgstr "Lähettämäsi %s tuhosi kohteensa %s kaupungissa %s."
 
-#: server/diplomats.c:1188
+#: server/diplomats.c:1237
 #, c-format
 msgid "The %s destroyed the %s in %s."
 msgstr "%s tuhosivat kohteen %s kaupungissa %s."
 
-#: server/diplomats.c:1281
+#: server/diplomats.c:1330
 #, c-format
 msgid "Your %s was caught attempting to steal gold!"
 msgstr "Lähettämäsi %s jäi kiinni kesken yrityksen varastaa kultaa!"
 
 #. TRANS: nation, unit, city
-#: server/diplomats.c:1286
+#: server/diplomats.c:1335
 #, c-format
 msgid "You caught %s %s attempting to steal your gold in %s!"
 msgstr "%s %s jäi kiinni yrittäessään varastaa kultaa kaupungista %s!"
 
 #. TRANS: unit, gold, city
-#: server/diplomats.c:1332
+#: server/diplomats.c:1381
 #, c-format
 msgid "Your %s stole %d gold from %s."
 msgid_plural "Your %s stole %d gold from %s."
@@ -41462,7 +41543,7 @@ msgstr[0] "Lähettämäsi %s varasti %d kultaa kaupungista %s."
 msgstr[1] "Lähettämäsi %s varasti %d kultaa kaupungista %s."
 
 #. TRANS: gold, city, nation
-#: server/diplomats.c:1337
+#: server/diplomats.c:1386
 #, c-format
 msgid "%d gold stolen from %s, %s suspected."
 msgid_plural "%d gold stolen from %s, %s suspected."
@@ -41471,52 +41552,52 @@ msgstr[0] ""
 msgstr[1] ""
 "%d kultaa varastettu kaupungista %s. Epäilemme että %s ovat syyllisiä."
 
-#: server/diplomats.c:1412
+#: server/diplomats.c:1461
 #, fuzzy, c-format
 #| msgid "Your %s was caught in the attempt of stealing technology from %s."
 msgid "Your %s was caught in an attempt of stealing parts of the %s world map!"
 msgstr ""
 "Lähettämäsi %s jäi kiinni yrittäessään varastaa teknologiaa kaupungissa %s."
 
-#: server/diplomats.c:1418
+#: server/diplomats.c:1467
 #, fuzzy, c-format
 #| msgid "You caught %s %s attempting to steal your gold in %s!"
 msgid "You caught %s %s attempting to steal parts of your world map in %s!"
 msgstr "%s %s jäi kiinni yrittäessään varastaa kultaa kaupungista %s!"
 
-#: server/diplomats.c:1441
+#: server/diplomats.c:1490
 #, fuzzy, c-format
 #| msgid "Your %s could not find the %s to sabotage in %s."
 msgid "Your %s stole parts of the %s world map in %s."
 msgstr ""
 "Lähettämäsi %s ei löytänyt suunniteltua sabotaasikohdetta %s kaupungista %s."
 
-#: server/diplomats.c:1446
+#: server/diplomats.c:1495
 #, fuzzy, c-format
 #| msgid "The %s are suspected of stealing %d gold from %s."
 #| msgid_plural "The %s are suspected of stealing %d gold from %s."
 msgid "The %s are suspected of stealing parts of your world map in %s."
 msgstr "%1$s ovat epäiltynä kultavarkaudesta. %3$s menettivät %2$d kultaa."
 
-#: server/diplomats.c:1510
+#: server/diplomats.c:1559
 #, fuzzy, c-format
 #| msgid "Your %s was caught in the attempt of inciting a revolt!"
 msgid "Your %s was caught in an attempt of hiding a nuke in %s!"
 msgstr "Lähettämäsi %s jäi kiinni kapinan lietsonnasta!"
 
-#: server/diplomats.c:1516
+#: server/diplomats.c:1565
 #, fuzzy, c-format
 #| msgid "You caught %s %s attempting to incite a revolt in %s!"
 msgid "You caught %s %s attempting to hide a nuke in %s!"
 msgstr "%s %s jäi kiinni yrittäessään lietsoa kapinaa kaupungissa %s!"
 
-#: server/diplomats.c:1535
+#: server/diplomats.c:1584
 #, fuzzy, c-format
 #| msgid "Your %s was nuked by %s."
 msgid "Your %s hid a nuke in %s."
 msgstr "Yksikkösi %s tuhoutui kun %s iskivät ydinasein."
 
-#: server/diplomats.c:1539
+#: server/diplomats.c:1588
 #, fuzzy, c-format
 #| msgid "The %s are suspected of stealing %d gold from %s."
 #| msgid_plural "The %s are suspected of stealing %d gold from %s."
@@ -41524,20 +41605,20 @@ msgid "The %s are suspected of hiding a nuke in %s."
 msgstr "%1$s ovat epäiltynä kultavarkaudesta. %3$s menettivät %2$d kultaa."
 
 #. TRANS: <unit> ... <diplomat>
-#: server/diplomats.c:1731
+#: server/diplomats.c:1780
 #, c-format
 msgid "An enemy %s has been eliminated by your %s."
 msgstr "Yksikkösi %2$s eliminoi vihollisen yksikön %1$s."
 
 #. TRANS: <unit> ... <city> ... <diplomat>
-#: server/diplomats.c:1738
+#: server/diplomats.c:1787
 #, c-format
 msgid "Your %s has been eliminated defending %s against a %s."
 msgstr "Puolustava %s kaupungissa %s tuhoutui, kun %s yritti tunkeutua sinne."
 
 #. TRANS: <nation adj> <unit> ... <city>
 #. * TRANS: ... <diplomat>
-#: server/diplomats.c:1745
+#: server/diplomats.c:1794
 #, c-format
 msgid "A %s %s has been eliminated defending %s against a %s."
 msgstr ""
@@ -41545,7 +41626,7 @@ msgstr ""
 
 #. TRANS: ... <unit> ... <nation adj> <city>
 #. * TRANS: ... <diplomat>
-#: server/diplomats.c:1752
+#: server/diplomats.c:1801
 #, c-format
 msgid "Your %s has been eliminated defending %s %s against a %s."
 msgstr ""
@@ -41553,54 +41634,54 @@ msgstr ""
 
 #. TRANS: <unit> ... <diplomat>
 #. TRANS: ... <unit> ... <diplomat>
-#: server/diplomats.c:1761 server/diplomats.c:1772
+#: server/diplomats.c:1810 server/diplomats.c:1821
 #, c-format
 msgid "Your %s has been eliminated defending against a %s."
 msgstr "Puolustava %s kaupungissa tuhoutui, kun %s yritti tunkeutua sinne."
 
 #. TRANS: <nation adj> <unit> ... <diplomat>
-#: server/diplomats.c:1766
+#: server/diplomats.c:1815
 #, c-format
 msgid "A %s %s has been eliminated defending against a %s."
 msgstr "Puolustava %s %s kaupungissa tuhoutui, kun %s yritti tunkeutua sinne."
 
-#: server/diplomats.c:1796
+#: server/diplomats.c:1845
 #, c-format
 msgid "Your %s was eliminated by a defending %s."
 msgstr "Lähettämäsi %s tuhoutui – puolustanut %s oli liian kova pala."
 
-#: server/diplomats.c:1802
+#: server/diplomats.c:1851
 #, c-format
 msgid "Eliminated a %s %s while infiltrating %s."
 msgstr "%s %s tuhottiin sen yrittäessä soluttautua kaupunkiin %s."
 
-#: server/diplomats.c:1807
+#: server/diplomats.c:1856
 #, c-format
 msgid "A %s %s eliminated a %s %s while infiltrating %s."
 msgstr "%s %s tuhosi %s yksikön %s sen yrittäessä soluttautua kaupunkiin %s."
 
-#: server/diplomats.c:1812
+#: server/diplomats.c:1861
 #, c-format
 msgid "Your %s eliminated a %s %s while infiltrating %s."
 msgstr "%s tuhosi %s yksikön %s sen yrittäessä soluttautua kaupunkiin %s."
 
-#: server/diplomats.c:1820
+#: server/diplomats.c:1869
 #, c-format
 msgid "Eliminated a %s %s while infiltrating our troops."
 msgstr "%s %s tuhoutui yrittäessään soluttautua joukkoihimme."
 
-#: server/diplomats.c:1825
+#: server/diplomats.c:1874
 #, c-format
 msgid "A %s %s eliminated a %s %s while infiltrating our troops."
 msgstr "%s %s tuhosi %s yksikön %s sen yrittäessä soluttautua joukkoihimme."
 
 #. TRANS: ... <unit> ... <diplomat>
-#: server/diplomats.c:1831
+#: server/diplomats.c:1880
 #, c-format
 msgid "Your %s eliminated a %s %s while infiltrating our troops."
 msgstr "%s tuhosi %s yksikön %s sen yrittäessä soluttautua joukkoihimme."
 
-#: server/diplomats.c:1947
+#: server/diplomats.c:1996
 #, c-format
 msgid ""
 "Your %s has successfully completed the mission and returned unharmed to %s."
@@ -41608,12 +41689,12 @@ msgstr ""
 "Lähettämäsi %s onnistui tehtävässään ja palasi vahingoittumattomana "
 "kaupunkiin %s."
 
-#: server/diplomats.c:1966
+#: server/diplomats.c:2015
 #, c-format
 msgid "Your %s was captured after completing the mission in %s."
 msgstr "Lähettämäsi %s onnistui tehtävässään, mutta jäi kiinni kaupungissa %s."
 
-#: server/diplomats.c:1972
+#: server/diplomats.c:2021
 #, c-format
 msgid "Your %s was captured after completing the mission."
 msgstr "Lähettämäsi %s onnistui tehtävässään, mutta jäi kiinni."
@@ -41929,22 +42010,22 @@ msgstr ""
 "En onnistu lataamaan fcdb-konfigurointitiedostoa '%s':\n"
 "%s"
 
-#: server/gamehand.c:412
+#: server/gamehand.c:413
 #, c-format
 msgid "Didn't find optimal solution for team placement in %d iterations."
 msgstr ""
 "Ei löytynyt kelvollista aloituspaikkojen jakoa joukkueille %d yrityksellä."
 
-#: server/gamehand.c:839
+#: server/gamehand.c:840
 #, c-format
 msgid "No units placed for %s!"
 msgstr "%s on jäänyt ilman sijoitettuja yksiköitä!"
 
-#: server/gamehand.c:967
+#: server/gamehand.c:968
 msgid "The turn timeout has exceeded its maximum value, fixing at its maximum."
 msgstr "Vuoron aikaraja on liian suuri ja palautetaan maksimiarvoon"
 
-#: server/gamehand.c:975
+#: server/gamehand.c:976
 msgid "The turn timeout is smaller than zero, fixing at zero."
 msgstr "Vuoron aikaraja on nollaa pienempi ja muutetaan nollaksi."
 
@@ -42001,7 +42082,7 @@ msgid ""
 msgstr ""
 "Asetetaan kartan kooksi %d (noin %d maaruutua kutakin %d pelaajaa kohden)."
 
-#: server/generator/startpos.c:495
+#: server/generator/startpos.c:496
 msgid ""
 "The server appears to have gotten into an infinite loop in the allocation of "
 "starting positions.\n"
@@ -42059,6 +42140,23 @@ msgstr "En löydä yhteyttä jonka nimi olisi %s."
 #, c-format
 msgid "There is no player nor connection by the name %s."
 msgstr "En löydä pelaajaa enkä yhteyttä nimellä %s."
+
+#: server/infrapts.c:40
+#, fuzzy, c-format
+#| msgid "%s can't do %s to an unknown tile."
+msgid "Cannot place %s to unseen tile."
+msgstr "Yksikkösi %s ei voi suorittaa toimintoa %s tuntemattomaan ruutuun."
+
+#: server/infrapts.c:47
+#, c-format
+msgid "Cannot place %s for lack of infrapoints."
+msgstr ""
+
+#: server/infrapts.c:54
+#, fuzzy, c-format
+#| msgid "Cannot open stringfile \"%s\"."
+msgid "Cannot place unbuildable %s."
+msgstr "Tekstikenttätiedoston \"%s\" avaaminen epäonnistui."
 
 #: server/maphand.c:106
 msgid "Global warming has occurred!"
@@ -42267,99 +42365,99 @@ msgstr ""
 "Joukkuetoverisi %s ja liittolaisesi %s ovat nyt sodassa. Sinulla ei ole "
 "vaihtoehtoa, %s ei voi enää olla liittolaisesi."
 
-#: server/plrhand.c:1473
+#: server/plrhand.c:1475
 msgid ""
 "Can only set player color prior to game start if 'plrcolormode' is PLR_SET."
 msgstr ""
 "Voit asettaa pelaajan värin ennen pelin alkua vain jos 'plrcolormode' on "
 "arvossa PLR_SET."
 
-#: server/plrhand.c:1612
+#: server/plrhand.c:1614
 msgid "no color"
 msgstr "ei väriä"
 
-#: server/plrhand.c:1704
+#: server/plrhand.c:1706
 #, c-format
 msgid "Removing player %s."
 msgstr "Pelaaja %s on poistettu pelistä."
 
-#: server/plrhand.c:1707
+#: server/plrhand.c:1709
 msgid "You've been removed from the game!"
 msgstr "Sinut on poistettu pelistä!"
 
-#: server/plrhand.c:1710
+#: server/plrhand.c:1712
 #, c-format
 msgid "%s has been removed from the game."
 msgstr "%s on poistettu pelistä."
 
-#: server/plrhand.c:1861
+#: server/plrhand.c:1863
 msgid "Please choose a non-blank name."
 msgstr "Ole hyvä ja valitse nimi joka ei ole tyhjä."
 
-#: server/plrhand.c:1874
+#: server/plrhand.c:1876
 msgid "That nation is already in use."
 msgstr "Valitsemasi kansakunta on jo käytössä."
 
-#: server/plrhand.c:1879
+#: server/plrhand.c:1881
 #, c-format
 msgid "Another player already has the name '%s'. Please choose another name."
 msgstr ""
 "Samanniminen ('%s') pelaaja on jo liittynyt peliin. Ole hyvä ja valitse "
 "toinen nimi."
 
-#: server/plrhand.c:1903
+#: server/plrhand.c:1905
 msgid "Please choose a name containing only ASCII characters."
 msgstr "Ole hyvä ja valitse nimi jossa on vain ASCII-merkkejä."
 
-#: server/plrhand.c:1978 server/plrhand.c:1992
+#: server/plrhand.c:1980 server/plrhand.c:1994
 #, c-format
 msgid "Player no. %d"
 msgstr "Pelaaja %d"
 
-#: server/plrhand.c:2007
+#: server/plrhand.c:2009
 msgid "A poorly-named player"
 msgstr "Huonosti nimetty pelaaja"
 
-#: server/plrhand.c:2076 server/plrhand.c:2080
+#: server/plrhand.c:2078 server/plrhand.c:2082
 #, c-format
 msgid "You have made contact with the %s, ruled by %s."
 msgstr "Olet kohdannut %s, joita hallitsee %s."
 
-#: server/plrhand.c:2758
+#: server/plrhand.c:2760
 #, c-format
 msgid "Could not throw %s into civil war - too many players"
 msgstr ""
 "%s kansakunta ei voi vajota sisällissotaan - pelissä on liikaa pelaajia"
 
-#: server/plrhand.c:2764
+#: server/plrhand.c:2766
 #, c-format
 msgid "Could not throw %s into civil war - no available nations"
 msgstr ""
 "%s eivät voi vajota sisällissotaan - sopivia kansakuntia ei ole saatavilla"
 
-#: server/plrhand.c:2798
+#: server/plrhand.c:2800
 #, c-format
 msgid "Could not throw %s into civil war - no available cities"
 msgstr "%s eivät voi vajota sisällissotaan - ei ole sopivia kaupunkeja"
 
-#: server/plrhand.c:2831
+#: server/plrhand.c:2833
 msgid "Your nation is thrust into civil war."
 msgstr "Kansakunnassasi syttyy sisällissota."
 
 #. TRANS: <leader> ... the Poles.
-#: server/plrhand.c:2835
+#: server/plrhand.c:2837
 #, c-format
 msgid "%s is the rebellious leader of the %s."
 msgstr "%s on kapinajohtaja, jota %s seuraavat."
 
 #. TRANS: <city> ... the Poles.
-#: server/plrhand.c:2857
+#: server/plrhand.c:2859
 #, c-format
 msgid "%s declares allegiance to the %s."
 msgstr "%s irtautuu emämaasta; nyt %s hallitsevat sitä."
 
 #. TRANS: ... Danes ... Poles ... <7> cities.
-#: server/plrhand.c:2882
+#: server/plrhand.c:2884
 #, c-format
 msgid "Civil war partitions the %s; the %s now hold %d city."
 msgid_plural "Civil war partitions the %s; the %s now hold %d cities."
@@ -42368,7 +42466,7 @@ msgstr[1] "Sisällissota jakaa %s kahtia; %s hallitsevat nyt %d kaupunkia."
 
 #. TRANS: '/delegate cancel' is a server command and must not
 #. * be translated
-#: server/plrhand.c:3023
+#: server/plrhand.c:3025
 #, c-format
 msgid ""
 "User '%s' is currently allowed to take control of your player while you are "
@@ -42377,14 +42475,14 @@ msgstr ""
 "Käyttäjä '%s' saa nykyasetuksilla ottaa pelaajasi haltuunsa kun olet poissa. "
 "Voit estää tämän komennolla '/delegate cancel'."
 
-#: server/plrhand.c:3035
+#: server/plrhand.c:3037
 #, c-format
 msgid "Control of player '%s' is delegated to you."
 msgstr "Pelaajan '%s' hallinta on delegoitu sinulle."
 
 #. TRANS: '/delegate take' is a server command and must not
 #. * be translated; but <player> should be translated.
-#: server/plrhand.c:3044
+#: server/plrhand.c:3046
 msgid "Use '/delegate take <player>' to take control of a delegated player."
 msgstr ""
 "Käytä komentoa '/delegate take <pelaaja>' ottaaksesi haltuun pelaaja jonka "
@@ -42806,7 +42904,7 @@ msgstr "Vihollisyksiköitä tuhottu\n"
 msgid "Unit Losses\n"
 msgstr "Yksiköitä menetetty\n"
 
-#: server/rssanity.c:1309
+#: server/rssanity.c:1317
 msgid "Disabling 'barbarians' setting for lack of suitable unit types."
 msgstr ""
 "Barbaarit poistettu käytöstä koska sääntökokoelmassa ei ole sopivia "
@@ -42826,15 +42924,15 @@ msgstr "Rakenna tyypin A tukikohta"
 msgid "?gui_type:Build Type B Base"
 msgstr "Rakenna tyypin B tukikohta"
 
-#: server/ruleset.c:8091
+#: server/ruleset.c:8102
 msgid "Ruleset couldn't be loaded. Keeping previous one."
 msgstr "Sääntökokoelmaa ei voitu ladata. Pidetään edellinen käytössä."
 
-#: server/ruleset.c:8109
+#: server/ruleset.c:8120
 msgid "Ruleset couldn't be loaded. Switching to default one."
 msgstr "Sääntökokoelmaa ei voitu ladata. Palataan oletuskokoelmaan."
 
-#: server/ruleset.c:8116
+#: server/ruleset.c:8127
 msgid ""
 "Cannot load any ruleset. Freeciv-web ruleset is available from https://"
 "github.com/freeciv/freeciv-web"
@@ -42843,7 +42941,7 @@ msgstr ""
 "yhteensopiva sääntökokoelma on olemassa git-repositoryssa https://github.com/"
 "freeciv/freeciv-web"
 
-#: server/ruleset.c:8157
+#: server/ruleset.c:8168
 msgid "Loading rulesets."
 msgstr "Lataan sääntökokoelmaa."
 
@@ -42876,38 +42974,38 @@ msgstr ""
 "tallennettu peli on vanha, tai tiedosto voi olla viallinen. Jatka omalla "
 "vastuullasi."
 
-#: server/savegame/savegame2.c:1103
+#: server/savegame/savegame2.c:1105
 msgid "Failed to load ruleset"
 msgstr "Virhe sääntökokoelman lataamisessa"
 
-#: server/savegame/savegame2.c:2598 server/savegame/savegame3.c:3476
+#: server/savegame/savegame2.c:2600 server/savegame/savegame3.c:3515
 #: server/srv_main.c:2370 server/srv_main.c:2375
 #, c-format
 msgid "%s has been added as %s level AI-controlled player (%s)."
 msgstr "%s on lisätty vaikeustason %s AI-pelaajaksi (%s)."
 
-#: server/savegame/savegame2.c:2603 server/savegame/savegame3.c:3481
+#: server/savegame/savegame2.c:2605 server/savegame/savegame3.c:3520
 #, c-format
 msgid "%s has been added as human player."
 msgstr "%s on lisätty tavalliseksi pelaajaksi."
 
 #. TRANS: Minor error message: <Leader> ... <Poles>.
-#: server/savegame/savegame2.c:2627 server/savegame/savegame3.c:3505
+#: server/savegame/savegame2.c:2629 server/savegame/savegame3.c:3544
 #, c-format
 msgid "%s had invalid nation; changing to %s."
 msgstr "%s johtama kansakunta ei kelpaa; vaihdetaan tilalle %s."
 
-#: server/savegame/savegame2.c:5121 server/savegame/savegame3.c:7103
+#: server/savegame/savegame2.c:5123 server/savegame/savegame3.c:7326
 #, c-format
 msgid "%s had invalid researching technology."
 msgstr "Pelaajan %s tutkimuskohde oli virheellinen."
 
-#: server/savegame/savegame2.c:5131 server/savegame/savegame3.c:7113
+#: server/savegame/savegame2.c:5133 server/savegame/savegame3.c:7336
 #, c-format
 msgid "%s had invalid technology goal."
 msgstr "Pelaajan %s tutkimustavoite oli virheellinen."
 
-#: server/savegame/savegame2.c:5156 server/savegame/savegame3.c:7131
+#: server/savegame/savegame2.c:5158 server/savegame/savegame3.c:7354
 #, c-format
 msgid ""
 "%s has multiple units of type %s though it should be possible to have only "
@@ -42916,23 +43014,34 @@ msgstr ""
 "%s omistaa monta %s yksikköä, vaikka sellaisia pitäisi voida olla vain yksi "
 "kullakin pelaajalla."
 
-#: server/savegame/savegame3.c:1317
+#: server/savegame/savegame3.c:1321
 #, fuzzy, c-format
 #| msgid "File capabilities: %s"
 msgid "Scenario requires ruleset capabilities: %s"
 msgstr "Tiedoston toimintomuuttuja: %s"
 
-#: server/savegame/savegame3.c:1318
+#: server/savegame/savegame3.c:1322
 #, fuzzy, c-format
 #| msgid "File capabilities: %s"
 msgid "Ruleset has capabilities: %s"
 msgstr "Tiedoston toimintomuuttuja: %s"
 
-#: server/savegame/savegame3.c:1319
+#: server/savegame/savegame3.c:1323
 #, fuzzy
 #| msgid "Current ruleset contains no summary."
 msgid "Current ruleset not compatible with the scenario."
 msgstr "Tämänhetkisestä sääntökokoelmasta puuttuu yhteenveto."
+
+#: server/savegame/savegame3.c:1347
+#, c-format
+msgid "Can't find scenario luadata file %s.luadata."
+msgstr ""
+
+#: server/savegame/savegame3.c:1354
+#, fuzzy, c-format
+#| msgid "Failed to load ruleset"
+msgid "Failed to load scenario luadata file %s.luadata"
+msgstr "Virhe sääntökokoelman lataamisessa"
 
 #: server/savegame/savemain.c:119
 #, c-format
@@ -44051,18 +44160,22 @@ msgid "Amount of huts (bonus extras)"
 msgstr "Majojen (bonus-tyyppisten ruutulisien) määrä"
 
 #: server/settings.c:1727
+#, fuzzy
+#| msgid ""
+#| "Huts are tile extras that may be investigated by units. The server "
+#| "variable's scale is huts per thousand tiles."
 msgid ""
-"Huts are tile extras that may be investigated by units. The server "
+"Huts are tile extras that usually may be investigated by units.The server "
 "variable's scale is huts per thousand tiles."
 msgstr ""
 "Majat ovat ruutulisiä, joita yksiköt voivat käydä tutkimassa. Tämä "
 "palvelinasetus kertoo montako majaa kartalla on tuhatta ruutua kohden."
 
-#: server/settings.c:1734
+#: server/settings.c:1735
 msgid "Amount of animals"
 msgstr "Eläinten määrä"
 
-#: server/settings.c:1735
+#: server/settings.c:1736
 msgid ""
 "Number of animals initially created on terrains defined for them in the "
 "ruleset (if the ruleset supports it). The server variable's scale is animals "
@@ -44071,11 +44184,11 @@ msgstr ""
 "Pelin alussa luotujen eläinten määrä tuhatta ruutua kohti, maastotyypeille "
 "joille niitä on sääntökokoelmassa määritelty, jos ollenkaan."
 
-#: server/settings.c:1747
+#: server/settings.c:1748
 msgid "Minimum number of players"
 msgstr "Pienin sallittu pelaajamäärä"
 
-#: server/settings.c:1748
+#: server/settings.c:1749
 msgid ""
 "There must be at least this many players (connected human players) before "
 "the game can start."
@@ -44083,11 +44196,11 @@ msgstr ""
 "Peli ei voi alkaa ennen kuin vähintään näin moni (yhteydessä oleva ihmis-) "
 "pelaaja on liittynyt."
 
-#: server/settings.c:1755
+#: server/settings.c:1756
 msgid "Maximum number of players"
 msgstr "Suurin sallittu pelaajamäärä"
 
-#: server/settings.c:1756
+#: server/settings.c:1757
 msgid ""
 "The maximal number of human and AI players who can be in the game. When this "
 "number of players are connected in the pregame state, any new players who "
@@ -44101,11 +44214,11 @@ msgstr ""
 "Pelatessa skenaariota joka määrittelee pelaajien aloituspaikat, tätä "
 "asetusta ei voi asettaa aloituspaikkojen määrää suuremmaksi."
 
-#: server/settings.c:1768
+#: server/settings.c:1769
 msgid "Limited number of AI players"
 msgstr "Rajattu määrä AI-pelaajia"
 
-#: server/settings.c:1769
+#: server/settings.c:1770
 msgid ""
 "If set to a positive value, then AI players will be automatically created or "
 "removed to keep the total number of players at this amount. As more players "
@@ -44117,11 +44230,11 @@ msgstr ""
 "liittyessä AI-pelaajien määrää vähennetään. Jos arvo on 0, kaikki AI-"
 "pelaajat poistetaan."
 
-#: server/settings.c:1779
+#: server/settings.c:1780
 msgid "When the Readiness of a player gets autotoggled off"
 msgstr "Milloin pelaajan ilmoittama valmius automaattisesti unohdetaan"
 
-#: server/settings.c:1780
+#: server/settings.c:1781
 msgid ""
 "In pre-game, usually when new players join or old ones leave, those who have "
 "already accepted game to start by toggling \"Ready\" get that autotoggled "
@@ -44134,12 +44247,12 @@ msgstr ""
 "tilanteessa. Tällä asetuksella voidaan määrittää että pelin alun hyväksyntä "
 "pysyy voimassa muuttuneissakin olosuhteissa."
 
-#: server/settings.c:1789
+#: server/settings.c:1790
 msgid "Set of nations to choose from"
 msgstr "Kansavalikoima, josta kansat valitaan"
 
 #. TRANS: do not translate '/list nationsets'
-#: server/settings.c:1791
+#: server/settings.c:1792
 msgid ""
 "Controls the set of nations allowed in the game. The choices are defined by "
 "the ruleset.\n"
@@ -44157,11 +44270,11 @@ msgstr ""
 "'/list nationsets' listaa käytössä olevan sääntökokoelman tukemat "
 "kansavalikoimat."
 
-#: server/settings.c:1805
+#: server/settings.c:1806
 msgid "Event cache for this number of turns"
 msgstr "Viestipuskuri näin moneksi vuoroksi"
 
-#: server/settings.c:1806
+#: server/settings.c:1807
 msgid ""
 "Event messages are saved for this number of turns. A value of 0 deactivates "
 "the event cache."
@@ -44169,30 +44282,30 @@ msgstr ""
 "Viestit talletetaan näin monelta kierrokselta. Arvo 0 poistaa puskurin "
 "käytöstä."
 
-#: server/settings.c:1814
+#: server/settings.c:1815
 msgid "Size of the event cache"
 msgstr "Viestipuskurin koko"
 
-#: server/settings.c:1815
+#: server/settings.c:1816
 msgid "This defines the maximal number of events in the event cache."
 msgstr "Tallennettavien viestien enimmäismäärä."
 
-#: server/settings.c:1822
+#: server/settings.c:1823
 msgid "Save chat messages in the event cache"
 msgstr "Säilytä keskustelu viestipuskurissa"
 
-#: server/settings.c:1823
+#: server/settings.c:1824
 msgid "If turned on, chat messages will be saved in the event cache."
 msgstr ""
 "Jos valinta on päällä, pelaajien välinen keskustelu tallennetaan "
 "viestipuskuriin."
 
-#: server/settings.c:1829
+#: server/settings.c:1830
 msgid "Print turn and time for each cached event"
 msgstr "Tulosta kunkin tallennetun viestin aika ja vuoronumero"
 
 #. TRANS: Don't translate the text between single quotes.
-#: server/settings.c:1831
+#: server/settings.c:1832
 msgid ""
 "If turned on, all cached events will be marked by the turn and time of the "
 "event like '(T2 - 15:29:52)'."
@@ -44200,11 +44313,11 @@ msgstr ""
 "Jos valinta on käytössä, tallennettujen viestien kanssa tulostetaan vuoron "
 "numero ja ajankohta, esimerkiksi '(T2 - 15:29:52)'."
 
-#: server/settings.c:1841
+#: server/settings.c:1842
 msgid "List of players' initial units"
 msgstr "Pelaajien aloitusyksiköiden luettelo"
 
-#: server/settings.c:1842
+#: server/settings.c:1843
 msgid ""
 "This should be a string of characters, each of which specifies a unit role. "
 "The first character must be native to at least one \"Starter\" terrain. The "
@@ -44234,11 +44347,11 @@ msgstr ""
 "    a   = Nopea hyökkäysyksikkö (esim. Hevospartio)\n"
 "    A   = Vahva hyökkäysyksikkö (esim. Katapultti)\n"
 
-#: server/settings.c:1861
+#: server/settings.c:1862
 msgid "Whether player starts with a city"
 msgstr "Aloittaako pelaaja valmiiksi perustetun kaupungin kanssa"
 
-#: server/settings.c:1862
+#: server/settings.c:1863
 msgid ""
 "If this is set, game will start with player's first city already founded to "
 "starting location."
@@ -44246,30 +44359,43 @@ msgstr ""
 "Jos tämä on asetettu, pelaajat saavat pelin alkaessa automaattisesti "
 "aloitusruutuunsa perustetun kaupungin."
 
-#: server/settings.c:1869
+#: server/settings.c:1870
 msgid "Area where initial units are located"
 msgstr "Aloitusyksiköiden hajonta-alue"
 
-#: server/settings.c:1870
+#: server/settings.c:1871
 msgid "This is the radius within which the initial units are dispersed."
 msgstr ""
 "Aloitusyksiköt hajautetaan alueelle, jonka säde on tämän asetuksen mukainen."
 
-#: server/settings.c:1878
+#: server/settings.c:1879
 msgid "Starting gold per player"
 msgstr "Kullan määrä pelaajaa kohti pelin alussa"
 
-#: server/settings.c:1879
+#: server/settings.c:1880
 msgid "At the beginning of the game, each player is given this much gold."
 msgstr "Kullekin pelaajalle annetaan arvon mukainen määrä kultaa pelin alussa."
 
-#: server/settings.c:1886
+#: server/settings.c:1887
+#, fuzzy
+#| msgid "Starting gold per player"
+msgid "Starting infrapoints per player"
+msgstr "Kullan määrä pelaajaa kohti pelin alussa"
+
+#: server/settings.c:1888
+#, fuzzy
+#| msgid "At the beginning of the game, each player is given this much gold."
+msgid ""
+"At the beginning of the game, each player is given this many infrapoints."
+msgstr "Kullekin pelaajalle annetaan arvon mukainen määrä kultaa pelin alussa."
+
+#: server/settings.c:1895
 msgid "Number of initial techs per player"
 msgstr "Pelaajien aloitusteknologioiden määrä"
 
 #. TRANS: The string between single quotes is a setting name and
 #. * should not be translated.
-#: server/settings.c:1889
+#: server/settings.c:1898
 msgid ""
 "At the beginning of the game, each player is given this many technologies. "
 "The technologies chosen are random for each player. Depending on the value "
@@ -44281,11 +44407,11 @@ msgstr ""
 "Sääntökokoelman tech_cost_style-arvosta riippuen korkea techlevel-arvo voi "
 "tehdä seuraavista teknologioista erittäin kalliita."
 
-#: server/settings.c:1899
+#: server/settings.c:1908
 msgid "Technology cost multiplier percentage"
 msgstr "Teknologiahinnan kerrannaisprosentti"
 
-#: server/settings.c:1900
+#: server/settings.c:1909
 msgid ""
 "This affects how quickly players can research new technology. All tech costs "
 "are multiplied by this amount (as a percentage). The base tech costs are "
@@ -44296,24 +44422,24 @@ msgstr ""
 "tulkittuna). Perusteknologiakustannukset määritetään sääntökokoelmassa tai "
 "muiden pelin asetusten kautta."
 
-#: server/settings.c:1909
+#: server/settings.c:1918
 #, fuzzy
 #| msgid "You cannot research this technology."
 msgid "Allow researching multiple technologies"
 msgstr "Et voi tutkia tätä teknologiaa."
 
-#: server/settings.c:1910
+#: server/settings.c:1919
 msgid ""
 "Allows switching to any technology without wasting old research. Bulbs are "
 "never transfered to new technology. Techpenalty options are inefective after "
 "enabling that option."
 msgstr ""
 
-#: server/settings.c:1918
+#: server/settings.c:1927
 msgid "Percentage penalty when changing tech"
 msgstr "Prosentuaalinen menetys tutkimuskohdetta muutettaessa"
 
-#: server/settings.c:1919
+#: server/settings.c:1928
 msgid ""
 "If you change your current research technology, and you have positive "
 "research points, you lose this percentage of those research points. This "
@@ -44323,21 +44449,21 @@ msgstr ""
 "positiivisia, menetät näin monta prosenttia tutkimuspisteistäsi. Menetystä "
 "ei tapahdu jos olet juuri tehnyt uuden edistysaskeleen tällä vuorolla."
 
-#: server/settings.c:1928
+#: server/settings.c:1937
 msgid "Chance to lose a technology while receiving it"
 msgstr "Mahdollisuus menettää saatava teknologia"
 
-#: server/settings.c:1929
+#: server/settings.c:1938
 msgid "The chance that learning a technology by treaty or theft will fail."
 msgstr ""
 "Mahdollisuus that sopimusteitse tai varastamalla saatavan teknologian "
 "oppiminen epäonnistuu."
 
-#: server/settings.c:1936
+#: server/settings.c:1945
 msgid "Chance to lose a technology while giving it"
 msgstr "Mahdollisuus menettää teknologia pois annettaessa"
 
-#: server/settings.c:1937
+#: server/settings.c:1946
 msgid ""
 "The chance that your civilization will lose a technology if you teach it to "
 "someone else by treaty, or if it is stolen from you."
@@ -44345,21 +44471,21 @@ msgstr ""
 "Mahdollisuus että teknologian alkuperäinen tuntija menettää sen opettaessaan "
 "sen toiselle pelaajalle, tai toisen pelaajan varastaessa sen."
 
-#: server/settings.c:1945
+#: server/settings.c:1954
 msgid "Tech leakage percent"
 msgstr ""
 
-#: server/settings.c:1946
+#: server/settings.c:1955
 #, fuzzy
 #| msgid "The name of the chat log file."
 msgid "The rate of the tech leakage."
 msgstr "Viestilogi tallennetaan annettuun tiedostoon."
 
-#: server/settings.c:1952
+#: server/settings.c:1961
 msgid "Team pooled research"
 msgstr "Joukkueen tutkimuksen yhdistäminen"
 
-#: server/settings.c:1953
+#: server/settings.c:1962
 msgid ""
 "If this setting is turned on, then the team mates will share the science "
 "research. Else, every player of the team will have to make its own."
@@ -44367,11 +44493,11 @@ msgstr ""
 "Jos asetus on käytössä, joukkueen jäsenet jakavat tutkimustulokset. Muutoin "
 "jokaisen jäsenen pitää erikseen saavuttaa edistyaskeleet."
 
-#: server/settings.c:1960
+#: server/settings.c:1969
 msgid "Penalty when getting tech from treaty"
 msgstr "Sopimusteitse saadun teknologian menetys"
 
-#: server/settings.c:1961
+#: server/settings.c:1970
 msgid ""
 "For each technology you gain from a diplomatic treaty, you lose research "
 "points equal to this percentage of the cost to research a new technology. If "
@@ -44381,11 +44507,11 @@ msgstr ""
 "näin monta prosenttia uuden edistysaskeleen vaatimista tutkimuspisteistä - "
 "voit siis päätyä pakkasen puolelle tutkimuspisteissäsi, jos arvo ei ole 0."
 
-#: server/settings.c:1970
+#: server/settings.c:1979
 msgid "Penalty when getting gold from treaty"
 msgstr "Sopimusteitse saadun kullan menetys"
 
-#: server/settings.c:1971
+#: server/settings.c:1980
 msgid ""
 "When transferring gold in diplomatic treaties, this percentage of the agreed "
 "sum is lost to both parties; it is deducted from the donor but not received "
@@ -44395,11 +44521,34 @@ msgstr ""
 "prosenttimäärä rahasta menetetään kokonaan. Se vähennetään antajalta, mutta "
 "ei päädy vastaanottajalle."
 
-#: server/settings.c:1979
+#: server/settings.c:1988
+msgid "Probability of gold loss during inciting revolt"
+msgstr ""
+
+#: server/settings.c:1989
+msgid ""
+"When unit trying to incite revolt is eliminated, half of the gold (or "
+"quarter, if unit was caught), prepared to bribe citizens, can be lost or "
+"captured by enemy."
+msgstr ""
+
+#: server/settings.c:1998
+msgid "Probability of gold capture during inciting revolt"
+msgstr ""
+
+#: server/settings.c:1999
+msgid ""
+"When unit trying to incite revolt is eliminated and lose its gold, there is "
+"chance that this gold would be captured by city defender. Transfer tax would "
+"be applied, though. This setting is irrevelant, if incite_gold_loss_chance "
+"is zero."
+msgstr ""
+
+#: server/settings.c:2009
 msgid "Penalty when getting tech from conquering"
 msgstr "Prosentuaalinen menetys valloituksen kautta saadun teknologian takia"
 
-#: server/settings.c:1980
+#: server/settings.c:2010
 msgid ""
 "For each technology you gain by conquering an enemy city, you lose research "
 "points equal to this percentage of the cost to research a new technology. If "
@@ -44409,13 +44558,13 @@ msgstr ""
 "näin monta prosenttia uuden edistysaskeleen vaatimista tutkimuspisteistä - "
 "voit siis päätyä pakkasen puolelle tutkimuspisteissäsi, jos arvo ei ole 0."
 
-#: server/settings.c:1990
+#: server/settings.c:2020
 msgid "Penalty when getting a free tech"
 msgstr "Prosentuaalinen menetys ilmaisen teknologian saamisen takia"
 
 #. TRANS: The strings between single quotes are setting names and
 #. * shouldn't be translated.
-#: server/settings.c:1993
+#: server/settings.c:2023
 msgid ""
 "For each technology you gain \"for free\" (other than covered by 'diplcost' "
 "or 'conquercost': for instance, from huts or from Great Library effects), "
@@ -44429,13 +44578,13 @@ msgstr ""
 "näin monta prosenttia uuden edistysaskeleen vaatimista tutkimuspisteistä – "
 "voit siis päätyä pakkasen puolelle tutkimuspisteissäsi."
 
-#: server/settings.c:2004
+#: server/settings.c:2034
 msgid "Research point debt threshold for losing tech"
 msgstr ""
 "Kuinka paljon tutkimuspisteet saavat olla alle nollan ennen kuin teknologia "
 "menetetään"
 
-#: server/settings.c:2005
+#: server/settings.c:2035
 msgid ""
 "When you have negative research points, and your shortfall is greater than "
 "this percentage of the cost of your current research, you forget a "
@@ -44448,12 +44597,12 @@ msgstr ""
 "tunnettu teknologia menetetään.\n"
 "Arvo '-1' poistaa teknologioiden menettämisen kokonaan käytöstä."
 
-#: server/settings.c:2016
+#: server/settings.c:2046
 msgid "Research points restored after losing a tech"
 msgstr ""
 "Paljonko tutkimuspisteitä palautetaan teknologian menettämisen yhteydessä"
 
-#: server/settings.c:2017
+#: server/settings.c:2047
 msgid ""
 "When you lose a technology due to a negative research balance (see "
 "'techlossforgiveness'), this percentage of its research cost is credited to "
@@ -44467,11 +44616,11 @@ msgstr ""
 "Arvo '-1' aiheuttaa tutkimuspisteiden määrän palauttamisen aina arvoon 0, "
 "riippumatta siitä kuinka paljon vajausta oli."
 
-#: server/settings.c:2030
+#: server/settings.c:2060
 msgid "Food required for a city to grow"
 msgstr "Kaupungin kasvuun tarvittava ruokamäärä"
 
-#: server/settings.c:2031
+#: server/settings.c:2061
 msgid ""
 "This is the base amount of food required to grow a city. This value is "
 "multiplied by another factor that comes from the ruleset and is dependent on "
@@ -44480,11 +44629,11 @@ msgstr ""
 "Tämä on kaupungin kasvuun tarvittava perusruokamäärä. Se kerrotaan "
 "sääntökokoelman määräämällä tekijällä, joka riippuu kaupungin koosta."
 
-#: server/settings.c:2039
+#: server/settings.c:2069
 msgid "Percentage food lost when city can't grow"
 msgstr "Prosentuaalinen ruokavarojen menetys kun kaupunki ei voi kasvaa"
 
-#: server/settings.c:2040
+#: server/settings.c:2070
 msgid ""
 "If a city would expand, but it can't because it lacks some prerequisite "
 "(traditionally an Aqueduct or Sewer System), this is the base percentage of "
@@ -44496,11 +44645,11 @@ msgstr ""
 "ruokavaroistaan kierroksessa; sääntökokoelmasta riippuen kaupungissa olevat "
 "rakennukset tai muut tekijät saattavat vaikuttaa lopulliseen prosenttiin."
 
-#: server/settings.c:2052
+#: server/settings.c:2082
 msgid "Multiplier percentage for production costs"
 msgstr "Tuotantohinnan kerroin"
 
-#: server/settings.c:2053
+#: server/settings.c:2083
 msgid ""
 "This affects how quickly units and buildings can be produced.  The base "
 "costs are multiplied by this value (as a percentage)."
@@ -44509,13 +44658,13 @@ msgstr ""
 "tuottaa. Perushinnat kerrotaan tällä arvolla (tulkittuna "
 "prosenttiyksiköiksi)."
 
-#: server/settings.c:2067
+#: server/settings.c:2097
 msgid "Minimum city size to get full trade"
 msgstr "Kaupungin minimikoko kaupan maksimoinniksi"
 
 #. TRANS: The strings between single quotes are setting names and
 #. * shouldn't be translated.
-#: server/settings.c:2070
+#: server/settings.c:2100
 msgid ""
 "There is a trade penalty in all cities smaller than this. The penalty is "
 "100% (no trade at all) for sizes up to 'notradesize', and decreases "
@@ -44527,13 +44676,13 @@ msgstr ""
 "lievenee asteettain 0 %:iin (ei lainkaan leikkuria tavanomaista korruptiota "
 "lukuunottamatta) kokoon 'fulltradesize' asti. Katso myös 'notradesize'."
 
-#: server/settings.c:2080
+#: server/settings.c:2110
 msgid "Maximum size of a city without trade"
 msgstr "Kaupattoman kaupungin maksimikoko"
 
 #. TRANS: The strings between single quotes are setting names and
 #. * shouldn't be translated.
-#: server/settings.c:2083
+#: server/settings.c:2113
 msgid ""
 "Cities do not produce any trade at all unless their size is larger than this "
 "amount. The produced trade increases gradually for cities larger than "
@@ -44543,7 +44692,7 @@ msgstr ""
 "lisääntyy vähitellen kunnes saavutetaan 'fulltradesize', täyden kaupan "
 "tuottava koko. Katso myös 'fulltradesize'."
 
-#: server/settings.c:2093
+#: server/settings.c:2123
 msgid "How largely trade distance is relative to world size"
 msgstr ""
 "Kuinka suurelta osin kartan koko vaikuttaa kauppareitin laskennalliseen "
@@ -44551,7 +44700,7 @@ msgstr ""
 
 #. TRANS: The strings between single quotes are setting names and
 #. * shouldn't be translated.
-#: server/settings.c:2096
+#: server/settings.c:2126
 msgid ""
 "When determining trade between cities, the distance factor can be partly or "
 "fully relative to world size. This setting determines how big percentage of "
@@ -44564,11 +44713,11 @@ msgstr ""
 "ja kuinka suurelta osin se jää laskettavaksi suoraan ruutumääräisen "
 "etäisyyden mukaan."
 
-#: server/settings.c:2108
+#: server/settings.c:2138
 msgid "Minimum distance between cities"
 msgstr "Kaupunkien välinen minimietäisyys"
 
-#: server/settings.c:2109
+#: server/settings.c:2139
 msgid ""
 "When a player attempts to found a new city, it is prevented if the distance "
 "from any existing city is less than this setting. For example, when this "
@@ -44581,44 +44730,44 @@ msgstr ""
 "vähintään 2 tyhjää ruutua joka suunnassa. Asetuksen arvo 1 poistaa "
 "rajoituksen, jolloin kaupunkeja voi perustaa jopa vierekkäisiin ruutuihin."
 
-#: server/settings.c:2121
+#: server/settings.c:2151
 msgid "Technology trading"
 msgstr "Teknologian vaihto"
 
-#: server/settings.c:2122
+#: server/settings.c:2152
 msgid ""
 "If turned off, trading technologies in the diplomacy dialog is not allowed."
 msgstr ""
 "Jos asetus ei ole käytössä, diplomatiadialogissa ei voi siirtää "
 "teknologioita kansakunnalta toiselle."
 
-#: server/settings.c:2128
+#: server/settings.c:2158
 msgid "Gold trading"
 msgstr "Kullan vaihto"
 
-#: server/settings.c:2129
+#: server/settings.c:2159
 msgid "If turned off, trading gold in the diplomacy dialog is not allowed."
 msgstr ""
 "Jos asetus ei ole käytössä, diplomatiadialogissa ei voi siirtää kultaa "
 "kansakunnalta toiselle."
 
-#: server/settings.c:2135
+#: server/settings.c:2165
 msgid "City trading"
 msgstr "Kaupunkien vaihto"
 
-#: server/settings.c:2136
+#: server/settings.c:2166
 msgid "If turned off, trading cities in the diplomacy dialog is not allowed."
 msgstr ""
 "Jos asetus ei ole käytössä, diplomatiadialogissa ei voi siirtää kaupunkeja "
 "kansakunnalta toiselle."
 
-#: server/settings.c:2142
+#: server/settings.c:2172
 #, fuzzy
 #| msgid "Caravan actions"
 msgid "Caravan bonus style"
 msgstr "Karavaanitapahtumat"
 
-#: server/settings.c:2143
+#: server/settings.c:2173
 msgid ""
 "The formula for the bonus when a caravan enters a city. CLASSIC bonuses are "
 "proportional to distance and trade of source and destination with "
@@ -44626,13 +44775,13 @@ msgid ""
 "are proportional to log^2(distance + trade)."
 msgstr ""
 
-#: server/settings.c:2153
+#: server/settings.c:2183
 #, fuzzy
 #| msgid "Trade routes: "
 msgid "Trade revenue style"
 msgstr "Kauppareitit: "
 
-#: server/settings.c:2154
+#: server/settings.c:2184
 msgid ""
 "The formula for the trade a city receives from a traderoute. CLASSIC "
 "revenues depend on distance and trade with multipliers for overseas and "
@@ -44640,11 +44789,11 @@ msgid ""
 "of the two cities."
 msgstr ""
 
-#: server/settings.c:2164
+#: server/settings.c:2194
 msgid "Minimum distance for trade routes"
 msgstr "Kauppareittien perustamiseksi tarvittava minimietäisyys"
 
-#: server/settings.c:2165
+#: server/settings.c:2195
 msgid ""
 "In order for two cities in the same civilization to establish a trade route, "
 "they must be at least this far apart on the map. For square grids, the "
@@ -44656,11 +44805,11 @@ msgstr ""
 "Neliöruuduilla välimatka lasketaan \"taksimiehen geometrialla\", toisin "
 "sanoen, laskemalla yhteen kaupunkien välimatka x- ja y- akselien suunnassa."
 
-#: server/settings.c:2176
+#: server/settings.c:2206
 msgid "Number of turns between rapture effect"
 msgstr "Vuorojen määrä hurmion vaikutusten välillä"
 
-#: server/settings.c:2177
+#: server/settings.c:2207
 msgid ""
 "Sets the number of turns between rapture growth of a city. If set to n a "
 "city will grow after celebrating for n+1 turns."
@@ -44668,11 +44817,11 @@ msgstr ""
 "Asettaa vuorojen määrän, joiden välein hurmiossa oleva kaupunki kasvaa. Jos "
 "arvo on n, kaupunki kasvaa juhlittuaan n+1 vuoroa."
 
-#: server/settings.c:2187
+#: server/settings.c:2217
 msgid "Frequency of disasters"
 msgstr "Onnettomuuksien esiintymistiheys"
 
-#: server/settings.c:2188
+#: server/settings.c:2218
 msgid ""
 "Affects how often random disasters happen to cities, if any are defined by "
 "the ruleset. The relative frequency of disaster types is set by the ruleset. "
@@ -44684,19 +44833,19 @@ msgstr ""
 "on asetettu sääntökokoelmassa. Arvo '0' poistaa onnettomuudet kokonaan "
 "käytöstä."
 
-#: server/settings.c:2198
+#: server/settings.c:2228
 msgid "AI trait distribution method"
 msgstr "Tietokonepelaajien ominaisuuksien jakautumistapa"
 
-#: server/settings.c:2199
+#: server/settings.c:2229
 msgid "How trait values are given to AI players."
 msgstr "Miten ominaisuusarvot jakautuvat tietokonepelaajille."
 
-#: server/settings.c:2204
+#: server/settings.c:2234
 msgid "Chance for conquered building destruction"
 msgstr "Valloitetun rakennuksen tuhoutumisriski"
 
-#: server/settings.c:2205
+#: server/settings.c:2235
 msgid ""
 "When a player conquers a city, each city improvement has this percentage "
 "chance to be destroyed."
@@ -44704,11 +44853,11 @@ msgstr ""
 "Kun pelaaja valloittaa kaupungin, kullakin kaupungin rakennuksista on näin "
 "monen prosentin todennäköisyys tuhoutua."
 
-#: server/settings.c:2211
+#: server/settings.c:2241
 msgid "Chance of moving into tile after attack"
 msgstr "Todennäköisyys ruutuun liikkumiselle hyökkäyksen jälkeen"
 
-#: server/settings.c:2212
+#: server/settings.c:2242
 msgid ""
 "If set to 0, combat is Civ1/2-style (when you attack, you remain in place). "
 "If set to 100, attacking units will always move into the tile they attacked "
@@ -44722,11 +44871,11 @@ msgstr ""
 "yksiköitä jäljellä ruudussa). Jos arvo on 0:n ja 100:n välillä, se tulkitaan "
 "maa-alueen \"valtaamisen\" prosentuaaliseksi todennäköisyydeksi."
 
-#: server/settings.c:2224
+#: server/settings.c:2254
 msgid "Turn on/off server-side autoattack"
 msgstr "Aseta palvelinpään automaattihyökkäys päälle/pois päältä"
 
-#: server/settings.c:2225
+#: server/settings.c:2255
 msgid ""
 "If set to on, units with moves left will automatically consider attacking "
 "enemy units that move adjacent to them."
@@ -44735,11 +44884,11 @@ msgstr ""
 "harkitsevat automaattisesti niiden viereen liikkuvien vihollisyksiköiden "
 "kimppuun hyökkäämistä."
 
-#: server/settings.c:2232
+#: server/settings.c:2262
 msgid "Do all units in tile die with defender"
 msgstr "Kuolevatko kaikki ruudun yksiköt puolustajan mukana"
 
-#: server/settings.c:2233
+#: server/settings.c:2263
 msgid ""
 "If this is enabled, each time a defender unit loses in combat, and is not "
 "inside a city or suitable base, all units in the same tile are destroyed "
@@ -44751,11 +44900,11 @@ msgstr ""
 "kerralla. Jos tätä ei ole asetettu, vain puolustustaistelun käynyt yksikkö "
 "tuhoutuu."
 
-#: server/settings.c:2241
+#: server/settings.c:2271
 msgid "Reduce city population after attack"
 msgstr "Vähennä kaupungin väestöä hyökkäyksen jälkeen"
 
-#: server/settings.c:2242
+#: server/settings.c:2272
 msgid ""
 "This flag indicates whether a city's population is reduced after a "
 "successful attack by an enemy unit. If this is disabled, population is never "
@@ -44766,11 +44915,11 @@ msgstr ""
 "Vaikka tämä olisikin päällä, vain tietyt yksiköt aiheuttavat väestön "
 "vähentymistä onnistuttuaan hyökkäyksessä."
 
-#: server/settings.c:2250
+#: server/settings.c:2280
 msgid "Slowly kill units without home cities (e.g., starting units)"
 msgstr "Tapa hitaasti yksiköt joilla ei ole kotikaupunkia"
 
-#: server/settings.c:2251
+#: server/settings.c:2281
 msgid ""
 "If greater than 0, then every unit without a homecity will lose hitpoints "
 "each turn. The number of hitpoints lost is given by 'killunhomed' percent of "
@@ -44783,11 +44932,11 @@ msgstr ""
 "maksimivoimapisteistä. Joka vuorolla menetetään ainakin yksi voimapiste "
 "kunnes yksikkö tuhoutuu."
 
-#: server/settings.c:2262
+#: server/settings.c:2292
 msgid "National borders"
 msgstr "Valtioiden rajat"
 
-#: server/settings.c:2263
+#: server/settings.c:2293
 #, fuzzy
 #| msgid ""
 #| "If this is not disabled, then any land tiles around a city or border "
@@ -44804,11 +44953,11 @@ msgstr ""
 "ruutulisän (kuten klassisten sääntöjen linnoituksen) ympärillä kuuluvat "
 "kansakunnalle."
 
-#: server/settings.c:2274
+#: server/settings.c:2304
 msgid "Units inside borders cause no unhappiness"
 msgstr "Sotilasyksiköt rajojen sisäpuolella eivät aiheuta tyytymättömyyttä"
 
-#: server/settings.c:2275
+#: server/settings.c:2305
 msgid ""
 "If this is set, units will not cause unhappiness when inside your borders, "
 "or even allies borders, depending on value."
@@ -44818,24 +44967,24 @@ msgstr ""
 "sisäpuolella, tai eivät aiheuta tyytymättömyyttä liittolaistesi rajojen "
 "sisäpuolella."
 
-#: server/settings.c:2283
+#: server/settings.c:2313
 msgid "Ability to do diplomacy with other players"
 msgstr "Diplomatia muiden pelaajien kanssa"
 
-#: server/settings.c:2284
+#: server/settings.c:2314
 msgid "This setting controls the ability to do diplomacy with other players."
 msgstr ""
 "Asetus säätelee mahdollisuutta käydä diplomaattisia keskusteluja muiden "
 "pelaajien kanssa."
 
-#: server/settings.c:2290
+#: server/settings.c:2320
 msgid "Allowed city names"
 msgstr "Sallitut kaupunkien nimet"
 
 #. TRANS: The strings between double quotes are also translated
 #. * separately (they must match!). The strings between parentheses
 #. * and in uppercase must not be translated.
-#: server/settings.c:2294
+#: server/settings.c:2324
 msgid ""
 "- \"No restrictions\" (NO_RESTRICTIONS): players can have multiple cities "
 "with the same names.\n"
@@ -44858,7 +45007,7 @@ msgstr ""
 "eivät voi myöskään kuulua muiden kansakuntien oletusnimistöön ellei nimi "
 "kuulu myös pelaajan omaan oletusnimistöön."
 
-#: server/settings.c:2308
+#: server/settings.c:2338
 msgid "How to pick player colors"
 msgstr "Miten pelaajien värit valitaan"
 
@@ -44866,7 +45015,7 @@ msgstr "Miten pelaajien värit valitaan"
 #. * separately (they must match!). The strings between single quotes
 #. * are setting names and shouldn't be translated. The strings
 #. * between parentheses and in uppercase must not be translated.
-#: server/settings.c:2313
+#: server/settings.c:2343
 msgid ""
 "This setting determines how player colors are chosen. Player colors are used "
 "in the Nations report, for national borders on the map, and so on.\n"
@@ -44908,13 +45057,13 @@ msgstr ""
 "Riippumatta tämän asetuksen arvosta, yksittäisten pelaajien värejä voi "
 "vaihtaa pelin aloituksen jälkeen komennolla 'playercolor'."
 
-#: server/settings.c:2355
+#: server/settings.c:2385
 msgid "Barbarian appearance frequency"
 msgstr "Barbaarien aktiivisuustaso"
 
 #. TRANS: The string between single quotes is a setting name and
 #. * should not be translated.
-#: server/settings.c:2358
+#: server/settings.c:2388
 msgid ""
 "This setting controls how frequently the barbarians appear in the game. See "
 "also the 'onsetbarbs' setting."
@@ -44922,19 +45071,19 @@ msgstr ""
 "Asetus ohjaa barbaarien esiintymistodennäköisyyttä. Katso myös asetusta "
 "'onsetbarbs'."
 
-#: server/settings.c:2365
+#: server/settings.c:2395
 msgid "Barbarian onset turn"
 msgstr "Barbaarien ilmaantumisvuoro"
 
-#: server/settings.c:2366
+#: server/settings.c:2396
 msgid "Barbarians will not appear before this turn."
 msgstr "Barbaareja ei ilmaannu ennen tätä vuoroa."
 
-#: server/settings.c:2373
+#: server/settings.c:2403
 msgid "Way to determine revolution length"
 msgstr "Tapa jolla vallankumouksen pituus määräytyy"
 
-#: server/settings.c:2374
+#: server/settings.c:2404
 msgid ""
 "Which method is used in determining how long period of anarchy lasts when "
 "changing government. The actual value is set with 'revolen' setting. The "
@@ -44949,11 +45098,11 @@ msgstr ""
 "yhteensä), eli hallitusmuotoon siirtyminen muuttuu sitä helpommaksi mitä "
 "enemmän siitä on maailmassa kokemusta."
 
-#: server/settings.c:2385
+#: server/settings.c:2415
 msgid "Length of revolution"
 msgstr "Vallankumouksen kesto"
 
-#: server/settings.c:2386
+#: server/settings.c:2416
 msgid ""
 "When changing governments, a period of anarchy will occur. Value of this "
 "setting, used the way 'revolentype' setting dictates, defines the length of "
@@ -44963,11 +45112,11 @@ msgstr ""
 "määrittää, tulkittuna 'revolentype' asetuksen määrittämällä tavalla, kuinka "
 "kauan anarkia kestää."
 
-#: server/settings.c:2395
+#: server/settings.c:2425
 msgid "Whether to enable fog of war"
 msgstr "Rajoita näkyvyyttä (\"fog of war\")"
 
-#: server/settings.c:2396
+#: server/settings.c:2426
 msgid ""
 "If this is enabled, only those units and cities within the vision range of "
 "your own units and cities will be revealed to you. You will not see new "
@@ -44977,11 +45126,11 @@ msgstr ""
 "kaupunkiesi näkökentässä olevat yksiköt ja kaupungit. Et näe uusia "
 "kaupunkeja tai maaston muutoksia ruuduissa joita et tarkkaile."
 
-#: server/settings.c:2404
+#: server/settings.c:2434
 msgid "Whether fog of war applies to border changes"
 msgstr "Rajoita rajojen näkyvyyttä (koskeeko\"fog of war\" myös rajoja)"
 
-#: server/settings.c:2405
+#: server/settings.c:2435
 msgid ""
 "If this setting is enabled, players will not be able to see changes in tile "
 "ownership if they do not have direct sight of the affected tiles. Otherwise, "
@@ -44994,7 +45143,7 @@ msgstr ""
 "näkevät kaikki valtiorajojen muutokset, jos ovat joskus nähneet kyseiset "
 "ruudut."
 
-#: server/settings.c:2414
+#: server/settings.c:2444
 msgid "Airlifting style"
 msgstr "Ilmasillan käyttö"
 
@@ -45002,18 +45151,18 @@ msgstr "Ilmasillan käyttö"
 #. * translated separately (they must match!). The strings
 #. * between parenthesis and in uppercase must not be
 #. * translated.
-#: server/settings.c:2419
+#: server/settings.c:2449
 msgid ""
 "This setting affects airlifting units between cities. It can be a set of the "
 "following values:\n"
 "- \"Allows units to be airlifted from allied cities\" (FROM_ALLIES).\n"
 "- \"Allows units to be airlifted to allied cities\" (TO_ALLIES).\n"
 "- \"Unlimited units from source city\" (SRC_UNLIMITED): note that airlifting "
-"from a city doesn't reduce the airlifted counter, but still needs at least "
-"1.\n"
+"from a city doesn't reduce the airlifted counter, but still needs airlift "
+"capacity of at least 1.\n"
 "- \"Unlimited units to destination city\" (DEST_UNLIMITED): note that "
 "airlifting to a city doesn't reduce the airlifted counter, and doesn't need "
-"any."
+"any airlift capacity."
 msgstr ""
 "Asetus vaikuttaa siihen miten yksiköitä voi liikutella ilmasiltaa myöten. Se "
 "voi saada yhden tai useamman seuravista arvoista:\n"
@@ -45024,11 +45173,11 @@ msgstr ""
 "- \"Rajaton saapuvien yksiköiden määrä\" (DEST_UNLIMITED).\n"
 "   Kohdekaupungissa ei tarvita lentokenttää."
 
-#: server/settings.c:2436
+#: server/settings.c:2468
 msgid "Base chance for diplomats and spies to succeed"
 msgstr "Perustodennäköisyys sille, että diplomaatit ja vakoojat onnistuvat"
 
-#: server/settings.c:2437
+#: server/settings.c:2469
 msgid ""
 "The base chance of a spy returning from a successful mission and the base "
 "chance of success for diplomats and spies."
@@ -45036,7 +45185,7 @@ msgstr ""
 "Perustodennäköisyys sille, että vakooja palaa onnistuneen tehtävän jälkeen, "
 "ja perustodennäköisyys diplomaattien ja vakoojien tehtävien onnistumiselle."
 
-#: server/settings.c:2445
+#: server/settings.c:2477
 msgid "What kinds of victories are possible"
 msgstr "Millaiset voittotavat ovat mahdollisia"
 
@@ -45045,7 +45194,7 @@ msgstr "Millaiset voittotavat ovat mahdollisia"
 #. * quotes are setting names and shouldn't be translated. The
 #. * strings between parentheses and in uppercase must stay as
 #. * untranslated.
-#: server/settings.c:2451
+#: server/settings.c:2483
 msgid ""
 "This setting controls how game can be won. One can always win by conquering "
 "entire planet, but other victory conditions can be enabled or disabled:\n"
@@ -45066,11 +45215,11 @@ msgstr ""
 "- \"Kulttuuri\" (CULTURE): Pelaaja on saavuttanut kulttuurisen valta-aseman. "
 "Sääntökokoelma määrittää mikä katsotaan valta-asemaksi.\n"
 
-#: server/settings.c:2464
+#: server/settings.c:2496
 msgid "Should the game end if the spaceship arrives?"
 msgstr "Loppuuko peli avaruusaluksen päästessä perille?"
 
-#: server/settings.c:2465
+#: server/settings.c:2497
 msgid ""
 "If this option is turned on, the game will end with the arrival of a "
 "spaceship at Alpha Centauri."
@@ -45078,11 +45227,11 @@ msgstr ""
 "Jos asetus on käytössä, peli päättyy kun avaruusalus pääsee perille Alfa "
 "Centauriin."
 
-#: server/settings.c:2472
+#: server/settings.c:2504
 msgid "Percentage to multiply spaceship travel time by"
 msgstr ""
 
-#: server/settings.c:2473
+#: server/settings.c:2505
 #, fuzzy
 #| msgid ""
 #| "If this option is turned on, the game will end with the arrival of a "
@@ -45094,11 +45243,11 @@ msgstr ""
 "Jos asetus on käytössä, peli päättyy kun avaruusalus pääsee perille Alfa "
 "Centauriin."
 
-#: server/settings.c:2481
+#: server/settings.c:2513
 msgid "Minimum number of cities for civil war"
 msgstr "Pienin määrä kaupunkeja sisällissodan syttymiseen"
 
-#: server/settings.c:2482
+#: server/settings.c:2514
 msgid ""
 "A civil war is triggered when a player has at least this many cities and the "
 "player's capital is captured. If this option is set to the maximum value, "
@@ -45108,11 +45257,11 @@ msgstr ""
 "tämä määrä kaupunkeja. Jos arvo on suurin mahdollinen, sisällissotia ei syty "
 "lainkaan."
 
-#: server/settings.c:2492
+#: server/settings.c:2524
 msgid "Restrict the use of the infrastructure for enemy units"
 msgstr "Estä vihollisyksiköiden infrastruktuurin käyttö"
 
-#: server/settings.c:2493
+#: server/settings.c:2525
 msgid ""
 "If this option is enabled, the use of roads and rails will be restricted for "
 "enemy units."
@@ -45120,15 +45269,23 @@ msgstr ""
 "Jos asetus on käytössä, vihollisyksiköt eivät voi käyttää teitä ja "
 "rautateitä."
 
-#: server/settings.c:2500
+#: server/settings.c:2532
 msgid "Does unreachable unit protect reachable ones"
 msgstr "Suojeleeko tavoittamattomissa oleva yksikkö muita"
 
-#: server/settings.c:2501
+#: server/settings.c:2533
+#, fuzzy
+#| msgid ""
+#| "This option controls whether tiles with both unreachable and reachable "
+#| "units can be attacked. If disabled, any tile with reachable units can be "
+#| "attacked. If enabled, tiles with an unreachable unit in them cannot be "
+#| "attacked."
 msgid ""
 "This option controls whether tiles with both unreachable and reachable units "
 "can be attacked. If disabled, any tile with reachable units can be attacked. "
-"If enabled, tiles with an unreachable unit in them cannot be attacked."
+"If enabled, tiles with an unreachable unit in them cannot be attacked. Some "
+"units in some rulesets may override this, never protecting reachable units "
+"on their tile."
 msgstr ""
 "Asetus määrittelee, onko hyökkäys mahdollinen ruutuihin, joissa on sekä "
 "tavoitettavissa että tavoittamattomissa olevia yksiköitä. Jos asetus on pois "
@@ -45136,11 +45293,11 @@ msgstr ""
 "yksikkö. Jos asetus on käytössä, ruutuihin ei voi hyökätä, jos niissä on "
 "tavoittamattomissa oleva yksikkö."
 
-#: server/settings.c:2510
+#: server/settings.c:2544
 msgid "Turns until player contact is lost"
 msgstr "Vuorojen määrä ennen kuin pelaajayhteys menetetään"
 
-#: server/settings.c:2511
+#: server/settings.c:2545
 msgid ""
 "Players may meet for diplomacy this number of turns after their units have "
 "last met, even when they do not have an embassy. If set to zero, then "
@@ -45151,11 +45308,11 @@ msgstr ""
 "Yhteyden aikana he voivat tehdä diplomaattisen sopimuksen. Jos arvo on 0, "
 "pelaajat eivät voi tavata ilman lähetystöä."
 
-#: server/settings.c:2522
+#: server/settings.c:2556
 msgid "Rebuild palace whenever capital is conquered"
 msgstr "Rakenna palatsi uudelleen jos pääkaupunki vallataan"
 
-#: server/settings.c:2523
+#: server/settings.c:2557
 msgid ""
 "If this is turned on, when the capital is conquered the palace is "
 "automatically rebuilt for free in another randomly chosen city. This is "
@@ -45168,13 +45325,13 @@ msgstr ""
 "Asetukselle antaa lisäpainoa se, että palatsin rakentamisen "
 "teknologiavaatimukset jätetään huomiotta."
 
-#: server/settings.c:2534
+#: server/settings.c:2568
 msgid "Give caught units a homecity"
 msgstr "Anna kotikaupunki valloitetun kaupungin yksiköille"
 
 #. TRANS: The string between single quotes is a setting name and
 #. * should not be translated.
-#: server/settings.c:2537
+#: server/settings.c:2571
 msgid ""
 "If unset, caught units will have no homecity and will be subject to the "
 "'killunhomed' option."
@@ -45182,11 +45339,11 @@ msgstr ""
 "Jos asetus ei ole päällä, valloitetun kaupungin mukana tulleilla yksiköillä "
 "ei ole kotikaupunkia ja ne ovat asetuksen 'killunhomed' kohteena."
 
-#: server/settings.c:2544
+#: server/settings.c:2578
 msgid "Whether to use natural city names"
 msgstr "Käytetäänkö luonnollisia kaupunkien nimiä"
 
-#: server/settings.c:2545
+#: server/settings.c:2579
 msgid ""
 "If enabled, the default city names will be determined based on the "
 "surrounding terrain."
@@ -45194,13 +45351,13 @@ msgstr ""
 "Jos tämä on valittu, kaupunkien oletusnimet valitaan niiden ympäristön "
 "perusteella."
 
-#: server/settings.c:2552
+#: server/settings.c:2586
 msgid "Whether to enable citizen migration"
 msgstr "Mahdollistetaanko asukkaiden muuttoliikkeet"
 
 #. TRANS: The strings between single quotes are setting names
 #. * and should not be translated.
-#: server/settings.c:2555
+#: server/settings.c:2589
 msgid ""
 "This is the master setting that controls whether citizen migration is active "
 "in the game. If enabled, citizens may automatically move from less desirable "
@@ -45228,12 +45385,12 @@ msgstr ""
 "  mgr_worldchance  – Todennäköisyys muuttoon ulkomaille.\n"
 "  mgr_nationchance – Todennäköisyys muuttoon valtion sisällä."
 
-#: server/settings.c:2574
+#: server/settings.c:2608
 msgid "Number of turns between migrations from a city"
 msgstr "Vuorojen määrä kaupungista muuttojen välillä"
 
 #. TRANS: Do not translate 'migration' setting name.
-#: server/settings.c:2576
+#: server/settings.c:2610
 msgid ""
 "This setting controls the number of turns between migration checks for a "
 "given city. The interval is calculated from the founding turn of the city. "
@@ -45249,12 +45406,12 @@ msgstr ""
 "kuitenkaan lähde heti kaupungin perustamisvuorolla. Asetuksella ei ole "
 "vaikutusta, ellei muuttoliikkeitä ole mahdollistettu 'migration'-asetuksella."
 
-#: server/settings.c:2591
+#: server/settings.c:2625
 msgid "Whether migration is limited by food"
 msgstr "Rajoittaako ruoka muuttoja"
 
 #. TRANS: Do not translate 'migration' setting name.
-#: server/settings.c:2593
+#: server/settings.c:2627
 msgid ""
 "If this setting is enabled, citizens will not migrate to cities which would "
 "not have enough food to support them. This setting has no effect unless "
@@ -45264,12 +45421,12 @@ msgstr ""
 "riittävästi ruokaa uusien asukkaiden ruokkimiseen. Asetuksella ei ole "
 "vaikutusta, ellei muuttoliikkeitä ole mahdollistettu 'migration'-asetuksella."
 
-#: server/settings.c:2602
+#: server/settings.c:2636
 msgid "Maximum distance citizens may migrate"
 msgstr "Maksimietäisyys, jonka siirtolaiset voivat muuttaa"
 
 #. TRANS: Do not translate 'migration' setting name.
-#: server/settings.c:2604
+#: server/settings.c:2638
 msgid ""
 "This setting controls how far citizens may look for a suitable migration "
 "destination when deciding which city to migrate to. The value is added to "
@@ -45283,12 +45440,12 @@ msgstr ""
 "tai yhtäsuuri, muuttoliike on mahdollinen. Asetuksella ei ole vaikutusta, "
 "ellei muuttoliikkeitä ole mahdollistettu 'migration'-asetuksella."
 
-#: server/settings.c:2617
+#: server/settings.c:2651
 msgid "Percent probability for migration within the same nation"
 msgstr "Todennäköisyys (%) maassamuuttoon"
 
 #. TRANS: Do not translate 'migration' setting name.
-#: server/settings.c:2619
+#: server/settings.c:2653
 msgid ""
 "This setting controls how likely it is for citizens to migrate between "
 "cities owned by the same player. Zero indicates migration will never occur, "
@@ -45302,12 +45459,12 @@ msgstr ""
 "sopivan kohdekaupungin muuttovuorollaan. Asetuksella ei ole vaikutusta, "
 "ellei muuttoliikkeitä ole mahdollistettu 'migration'-asetuksella."
 
-#: server/settings.c:2632
+#: server/settings.c:2666
 msgid "Percent probability for migration between foreign cities"
 msgstr "Todennäköisyys (%) maastamuuttoon"
 
 #. TRANS: Do not translate 'migration' setting name.
-#: server/settings.c:2634
+#: server/settings.c:2668
 msgid ""
 "This setting controls how likely it is for migration to occur between cities "
 "owned by different players. Zero indicates migration will never occur, 100 "
@@ -45321,13 +45478,13 @@ msgstr ""
 "sopivan kohdekaupungin muuttovuorollaan. Asetuksella ei ole vaikutusta, "
 "ellei muuttoliikkeitä ole mahdollistettu 'migration'-asetuksella."
 
-#: server/settings.c:2653
+#: server/settings.c:2687
 msgid "Players that users are allowed to take"
 msgstr "Pelaajat, joihin käyttäjät voivat kytkeytyä"
 
 #. TRANS: the strings in double quotes are server command names
 #. * and should not be translated.
-#: server/settings.c:2656
+#: server/settings.c:2690
 msgid ""
 "This should be a string of characters, each of which specifies a type or "
 "status of a civilization (player).\n"
@@ -45384,11 +45541,11 @@ msgstr ""
 "syrjäyttää;\n"
 "          4 = hallintaa ei sallita, tarkkailijat sallitaan"
 
-#: server/settings.c:2692
+#: server/settings.c:2726
 msgid "Whether AI-status toggles with connection"
 msgstr "Muuttuuko AI-tila yhteyden mukaan"
 
-#: server/settings.c:2693
+#: server/settings.c:2727
 msgid ""
 "If enabled, AI status is turned off when a player connects, and on when a "
 "player disconnects."
@@ -45396,15 +45553,15 @@ msgstr ""
 "Jos asetus on käytössä, AI-tilasta poistutaan kun pelaaja on yhteydessä ja "
 "siihen palataan kun pelaaja katkaisee yhteyden."
 
-#: server/settings.c:2699
+#: server/settings.c:2733
 msgid "Turn the game ends"
 msgstr "Pelin päättymisvuoro"
 
-#: server/settings.c:2700
+#: server/settings.c:2734
 msgid "The game will end at the end of the given turn."
 msgstr "Peli päättyy annetun vuoron lopussa."
 
-#: server/settings.c:2706
+#: server/settings.c:2740
 msgid "Reveal the map"
 msgstr "Kartan paljastus"
 
@@ -45413,7 +45570,7 @@ msgstr "Kartan paljastus"
 #. * quotes are setting names and shouldn't be translated. The
 #. * strings between parentheses and in uppercase must not be
 #. * translated.
-#: server/settings.c:2712
+#: server/settings.c:2746
 msgid ""
 "If \"Reveal map at game start\" (START) is set, the initial state of the "
 "entire map will be known to all players from the start of the game, although "
@@ -45428,7 +45585,7 @@ msgstr ""
 "hävitetyt pelaajat voivat nähdä koko kartan täydellisesti, jos he ovat yksin "
 "joukkueessaan."
 
-#: server/settings.c:2723
+#: server/settings.c:2757
 msgid "Maximum seconds per turn"
 msgstr "Suurin sallittu aika kierrosta kohti (sekunteina)"
 
@@ -45436,7 +45593,7 @@ msgstr "Suurin sallittu aika kierrosta kohti (sekunteina)"
 #. * translated separately, the translation should be the same.
 #. * \"timeoutincrease\" is a command name and must not to be
 #. * translated.
-#: server/settings.c:2728
+#: server/settings.c:2762
 msgid ""
 "If all players have not hit \"Turn Done\" before this time is up, then the "
 "turn ends automatically. Zero means there is no timeout. In servers compiled "
@@ -45455,13 +45612,13 @@ msgstr ""
 "Ensimmäinen vuoro on erikoistapaus, sitä säädetään asetuksella "
 "'first_timeout' (Ensimmäisen vuoron aikakatkaisu)."
 
-#: server/settings.c:2742
+#: server/settings.c:2776
 msgid "First turn timeout"
 msgstr "Ensimmäisen vuoron aikakatkaisu"
 
 #. TRANS: The strings between single quotes are setting names and
 #. * should not be translated.
-#: server/settings.c:2745
+#: server/settings.c:2779
 msgid ""
 "If greater than 0, T1 will last for 'first_timeout' seconds.\n"
 "If set to 0, T1 will not have a timeout.\n"
@@ -45474,11 +45631,11 @@ msgstr ""
 "Jos asetettu arvoon -1, ensimmäisen vuoron erityinen kohtelu on poistettu.\n"
 "Katso myös asetus 'timeout' (Suurin sallittu aika kierrosta kohti)"
 
-#: server/settings.c:2755
+#: server/settings.c:2789
 msgid "Timeout at least n seconds when enemy moved"
 msgstr "Aikakatkaisu vähintään n sekuntia, kun vihollinen on liikkunut"
 
-#: server/settings.c:2756
+#: server/settings.c:2790
 msgid ""
 "Any time a unit moves while in sight of an enemy player, the remaining "
 "timeout is increased to this value."
@@ -45486,13 +45643,13 @@ msgstr ""
 "Aina kun yksikkö liikkuu vihollispelaajan näköpiirissä, jäljellä olevaa "
 "siirtoaikaa korotetaan tähän arvoon."
 
-#: server/settings.c:2764
+#: server/settings.c:2798
 msgid "Minimum time between unit actions over turn change"
 msgstr "Vähimmäisaika yksikön siirtojen välillä vuoronvaihdon molemmin puolin"
 
 #. TRANS: The string between single quotes is a setting name and
 #. * should not be translated.
-#: server/settings.c:2767
+#: server/settings.c:2801
 msgid ""
 "This setting gives the minimum amount of time in seconds between unit moves "
 "and other significant actions (such as building cities) after a turn change "
@@ -45509,11 +45666,11 @@ msgstr ""
 "kuljetusyksikön sisällä. Asetuksen arvo on korkeintaan 2/3 asetuksen "
 "'timeout' arvosta."
 
-#: server/settings.c:2783
+#: server/settings.c:2817
 msgid "Control of simultaneous player/team phases"
 msgstr "Pelaajien/joukkueiden vuorottainen liikkuminen"
 
-#: server/settings.c:2784
+#: server/settings.c:2818
 msgid ""
 "This setting controls whether players may make moves at the same time during "
 "a turn. Change in setting takes effect next turn."
@@ -45521,11 +45678,11 @@ msgstr ""
 "Tällä asetuksella määrätään, tekevätkö pelaajat siirtonsa samaan aikaan "
 "vuoron sisällä. Asetuksen muutos astuu voimaan seuraavalla siirrolla."
 
-#: server/settings.c:2791
+#: server/settings.c:2825
 msgid "Seconds to let a client's network connection block"
 msgstr "Kuinka kauan asiakkaan verkkoyhteyttä odotetaan (s)"
 
-#: server/settings.c:2792
+#: server/settings.c:2826
 msgid ""
 "If a network connection is blocking for a time greater than this value, then "
 "the connection is closed. Zero means there is no timeout (although "
@@ -45535,11 +45692,11 @@ msgstr ""
 "suljetaan. Jos arvo on nolla, yhteyttä ei suljeta tällä perusteella (tosin "
 "yhteydet sulkeutuvat automaattisesti lopulta joka tapauksessa)."
 
-#: server/settings.c:2801
+#: server/settings.c:2835
 msgid "Max seconds for network buffers to drain"
 msgstr "Verkkopuskureiden tyhjenemisen maksimiodotusaika sekunteina"
 
-#: server/settings.c:2802
+#: server/settings.c:2836
 msgid ""
 "The server will wait for up to the value of this parameter in seconds, for "
 "all client connection network buffers to unblock. Zero means the server will "
@@ -45549,11 +45706,11 @@ msgstr ""
 "verkkopuskureiden vapautumista (unblock). Jos arvo on nolla, palvelin ei "
 "odota lainkaan."
 
-#: server/settings.c:2810
+#: server/settings.c:2844
 msgid "Seconds between PINGs"
 msgstr "Tauko yhteystarkistusten välillä (s)"
 
-#: server/settings.c:2811
+#: server/settings.c:2845
 msgid ""
 "The server will poll the clients with a PING request each time this period "
 "elapses."
@@ -45561,22 +45718,22 @@ msgstr ""
 "Aika palvelimen asiakasohjelmille lähettämien yhteystarkistusviestien "
 "välillä."
 
-#: server/settings.c:2818
+#: server/settings.c:2852
 msgid "Time to cut a client"
 msgstr "Aika yhteyden katkaisuun"
 
-#: server/settings.c:2819
+#: server/settings.c:2853
 msgid ""
 "If a client doesn't reply to a PING in this time the client is disconnected."
 msgstr ""
 "Jos asiakasohjelma ei vastaa yhteystarkistukseen tässä ajassa, yhteys "
 "katkaistaan."
 
-#: server/settings.c:2826
+#: server/settings.c:2860
 msgid "Turn-blocking game play mode"
 msgstr "Kierroksen vaihtumisen esto"
 
-#: server/settings.c:2827
+#: server/settings.c:2861
 msgid ""
 "If this is turned on, the game turn is not advanced until all players have "
 "finished their turn, including disconnected players."
@@ -45584,13 +45741,13 @@ msgstr ""
 "Jos asetus on käytössä, pelin vuoro ei vaihdu ennen kuin kaikki pelaajat "
 "ovat päättäneet omat vuoronsa, mukaanlukien pelaajat joiden yhteys on poikki."
 
-#: server/settings.c:2835
+#: server/settings.c:2869
 msgid "Fixed-length turns play mode"
 msgstr "Tasapitkät kierrokset"
 
 #. TRANS: \"Turn Done\" refers to the client button; it is also
 #. * translated separately, the translation should be the same.
-#: server/settings.c:2838
+#: server/settings.c:2872
 msgid ""
 "If this is turned on the game turn will not advance until the timeout has "
 "expired, even after all players have clicked on \"Turn Done\"."
@@ -45598,13 +45755,13 @@ msgstr ""
 "Jos asetus on käytössä, uusi kierros ei ala ennen kuin asetettu kierrosaika "
 "on kulunut, vaikka kaikki olisivat painaneet \"Vuoro valmis\"."
 
-#: server/settings.c:2846
+#: server/settings.c:2880
 msgid "What is in the Demographics report"
 msgstr "Mitä väestökatsaus sisältää"
 
 #. TRANS: The strings between double quotes should be
 #. * translated.
-#: server/settings.c:2849
+#: server/settings.c:2883
 msgid ""
 "This should be a string of characters, each of which specifies the inclusion "
 "of a line of information in the Demographics report.\n"
@@ -45646,14 +45803,14 @@ msgstr ""
 "    b = näytä paras valtio\n"
 "(Kirjainten järjestyksellä ei ole merkitystä, mutta niiden koolla (P/p) on.)"
 
-#: server/settings.c:2874
+#: server/settings.c:2908
 msgid "Turns per auto-save"
 msgstr "Vuoroja automaattista tallennusta kohden"
 
 #. TRANS: The string between double quotes is also translated
 #. * separately (it must match!). The string between single
 #. * quotes is a setting name and shouldn't be translated.
-#: server/settings.c:2878
+#: server/settings.c:2912
 msgid ""
 "How many turns elapse between automatic game saves. This setting only has an "
 "effect when the 'autosaves' setting includes \"New turn\"."
@@ -45662,14 +45819,14 @@ msgstr ""
 "asetuksella on vaikutusta vain jos asetus 'autosaves' pitää sisällään vivun "
 "\"Vuoron vaihtuessa\"."
 
-#: server/settings.c:2885
+#: server/settings.c:2919
 msgid "Minutes per auto-save"
 msgstr "Monenko minuutin välein automaattinen talletus tapahtuu"
 
 #. TRANS: The string between double quotes is also translated
 #. * separately (it must match!). The string between single
 #. * quotes is a setting name and shouldn't be translated.
-#: server/settings.c:2889
+#: server/settings.c:2923
 msgid ""
 "How many minutes elapse between automatic game saves. Unlike other save "
 "types, this save is only meant as backup for computer memory, and it always "
@@ -45683,7 +45840,7 @@ msgstr ""
 "tallennuskerralla. Tällä asetuksella on vaikutusta vain jos asetus "
 "'autosaves' pitää sisällään vivun \"Ajastin\"."
 
-#: server/settings.c:2898
+#: server/settings.c:2932
 msgid "Which savegames are generated automatically"
 msgstr "Mitä automaattisia pelitallennuksia luodaan"
 
@@ -45692,7 +45849,7 @@ msgstr "Mitä automaattisia pelitallennuksia luodaan"
 #. * quotes are setting names and shouldn't be translated. The
 #. * strings between parentheses and in uppercase must stay as
 #. * untranslated.
-#: server/settings.c:2904
+#: server/settings.c:2938
 msgid ""
 "This setting controls which autosave types get generated:\n"
 "- \"New turn\" (TURN): Save when turn begins, once every 'saveturns' turns.\n"
@@ -45714,13 +45871,13 @@ msgstr ""
 "- \"Ajastin\" (TIMER): Tallenna peli jokaisen 'savefrequency' asetuksen "
 "mukaisen minuuttimäärän kulututua."
 
-#: server/settings.c:2917
+#: server/settings.c:2951
 msgid "Whether to do saving in separate thread"
 msgstr "Hoidetaanko pelin tallentaminen erillisessä säikeessä"
 
 #. TRANS: The string between single quotes is a setting name and
 #. * should not be translated.
-#: server/settings.c:2920
+#: server/settings.c:2954
 msgid ""
 "If this is turned in, compressing and saving the actual file containing the "
 "game situation takes place in the background while game otherwise continues. "
@@ -45731,12 +45888,12 @@ msgstr ""
 "etenee. Näin käyttäjien ei tarvitse odottaa näiden toimenpiteiden "
 "valmistumista ennen pelin jatkumista."
 
-#: server/settings.c:2928
+#: server/settings.c:2962
 msgid "Savegame compression level"
 msgstr "Tallennetun pelin pakkaustaso"
 
 #. TRANS: 'compresstype' setting name should not be translated.
-#: server/settings.c:2930
+#: server/settings.c:2964
 msgid ""
 "If non-zero, saved games will be compressed depending on the 'compresstype' "
 "setting. Larger values will give better compression but take longer."
@@ -45745,22 +45902,22 @@ msgstr ""
 "'compresstype' määrittämällä tavalla. Suuremmilla arvoilla pakkaus tehostuu "
 "mutta vie enemmän aikaa."
 
-#: server/settings.c:2938
+#: server/settings.c:2972
 msgid "Savegame compression algorithm"
 msgstr "Tallennetun pelin pakkausalgoritmi"
 
-#: server/settings.c:2939
+#: server/settings.c:2973
 msgid "Compression library to use for savegames."
 msgstr "Pakkauskirjasto jota käytetään pelien tallentamiseen"
 
-#: server/settings.c:2944
+#: server/settings.c:2978
 msgid "Definition of the save file name"
 msgstr "Tallennustiedoston nimen määritys"
 
 #. TRANS: %R, %S, %T and %Y must not be translated. The
 #. * strings (examples and setting names) between single quotes
 #. * neither. The strings between <> should be translated.
-#: server/settings.c:2949
+#: server/settings.c:2983
 #, no-c-format
 msgid ""
 "Within the string the following custom formats are allowed:\n"
@@ -45787,13 +45944,13 @@ msgstr ""
 "pelitallennukset kirjoitetaan vanhojen päälle. Jos asetuksessa ei ole mitään "
 "edelläolevista erikoismerkinnöistä, '-T%04T-Y%05Y-%R' liitetään sen perään."
 
-#: server/settings.c:2972
+#: server/settings.c:3006
 msgid "Whether to log player statistics"
 msgstr "Pidetäänkö pelaajatilastoista kirjaa"
 
 #. TRANS: The string between single quotes is a setting name and
 #. * should not be translated.
-#: server/settings.c:2975
+#: server/settings.c:3009
 msgid ""
 "If this is turned on, player statistics are appended to the file defined by "
 "the option 'scorefile' every turn. These statistics can be used to create "
@@ -45803,11 +45960,11 @@ msgstr ""
 "määriteltyyn tiedostoon joka vuoro. Tilastoja voidaan käyttää valta/voima-"
 "kuvaajien luomiseen pelin päätyttyä."
 
-#: server/settings.c:2983
+#: server/settings.c:3017
 msgid "Scorelog level"
 msgstr "Tulostiedoston sisältö"
 
-#: server/settings.c:2984
+#: server/settings.c:3018
 msgid ""
 "Whether scores are logged for all players including AIs, or only for human "
 "players."
@@ -45815,20 +45972,20 @@ msgstr ""
 "Kirjataanko pistelogeihin myös tietokonepelaajien vai ainostaan "
 "ihmispelaajien pisteet."
 
-#: server/settings.c:2992
+#: server/settings.c:3026
 msgid "Name for the score log file"
 msgstr "Tulostiedoston nimi"
 
 #. TRANS: Don't translate the string in single quotes.
-#: server/settings.c:2994
+#: server/settings.c:3028
 msgid "The default name for the score log file is 'freeciv-score.log'."
 msgstr "Oletusarvo tulostiedoston nimelle on 'freeciv-score.log'."
 
-#: server/settings.c:3002
+#: server/settings.c:3036
 msgid "Maximum number of connections to the server per host"
 msgstr "Yhdeltä koneelta tulevien yhteyksien maksimimäärä"
 
-#: server/settings.c:3003
+#: server/settings.c:3037
 msgid ""
 "New connections from a given host will be rejected if the total number of "
 "connections from the very same host equals or exceeds this value. A value of "
@@ -45840,13 +45997,13 @@ msgstr ""
 "tarkoittaa, ettei rajoituksia ole, kunhan palvelimen kokonaisuudessaan "
 "sallimien yhteyksien määrän raja ei tule vastaan."
 
-#: server/settings.c:3014
+#: server/settings.c:3048
 msgid "Time before a kicked user can reconnect"
 msgstr "Jäähyaika"
 
 #. TRANS: the string in double quotes is a server command name and
 #. * should not be translated
-#: server/settings.c:3017
+#: server/settings.c:3051
 msgid ""
 "Gives the time in seconds before a user kicked using the \"kick\" command "
 "may reconnect. Changing this setting will affect users kicked in the past."
@@ -45855,11 +46012,11 @@ msgstr ""
 "laitettu käyttäjä joutuu odottamaan ennen uutta yhteydenottoa palvelimeen. "
 "Asetuksen muuttaminen vaikuttaa myös nykyisten jäähyllä olevien jäähyaikaan."
 
-#: server/settings.c:3024
+#: server/settings.c:3058
 msgid "Metaserver info line"
 msgstr "Metapalvelimella näkyvä infoteksti"
 
-#: server/settings.c:3025
+#: server/settings.c:3059
 #, fuzzy
 #| msgid ""
 #| "Set user defined metaserver info line. If parameter is omitted, "
@@ -45876,104 +46033,104 @@ msgstr ""
 "tämä infoteksti poistetaan. Tätä käyttäjän määrittelemää infotekstiä "
 "käytetään useimmiten automaattisesti luotujen tietojen sijaan."
 
-#: server/settings.c:3145
+#: server/settings.c:3179
 #, c-format
 msgid "The setting '%s' can't be modified after the map is fixed."
 msgstr "Asetusta '%s' ei voida muuttaa kartan generoinnin jälkeen."
 
-#: server/settings.c:3180
+#: server/settings.c:3214
 #, c-format
 msgid "The setting '%s' can't be modified after the game has started."
 msgstr "Asetusta '%s' ei voida muuttaa pelin alettua."
 
-#: server/settings.c:3192
+#: server/settings.c:3226
 msgid "Internal error."
 msgstr "Sisäinen virhe"
 
-#: server/settings.c:3209
+#: server/settings.c:3243
 #, c-format
 msgid "You are not allowed to change the setting '%s'."
 msgstr "Sinulla ei ole tarvittavia oikeuksia asetuksen '%s' muuttamiseen."
 
-#: server/settings.c:3217
+#: server/settings.c:3251
 #, c-format
 msgid "The setting '%s' is locked by the ruleset."
 msgstr "Asetus '%s' on lukittu sääntökokoelmassa."
 
-#: server/settings.c:3317
+#: server/settings.c:3351
 #, c-format
 msgid "\"%s\" prefix is ambiguous. Candidates are: %s."
 msgstr "Alku \"%s\" vastaa useampaa kandidaattia: %s."
 
-#: server/settings.c:3324
+#: server/settings.c:3358
 msgid "Missing value."
 msgstr "Puuttuva arvo."
 
-#: server/settings.c:3333
+#: server/settings.c:3367
 #, c-format
 msgid "No match for \"%s\"."
 msgstr "Alulla \"%s\" ei löydy osumia."
 
-#: server/settings.c:3371
+#: server/settings.c:3405
 msgid "This setting is not a boolean."
 msgstr "Asetus ei ole kaksiarvoinen."
 
-#: server/settings.c:3502
+#: server/settings.c:3536
 msgid "This setting is not an integer."
 msgstr "Asetus ei ole kokonaisluku."
 
-#: server/settings.c:3508
+#: server/settings.c:3542
 #, c-format
 msgid "Value out of range: %d (min: %d; max: %d)."
 msgstr "Arvo %d ei ole välillä %d–%d."
 
-#: server/settings.c:3573
+#: server/settings.c:3607
 msgid "This setting is not a string."
 msgstr "Asetus ei ole merkkijono."
 
-#: server/settings.c:3579
+#: server/settings.c:3613
 #, c-format
 msgid "String value too long (max length: %lu)."
 msgstr "Merkkijonoarvo saa olla korkeintaa %lu merkkiä pitkä"
 
-#: server/settings.c:3667
+#: server/settings.c:3701
 msgid "This setting is not an enumerator."
 msgstr "Asetus ei ole enumeraatio."
 
 #. TRANS: only emphasizing a string.
-#: server/settings.c:3836
+#: server/settings.c:3870
 #, c-format
 msgid "\"%s\""
 msgstr "\"%s\""
 
 #. TRANS: Bitwise setting has no bits set.
-#: server/settings.c:3845
+#: server/settings.c:3879
 msgid "empty value"
 msgstr "tyhjä arvo"
 
-#: server/settings.c:3897
+#: server/settings.c:3931
 msgid "This setting is not a bitwise."
 msgstr "Asetus ei ole arvojoukko."
 
-#: server/settings.c:4180 server/settings.c:4200 server/settings.c:4220
-#: server/settings.c:4244 server/settings.c:4268
+#: server/settings.c:4214 server/settings.c:4234 server/settings.c:4254
+#: server/settings.c:4278 server/settings.c:4302
 #, c-format
 msgid "Ruleset: '%s' has been set to %s."
 msgstr "Sääntökokoelma: '%s' on asetettu arvoon %s."
 
-#: server/settings.c:4291
+#: server/settings.c:4325
 #, c-format
 msgid "Ruleset: '%s' has been locked by the ruleset."
 msgstr "Sääntökokoelma: '%s' on lukittu."
 
-#: server/settings.c:4579 server/settings.c:4611 server/settings.c:4640
-#: server/settings.c:4674 server/settings.c:4708
+#: server/settings.c:4613 server/settings.c:4645 server/settings.c:4674
+#: server/settings.c:4708 server/settings.c:4742
 #, c-format
 msgid "Savegame: '%s' has been set to %s."
 msgstr "Ladattu peli: '%s' on asetettu arvoon %s."
 
-#: server/settings.c:4587 server/settings.c:4619 server/settings.c:4648
-#: server/settings.c:4682 server/settings.c:4716
+#: server/settings.c:4621 server/settings.c:4653 server/settings.c:4682
+#: server/settings.c:4716 server/settings.c:4750
 #, c-format
 msgid "Savegame: '%s' explicitly set to value same as default."
 msgstr "Talletus: '%s' erikseen asetettu samaan arvoon kuin oletusarvo."
@@ -46393,7 +46550,7 @@ msgstr "En onnistunut luomaan sopivaa karttaa annetuilla asetuksilla."
 msgid "Setting '%s' has been adjusted from %s to %s."
 msgstr "Asetus '%s' on muutettu arvosta %s arvoon %s."
 
-#: server/srv_main.c:3356
+#: server/srv_main.c:3357
 #, c-format
 msgid "Now accepting new client connections on port %d."
 msgstr "Vastaanotan nyt uusia asiakasohjelmien yhteydenottoja porttiin %d."
@@ -48922,8 +49079,8 @@ msgstr "%s selviytyi surkeasta hyökkäyksestä, jota %s %s yritti."
 msgid "Your attacking %s failed against the %s %s!"
 msgstr "Hyökkäyksesi meni mönkään, %s hävisi ja %s %s selviytyi voittajana."
 
-#: server/unithand.c:3842 server/unittools.c:2839 server/unittools.c:2847
-#: server/unittools.c:2877
+#: server/unithand.c:3842 server/unittools.c:2845 server/unittools.c:2853
+#: server/unittools.c:2883
 msgid "Cannot attack unless you declare war first."
 msgstr "Et voi hyökätä ennen sodanjulistusta."
 
@@ -48932,7 +49089,7 @@ msgstr "Et voi hyökätä ennen sodanjulistusta."
 msgid "%s can only move into your own zone of control."
 msgstr "%s voi siirtyä vain itse valvomallesi alueelle."
 
-#: server/unithand.c:3860 server/unittools.c:2855 server/unittools.c:2885
+#: server/unithand.c:3860 server/unittools.c:2861 server/unittools.c:2891
 #, c-format
 msgid "Cannot invade unless you break peace with %s first."
 msgstr ""
@@ -49130,46 +49287,46 @@ msgstr "Yksikköä %s ei voi muuntaa."
 msgid "Orders for %s aborted because activity is no longer available."
 msgstr "%s keskeytti toimintansa, koska toiminto ei ole enää mahdollinen."
 
-#: server/unittools.c:1181
+#: server/unittools.c:1187
 #, c-format
 msgid "Teleported your %s to %s."
 msgstr "%s siirrettiin kaupunkiin %s."
 
 #. TRANS: A unit is moved to resolve stack conflicts.
-#: server/unittools.c:1247
+#: server/unittools.c:1253
 #, c-format
 msgid "Moved your %s."
 msgstr "%s siirrettiin."
 
 #. TRANS: A unit is disbanded to resolve stack conflicts.
-#: server/unittools.c:1266
+#: server/unittools.c:1272
 #, c-format
 msgid "Disbanded your %s."
 msgstr "%s lakkautettiin."
 
-#: server/unittools.c:1766
+#: server/unittools.c:1772
 #, c-format
 msgid "Unable to defend %s, %s has lost the game."
 msgstr "Yksikön %s puolustaminen epäonnistui, %s on hävinnyt pelin."
 
-#: server/unittools.c:1770
+#: server/unittools.c:1776
 #, c-format
 msgid "Losing %s meant losing the game! Be more careful next time!"
 msgstr ""
 "Yksikön %s menettäminen sai sinut häviämään pelin - ole varovaisempi ensi "
 "kerralla!"
 
-#: server/unittools.c:1827
+#: server/unittools.c:1833
 #, c-format
 msgid "%s lost when %s was lost."
 msgstr "%s menetetty yksikön %s mukana."
 
-#: server/unittools.c:2071
+#: server/unittools.c:2077
 #, c-format
 msgid "%s escaped the destruction of %s, and fled to %s."
 msgstr "%s pakeni yksikön %s tuhoa ja pakeni kaupunkiin %s."
 
-#: server/unittools.c:2232
+#: server/unittools.c:2238
 #, c-format
 msgid "Barbarian leader captured; %d gold ransom paid."
 msgid_plural "Barbarian leader captured; %d gold ransom paid."
@@ -49177,19 +49334,19 @@ msgstr[0] "Barbaarijohtaja vangittu, saat %d kullan lunnaat."
 msgstr[1] "Barbaarijohtaja vangittu, saat %d kullan lunnaat."
 
 #. TRANS: "... Cannon ... the Polish Destroyer."
-#: server/unittools.c:2253
+#: server/unittools.c:2259
 #, c-format
 msgid "Your attacking %s succeeded against the %s %s!"
 msgstr "Hyökännyt yksikkösi %s onnistui, %s %s kukistettiin!"
 
 #. TRANS: "Cannon ... the Polish Destroyer."
-#: server/unittools.c:2262 server/unittools.c:2369
+#: server/unittools.c:2268 server/unittools.c:2375
 #, c-format
 msgid "%s lost to an attack by the %s %s."
 msgstr "%s menetettiin taistelussa; %s hyökännyt %s teki siitä selvää jälkeä."
 
 #. TRANS: "... Cannon ... the Polish Destroyer ...."
-#: server/unittools.c:2344
+#: server/unittools.c:2350
 #, c-format
 msgid "Your attacking %s succeeded against the %s %s (and %d other unit)!"
 msgid_plural ""
@@ -49201,14 +49358,14 @@ msgstr[1] ""
 
 #. TRANS: "Cannon lost when the Polish Destroyer
 #. * attacked the German Musketeers."
-#: server/unittools.c:2379
+#: server/unittools.c:2385
 #, c-format
 msgid "%s lost when the %s %s attacked the %s %s."
 msgstr "%s menetettiin kun %s %s hyökkäsi kohteen %s %s kimppuun."
 
 #. TRANS: "Musketeers (and Cannon) lost to an
 #. * attack from the Polish Destroyer."
-#: server/unittools.c:2395
+#: server/unittools.c:2401
 #, c-format
 msgid "%s (and %s) lost to an attack from the %s %s."
 msgstr "%s (ja %s) menetettiin kun %s %s hyökkäsi."
@@ -49216,7 +49373,7 @@ msgstr "%s (ja %s) menetettiin kun %s %s hyökkäsi."
 #. TRANS: "Musketeers and 3 other units lost to
 #. * an attack from the Polish Destroyer."
 #. * (only happens with at least 2 other units)
-#: server/unittools.c:2406
+#: server/unittools.c:2412
 #, c-format
 msgid "%s and %d other unit lost to an attack from the %s %s."
 msgid_plural "%s and %d other units lost to an attack from the %s %s."
@@ -49226,14 +49383,14 @@ msgstr[1] "%s ja %d muuta yksikköä menetettiin kun %s %s hyökkäsi."
 #. TRANS: "2 units lost when the Polish Destroyer
 #. * attacked the German Musketeers."
 #. * (only happens with at least 2 other units)
-#: server/unittools.c:2421
+#: server/unittools.c:2427
 #, c-format
 msgid "%d unit lost when the %s %s attacked the %s %s."
 msgid_plural "%d units lost when the %s %s attacked the %s %s."
 msgstr[0] "%d yksikkö menetettiin kun %s %s hyökkäsi kohteenaan %s %s."
 msgstr[1] "%d yksikköä menetettiin kun %s %s hyökkäsi kohteenaan %s %s."
 
-#: server/unittools.c:2438
+#: server/unittools.c:2444
 #, fuzzy, c-format
 #| msgid "%d unit lost when the %s %s attacked the %s %s."
 #| msgid_plural "%d units lost when the %s %s attacked the %s %s."
@@ -49242,104 +49399,104 @@ msgid_plural "%d units escaped from attack by %s %s"
 msgstr[0] "%d yksikkö menetettiin kun %s %s hyökkäsi kohteenaan %s %s."
 msgstr[1] "%d yksikköä menetettiin kun %s %s hyökkäsi kohteenaan %s %s."
 
-#: server/unittools.c:2694
+#: server/unittools.c:2700
 #, c-format
 msgid "Your %s was nuked by %s."
 msgstr "Yksikkösi %s tuhoutui kun %s iskivät ydinasein."
 
-#: server/unittools.c:2697 server/unittools.c:2714
+#: server/unittools.c:2703 server/unittools.c:2720
 msgid "yourself"
 msgstr "sinä itse"
 
-#: server/unittools.c:2701
+#: server/unittools.c:2707
 #, c-format
 msgid "The %s %s was nuked."
 msgstr "%s %s tuhottiin ydiniskussa."
 
-#: server/unittools.c:2711
+#: server/unittools.c:2717
 #, c-format
 msgid "%s was nuked by %s."
 msgstr "%s tuhoutui kun %s iski ydinasein."
 
-#: server/unittools.c:2719
+#: server/unittools.c:2725
 #, c-format
 msgid "You nuked %s."
 msgstr "Olet pamauttanut kohteen %s tuusannuuskaksi ydiniskussa."
 
-#: server/unittools.c:2751
+#: server/unittools.c:2757
 #, c-format
 msgid "The %s detonated a nuke!"
 msgstr "%s räjäyttivät ydinlatauksen!"
 
-#: server/unittools.c:2765
+#: server/unittools.c:2771
 #, c-format
 msgid "%s transported successfully."
 msgstr "%s on turvallisesti siirretty kohteeseensa."
 
-#: server/unittools.c:2832 server/unittools.c:2868
+#: server/unittools.c:2838 server/unittools.c:2874
 #, c-format
 msgid "This unit cannot paradrop into %s."
 msgstr "%s ei sovi yksikön maahanlaskupaikaksi."
 
-#: server/unittools.c:2897
+#: server/unittools.c:2903
 #, c-format
 msgid "Your %s paradropped into the %s and was lost."
 msgstr "Yksikkösi %s menetettiin maahanlaskupaikassa %s."
 
-#: server/unittools.c:2911
+#: server/unittools.c:2917
 #, c-format
 msgid "Your %s was killed by enemy units at the paradrop destination."
 msgstr "Maahanlaskupaikalla olleet vihollisyksiköt tuhosivat yksikkösi %s."
 
-#: server/unittools.c:3327
+#: server/unittools.c:3341
 #, c-format
 msgid "Orders for %s aborted after enemy movement was spotted."
 msgstr "%s keskeytti toimintansa havaittuaan vihollisen liikehdintää."
 
-#: server/unittools.c:4116
+#: server/unittools.c:4130
 #, c-format
 msgid "Orders for %s aborted as there are units nearby."
 msgstr "%s keskeytti toimintansa, koska lähistöllä on yksiköitä."
 
-#: server/unittools.c:4256
+#: server/unittools.c:4270
 #, c-format
 msgid "Orders for %s aborted since they give an invalid activity."
 msgstr ""
 "%s kieltäytyy jatkamasta sopimattomiksi käyneiden komentojen seuraamista."
 
-#: server/unittools.c:4266
+#: server/unittools.c:4280
 #, c-format
 msgid "Orders for %s aborted since they give an invalid location."
 msgstr "%s keskeytti liikkumisensa, koska kohdepaikka on sopimaton."
 
-#: server/unittools.c:4277
+#: server/unittools.c:4291
 #, c-format
 msgid "Orders for %s aborted as there are units in the way."
 msgstr "%s keskeytti toimintansa, koska muut yksiköt ovat sen tiellä."
 
-#: server/unittools.c:4322
+#: server/unittools.c:4336
 #, c-format
 msgid "Orders for %s aborted because of failed move."
 msgstr "%s keskeytti toimintansa, koska sen liikkuminen epäonnistui."
 
-#: server/unittools.c:4428
+#: server/unittools.c:4442
 #, fuzzy, c-format
 #| msgid "Your %s can't do %s to %s."
 msgid "%s could not do %s to %s."
 msgstr "Yksikkösi %s ei voi suorittaa toimintoa %s kohteelle %s."
 
-#: server/unittools.c:4466
+#: server/unittools.c:4480
 #, fuzzy, c-format
 #| msgid "Orders for %s aborted because building of city failed."
 msgid "Orders for %s aborted because doing %s to %s failed."
 msgstr "%s keskeytti toimintansa, koska kaupungin rakentaminen epäonnistui."
 
-#: server/unittools.c:4487
+#: server/unittools.c:4501
 #, c-format
 msgid "Your %s has invalid orders."
 msgstr "Yksikölle %s annetut ohjeet eivät enää kelpaa."
 
-#: server/unittools.c:4589
+#: server/unittools.c:4603
 #, c-format
 msgid "Your unit may not act for another %s this turn. See /help unitwaittime."
 msgstr ""
@@ -50057,6 +50214,10 @@ msgstr "virhe %d (funktio strerror() ei ole käytössä)"
 #~ msgid "Transf_orm to %s"
 #~ msgstr "Muunna maast_oksi %s"
 
+#~ msgid "* Can convert terrain to another type by irrigation.\n"
+#~ msgstr ""
+#~ "· Voi muokata maastotyypin toiseksi kastelukanavien kaivuu käskyllä.\n"
+
 #~ msgid "Better fog-of-war drawing"
 #~ msgstr "Kauniimmat hämärrykset (\"fog of war\")"
 
@@ -50341,6 +50502,20 @@ msgstr "virhe %d (funktio strerror() ei ole käytössä)"
 #~ msgstr ""
 #~ "Efektimäärityksissä tulisi olla kenttä \"type\", eikä enää ennen samassa "
 #~ "merkityksessä käytetty \"name\"."
+
+#~ msgid ""
+#~ "City Walls make it easier to defend a city.  They triple the defense "
+#~ "strength of units within the city against land, sea, and helicopter "
+#~ "units.  They are ineffective against non-helicopter airborne units as "
+#~ "well as Artillery.  City Walls also prevent the loss of population which "
+#~ "occurs when a defending unit is destroyed by a land unit."
+#~ msgstr ""
+#~ "Kaupunginmuuri helpottaa kaupungin puolustamista. Se kolminkertaistaa "
+#~ "kaupungissa olevien yksiköiden puolustuskyvyn maa- ja merivoimien "
+#~ "yksiköitä sekä helikoptereita vastaan. Muurit eivät auta "
+#~ "puolustauduttaessa muita ilma-aluksia tai tykistöä vastaan. Muurit "
+#~ "suojaavat myös siviiliväestöä; kaupungin väkiluku ei laske vaikka "
+#~ "puolustava yksikkö tuhoutuisikin maavoimien yksikön hyökkäyksessä."
 
 #~ msgid "Year"
 #~ msgstr "Vuosi"


### PR DESCRIPTION
Couple of big/risky changes in this set;
for the introduction of server side rally points handling
of orders has been refactored. The code has fcw.org
modifications in it.

--

Ruleset format changes (@Lexxie9952):
- Extra removal cause "Enter" added, should be used for Hut type extras
- Added history_interest_pml ruleset setting

Transition from terrain converting Irrigate and Mine to
dedicated Cultivate and Plant activities started.

Several path finding fixes for fuel using units.

Server side rally point support added

Some commits of granularity ruleset implementation