### PR TITLE
Bring in unit orders network protocol simplification

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/action_dialog.js
+++ b/freeciv-web/src/main/webapp/javascript/action_dialog.js
@@ -389,6 +389,14 @@ function popup_action_selection(actor_unit, action_probabilities,
         click   : function() {
           var dir = get_direction_for_step(tiles[actor_unit['tile']],
                                            target_tile);
+          var order = {
+            "order"      : ORDER_MOVE,
+            "dir"        : dir,
+            "activity"   : ACTIVITY_LAST,
+            "sub_target" : 0,
+            "action"     : ACTION_COUNT
+          };
+
           var packet = {
             "pid"       : packet_unit_orders,
             "unit_id"   : actor_unit['id'],
@@ -396,17 +404,13 @@ function popup_action_selection(actor_unit, action_probabilities,
             "length"    : 1,
             "repeat"    : false,
             "vigilant"  : false,
-            "orders"    : [ORDER_MOVE],
-            "dir"       : [dir],
-            "activity"  : [ACTIVITY_LAST],
-            "sub_target": [0],
-            "action"    : [ACTION_COUNT],
+            "orders"    : [order],
             "dest_tile" : target_tile['index']
           };
 
           if (dir == -1) {
             /* Non adjacent target tile? */
-            console.log("Action slection move: bad target tile");
+            console.log("Action selection move: bad target tile");
           } else {
             send_request(JSON.stringify(packet));
           }

--- a/freeciv/freeciv/client/control.c
+++ b/freeciv/freeciv/client/control.c
@@ -1732,11 +1732,11 @@ void request_unit_non_action_move(struct unit *punit,
   p.dest_tile = tile_index(dest_tile);
 
   p.length = 1;
-  p.orders[0] = ORDER_MOVE;
-  p.dir[0] = dir;
-  p.activity[0] = ACTIVITY_LAST;
-  p.sub_target[0] = -1;
-  p.action[0] = ACTION_NONE;
+  p.orders[0].order = ORDER_MOVE;
+  p.orders[0].dir = dir;
+  p.orders[0].activity = ACTIVITY_LAST;
+  p.orders[0].sub_target = -1;
+  p.orders[0].action = ACTION_NONE;
 
   send_packet_unit_orders(&client.conn, &p);
 }
@@ -1784,11 +1784,11 @@ void request_move_unit_direction(struct unit *punit, int dir)
   p.dest_tile = tile_index(dest_tile);
 
   p.length = 1;
-  p.orders[0] = ORDER_ACTION_MOVE;
-  p.dir[0] = dir;
-  p.activity[0] = ACTIVITY_LAST;
-  p.sub_target[0] = -1;
-  p.action[0] = ACTION_NONE;
+  p.orders[0].order = ORDER_ACTION_MOVE;
+  p.orders[0].dir = dir;
+  p.orders[0].activity = ACTIVITY_LAST;
+  p.orders[0].sub_target = -1;
+  p.orders[0].action = ACTION_NONE;
 
   send_packet_unit_orders(&client.conn, &p);
 }

--- a/freeciv/freeciv/client/goto.c
+++ b/freeciv/freeciv/client/goto.c
@@ -1400,34 +1400,34 @@ static void send_path_orders(struct unit *punit, struct pf_path *path,
     struct tile *new_tile = path->positions[i + 1].tile;
 
     if (same_pos(new_tile, old_tile)) {
-      p.orders[i] = ORDER_FULL_MP;
-      p.dir[i] = DIR8_ORIGIN;
-      p.activity[i] = ACTIVITY_LAST;
-      p.sub_target[i] = -1;
-      p.action[i] = ACTION_NONE;
+      p.orders[i].order = ORDER_FULL_MP;
+      p.orders[i].dir = DIR8_ORIGIN;
+      p.orders[i].activity = ACTIVITY_LAST;
+      p.orders[i].sub_target = -1;
+      p.orders[i].action = ACTION_NONE;
       log_goto_packet("  packet[%d] = wait: %d,%d", i, TILE_XY(old_tile));
     } else {
-      p.orders[i] = orders;
-      p.dir[i] = get_direction_for_step(&(wld.map), old_tile, new_tile);
-      p.activity[i] = ACTIVITY_LAST;
-      p.sub_target[i] = -1;
-      p.action[i] = ACTION_NONE;
+      p.orders[i].order = orders;
+      p.orders[i].dir = get_direction_for_step(&(wld.map), old_tile, new_tile);
+      p.orders[i].activity = ACTIVITY_LAST;
+      p.orders[i].sub_target = -1;
+      p.orders[i].action = ACTION_NONE;
       log_goto_packet("  packet[%d] = move %s: %d,%d => %d,%d",
-                      i, dir_get_name(p.dir[i]),
+                      i, dir_get_name(p.orders[i].dir),
                       TILE_XY(old_tile), TILE_XY(new_tile));
     }
     old_tile = new_tile;
   }
 
   if (i > 0
-      && p.orders[i - 1] == ORDER_MOVE
+      && p.orders[i - 1].order == ORDER_MOVE
       && (is_non_allied_city_tile(old_tile, client_player()) != NULL
           || is_non_allied_unit_tile(old_tile, client_player()) != NULL)) {
     /* Won't be able to perform a regular move to the target tile... */
     if (!final_order) {
       /* ...and no final order exists. Choose what to do when the unit gets
        * there. */
-      p.orders[i - 1] = ORDER_ACTION_MOVE;
+      p.orders[i - 1].order = ORDER_ACTION_MOVE;
     } else {
       /* ...and a final order exist. Can't assume an action move. Did the
        * caller hope that the situation would change before the unit got
@@ -1444,12 +1444,12 @@ static void send_path_orders(struct unit *punit, struct pf_path *path,
 
   if (final_order) {
     /* Append the final order after moving to the target tile. */
-    p.orders[i] = final_order->order;
-    p.dir[i] = final_order->dir;
-    p.activity[i] = (final_order->order == ORDER_ACTIVITY)
+    p.orders[i].order = final_order->order;
+    p.orders[i].dir = final_order->dir;
+    p.orders[i].activity = (final_order->order == ORDER_ACTIVITY)
       ? final_order->activity : ACTIVITY_LAST;
-    p.sub_target[i] = final_order->sub_target;
-    p.action[i] = final_order->action;
+    p.orders[i].sub_target = final_order->sub_target;
+    p.orders[i].action = final_order->action;
     p.length++;
   }
 
@@ -1567,11 +1567,11 @@ static bool order_recursive_roads(struct tile *ptile, struct extra_type *pextra,
     }
   } extra_deps_iterate_end;
 
-  p->orders[p->length] = ORDER_ACTIVITY;
-  p->dir[p->length] = DIR8_ORIGIN;
-  p->activity[p->length] = ACTIVITY_GEN_ROAD;
-  p->sub_target[p->length] = extra_index(pextra);
-  p->action[p->length] = ACTION_NONE;
+  p->orders[p->length].order = ORDER_ACTIVITY;
+  p->orders[p->length].dir = DIR8_ORIGIN;
+  p->orders[p->length].activity = ACTIVITY_GEN_ROAD;
+  p->orders[p->length].sub_target = extra_index(pextra);
+  p->orders[p->length].action = ACTION_NONE;
   p->length++;
 
   return TRUE;
@@ -1616,11 +1616,11 @@ void send_connect_route(enum unit_activity activity,
       case ACTIVITY_IRRIGATE:
 	if (!tile_has_extra(old_tile, tgt)) {
 	  /* Assume the unit can irrigate or we wouldn't be here. */
-	  p.orders[p.length] = ORDER_ACTIVITY;
-          p.dir[p.length] = DIR8_ORIGIN;
-	  p.activity[p.length] = ACTIVITY_IRRIGATE;
-          p.sub_target[p.length] = extra_index(tgt);
-          p.action[p.length] = ACTION_NONE;
+	  p.orders[p.length].order = ORDER_ACTIVITY;
+          p.orders[p.length].dir = DIR8_ORIGIN;
+	  p.orders[p.length].activity = ACTIVITY_IRRIGATE;
+          p.orders[p.length].sub_target = extra_index(tgt);
+          p.orders[p.length].action = ACTION_NONE;
 	  p.length++;
 	}
 	break;
@@ -1637,12 +1637,12 @@ void send_connect_route(enum unit_activity activity,
 
         fc_assert(!same_pos(new_tile, old_tile));
 
-        p.orders[p.length] = ORDER_MOVE;
-        p.dir[p.length] = get_direction_for_step(&(wld.map),
-                                                 old_tile, new_tile);
-        p.activity[p.length] = ACTIVITY_LAST;
-        p.sub_target[p.length] = -1;
-        p.action[p.length] = ACTION_NONE;
+        p.orders[p.length].order = ORDER_MOVE;
+        p.orders[p.length].dir = get_direction_for_step(&(wld.map),
+                                                        old_tile, new_tile);
+        p.orders[p.length].activity = ACTIVITY_LAST;
+        p.orders[p.length].sub_target = -1;
+        p.orders[p.length].action = ACTION_NONE;
         p.length++;
 
         old_tile = new_tile;

--- a/freeciv/freeciv/client/packhand.c
+++ b/freeciv/freeciv/client/packhand.c
@@ -247,19 +247,15 @@ static struct unit *unpackage_unit(const struct packet_unit_info *packet)
   if (punit->has_orders) {
     int i;
 
+    for (i = 0; i < packet->orders_length; i++) {
+      /* Just an assert. The client doesn't use the action data. */
+      fc_assert(packet->orders[i].order != ORDER_PERFORM_ACTION
+                || action_id_exists(packet->orders[i].action));
+    }
     punit->orders.list
       = fc_malloc(punit->orders.length * sizeof(*punit->orders.list));
-    for (i = 0; i < punit->orders.length; i++) {
-      punit->orders.list[i].order = packet->orders[i];
-      punit->orders.list[i].dir = packet->orders_dirs[i];
-      punit->orders.list[i].activity = packet->orders_activities[i];
-      punit->orders.list[i].sub_target = packet->orders_sub_targets[i];
-      punit->orders.list[i].action = packet->orders_actions[i];
-
-      /* Just an assert. The client doesn't use the action data. */
-      fc_assert(punit->orders.list[i].order != ORDER_PERFORM_ACTION
-                || action_id_exists(punit->orders.list[i].action));
-    }
+    memcpy(punit->orders.list, packet->orders,
+           punit->orders.length * sizeof(*punit->orders.list));
   }
 
   punit->action_decision_want = packet->action_decision_want;

--- a/freeciv/freeciv/common/networking/dataio_json.c
+++ b/freeciv/freeciv/common/networking/dataio_json.c
@@ -239,6 +239,26 @@ void dio_put_sint16_json(struct json_data_out *dout,
 }
 
 /**********************************************************************//**
+  Insert the given unit_order struct
+**************************************************************************/
+void dio_put_unit_order_json(struct json_data_out *dout,
+                             struct plocation *location,
+                             const struct unit_order *order)
+{
+  if (dout->json) {
+    json_t *obj = json_object();
+    json_object_set_new(obj, "order", json_integer(order->order));
+    json_object_set_new(obj, "activity", json_integer(order->activity));
+    json_object_set_new(obj, "sub_target", json_integer(order->sub_target));
+    json_object_set_new(obj, "action", json_integer(order->action));
+    json_object_set_new(obj, "dir", json_integer(order->dir));
+    plocation_write_data(dout->json, location, obj);
+  } else {
+    dio_put_unit_order_raw(&dout->raw, order);
+  }
+}
+
+/**********************************************************************//**
   Insert the given cm_parameter struct
 **************************************************************************/
 void dio_put_cm_parameter_json(struct json_data_out *dout,
@@ -498,6 +518,73 @@ bool dio_get_cm_parameter_json(struct connection *pc, struct data_in *din,
     FC_FREE(location->sub_location);
   } else {
     return dio_get_cm_parameter_raw(din, param);
+  }
+
+  return TRUE;
+}
+
+/**********************************************************************//**
+  Retrieve an unit_order
+**************************************************************************/
+bool dio_get_unit_order_json(struct connection *pc, struct data_in *din,
+                             struct plocation *location,
+                             struct unit_order *order)
+{
+  if (pc->json_mode) {
+    struct plocation *loc;
+    int iorder, iactivity, idir; /* These fields are enums */
+
+    /* Orders may be located in a nested field (as items in an array) */
+    loc = location;
+    while (loc->sub_location) {
+      loc = loc->sub_location;
+    }
+
+    loc->sub_location = plocation_field_new("order");
+    if (!dio_get_uint8_json(pc, din, location, &iorder)) {
+      log_packet("Corrupt order.order");
+      FC_FREE(loc->sub_location);
+      return FALSE;
+    }
+
+    loc->sub_location->name = "activity";
+    if (!dio_get_uint8_json(pc, din, location, &iactivity)) {
+      log_packet("Corrupt order.activity");
+      FC_FREE(loc->sub_location);
+      return FALSE;
+    }
+
+    loc->sub_location->name = "sub_target";
+    if (!dio_get_sint16_json(pc, din, location, &order->sub_target)) {
+      log_packet("Corrupt order.sub_target");
+      FC_FREE(loc->sub_location);
+      return FALSE;
+    }
+
+    loc->sub_location->name = "action";
+    if (!dio_get_uint8_json(pc, din, location, &order->action)) {
+      log_packet("Corrupt order.action");
+      FC_FREE(loc->sub_location);
+      return FALSE;
+    }
+
+    loc->sub_location->name = "dir";
+    if (!dio_get_uint8_json(pc, din, location, &idir)) {
+      log_packet("Corrupt order.dir");
+      FC_FREE(loc->sub_location);
+      return FALSE;
+    }
+
+    /*
+     * FIXME: The values should be checked!
+     */
+    order->order = iorder;
+    order->activity = iactivity;
+    order->dir = idir;
+
+    FC_FREE(loc->sub_location);
+  } else {
+    return dio_get_unit_order_raw(din, order);
   }
 
   return TRUE;

--- a/freeciv/freeciv/common/networking/dataio_json.h
+++ b/freeciv/freeciv/common/networking/dataio_json.h
@@ -27,6 +27,7 @@ extern "C" {
 #include "connection.h"
 
 struct cm_parameter;
+struct unit_order;
 struct worklist;
 struct requirement;
 
@@ -78,6 +79,9 @@ bool dio_get_cm_parameter_json(struct connection *pc, struct data_in *din,
 bool dio_get_worklist_json(struct connection *pc, struct data_in *din,
                            struct plocation *location,
                            struct worklist *pwl);
+bool dio_get_unit_order_json(struct connection *pc, struct data_in *din,
+                             struct plocation *location,
+                             struct unit_order *order);
 bool dio_get_requirement_json(struct connection *pc, struct data_in *din,
                               const struct plocation *location,
                               struct requirement *preq);
@@ -145,7 +149,10 @@ void dio_put_city_map_json(struct json_data_out *dout,
                            const char *value);
 void dio_put_cm_parameter_json(struct json_data_out *dout,
                                struct plocation *location,
-                               const struct cm_parameter *order);                           
+                               const struct cm_parameter *order);
+void dio_put_unit_order_json(struct json_data_out *dout,
+                             struct plocation *location,
+                             const struct unit_order *order);
 void dio_put_worklist_json(struct json_data_out *dout,
                            struct plocation *location,
                            const struct worklist *pwl);

--- a/freeciv/freeciv/common/networking/dataio_raw.c
+++ b/freeciv/freeciv/common/networking/dataio_raw.c
@@ -535,6 +535,19 @@ void dio_put_cm_parameter_raw(struct raw_data_out *dout,
 }
 
 /**********************************************************************//**
+  Insert the given unit_order struct/
+**************************************************************************/
+void dio_put_unit_order_raw(struct raw_data_out *dout,
+                            const struct unit_order *order)
+{
+  dio_put_uint8_raw(dout, order->order);
+  dio_put_uint8_raw(dout, order->activity);
+  dio_put_sint16_raw(dout, order->sub_target);
+  dio_put_uint8_raw(dout, order->action);
+  dio_put_sint8_raw(dout, order->dir);
+}
+
+/**********************************************************************//**
   Insert number of worklist items as 8 bit value and then insert
   8 bit kind and 8 bit number for each worklist item.
 **************************************************************************/
@@ -855,6 +868,30 @@ bool dio_get_cm_parameter_raw(struct data_in *din,
     log_packet("Got a bad cm_parameter");
     return FALSE;
   }
+
+  return TRUE;
+}
+
+/**********************************************************************//**
+  Take unit_order struct and put it in the provided orders.
+**************************************************************************/
+bool dio_get_unit_order_raw(struct data_in *din, struct unit_order *order)
+{
+  /* These fields are enums */
+  int iorder, iactivity, idir;
+
+  if (!dio_get_uint8_raw(din, &iorder)
+      || !dio_get_uint8_raw(din, &iactivity)
+      || !dio_get_sint16_raw(din, &order->sub_target)
+      || !dio_get_uint8_raw(din, &order->action)
+      || !dio_get_sint8_raw(din, &idir)) {
+    log_packet("Got a bad unit_order");
+    return FALSE;
+  }
+
+  order->order = iorder;
+  order->activity = iactivity;
+  order->dir = idir;
 
   return TRUE;
 }

--- a/freeciv/freeciv/common/networking/dataio_raw.h
+++ b/freeciv/freeciv/common/networking/dataio_raw.h
@@ -23,6 +23,7 @@ extern "C" {
 
 struct cm_parameter;
 struct worklist;
+struct unit_order;
 struct requirement;
 struct act_prob;
 
@@ -143,6 +144,8 @@ bool dio_get_cm_parameter_raw(struct data_in *din, struct cm_parameter *param)
     fc__attribute((nonnull (2)));
 bool dio_get_worklist_raw(struct data_in *din, struct worklist *pwl)
     fc__attribute((nonnull (2)));
+bool dio_get_unit_order_raw(struct data_in *din, struct unit_order *order)
+    fc__attribute((nonnull (2)));
 bool dio_get_requirement_raw(struct data_in *din, struct requirement *preq)
     fc__attribute((nonnull (2)));
 bool dio_get_action_probability_raw(struct data_in *din,
@@ -190,6 +193,8 @@ void dio_put_city_map_raw(struct raw_data_out *dout, const char *value);
 void dio_put_cm_parameter_raw(struct raw_data_out *dout,
                               const struct cm_parameter *param);
 void dio_put_worklist_raw(struct raw_data_out *dout, const struct worklist *pwl);
+void dio_put_unit_order_raw(struct raw_data_out *dout,
+                            const struct unit_order *order);
 void dio_put_requirement_raw(struct raw_data_out *dout, const struct requirement *preq);
 void dio_put_action_probability_raw(struct raw_data_out *dout,
                                     const struct act_prob *aprob);

--- a/freeciv/freeciv/common/networking/packets.def
+++ b/freeciv/freeciv/common/networking/packets.def
@@ -206,6 +206,7 @@ type STRVEC             = STRING
 type WORKLIST           = worklist(struct worklist)
 # string that is URI encoded in the JSON protocol
 type ESTRING            = estring(char)
+type UNIT_ORDER         = unit_order(struct unit_order)
 type CM_PARAMETER       = cm_parameter(struct cm_parameter)
 
 # typedefs for enums
@@ -232,7 +233,6 @@ type GUI_TYPE           = uint8(enum gui_type)
 type IMPR_GENUS         = uint8(enum impr_genus_id)
 type KNOWN              = uint8(enum known_type)
 type MOOD               = uint8(enum mood_type)
-type ORDERS             = uint8(enum unit_orders)
 type PHASE_MODE         = uint8(enum phase_mode_type)
 type PLACE_TYPE         = uint8(enum spaceship_place_type)
 type REPORT_TYPE        = uint8(enum report_type)
@@ -746,11 +746,7 @@ PACKET_CITY_INFO = 31; sc, lsend, is-game-info, force, cancel(PACKET_CITY_SHORT_
   UINT16 rally_point_length;
   BOOL rally_point_persistent;
   BOOL rally_point_vigilant;
-  ORDERS rally_point_orders[MAX_LEN_ROUTE:rally_point_length];
-  DIRECTION rally_point_dirs[MAX_LEN_ROUTE:rally_point_length];
-  ACTIVITY rally_point_activities[MAX_LEN_ROUTE:rally_point_length];
-  ACTION_SUB_TGT rally_point_sub_targets[MAX_LEN_ROUTE:rally_point_length];
-  ACTION_ID rally_point_actions[MAX_LEN_ROUTE:rally_point_length];
+  UNIT_ORDER rally_point_orders[MAX_LEN_ROUTE:rally_point_length];
 
   BOOL cma_enabled;
   CM_PARAMETER cm_parameter;
@@ -870,11 +866,7 @@ PACKET_CITY_RALLY_POINT = 138; cs
   UINT16 length;
   BOOL persistent;
   BOOL vigilant;
-  ORDERS orders[MAX_LEN_ROUTE:length];
-  DIRECTION dirs[MAX_LEN_ROUTE:length];
-  ACTIVITY activities[MAX_LEN_ROUTE:length];
-  ACTION_SUB_TGT sub_targets[MAX_LEN_ROUTE:length];
-  ACTION_ID actions[MAX_LEN_ROUTE:length];
+  UNIT_ORDER orders[MAX_LEN_ROUTE:length];
 end
 
 PACKET_WORKER_TASK = 241; cs, sc, lsend, handle-via-packet
@@ -1049,11 +1041,7 @@ PACKET_UNIT_INFO = 63; sc, lsend, is-game-info, cancel(PACKET_UNIT_SHORT_INFO)
   BOOL has_orders;
   UINT16 orders_length, orders_index;
   BOOL orders_repeat, orders_vigilant;
-  ORDERS orders[MAX_LEN_ROUTE:orders_length];
-  DIRECTION orders_dirs[MAX_LEN_ROUTE:orders_length];
-  ACTIVITY orders_activities[MAX_LEN_ROUTE:orders_length];
-  ACTION_SUB_TGT orders_sub_targets[MAX_LEN_ROUTE:orders_length];
-  ACTION_ID orders_actions[MAX_LEN_ROUTE:orders_length];
+  UNIT_ORDER orders[MAX_LEN_ROUTE:orders_length];
 
   ACTION_DECISION action_decision_want;
   TILE action_decision_tile;
@@ -1101,11 +1089,7 @@ PACKET_UNIT_ORDERS = 73; cs
 
   UINT16 length;
   BOOL repeat, vigilant;
-  ORDERS orders[MAX_LEN_ROUTE:length];
-  DIRECTION dir[MAX_LEN_ROUTE:length];
-  ACTIVITY activity[MAX_LEN_ROUTE:length];
-  ACTION_SUB_TGT sub_target[MAX_LEN_ROUTE:length];
-  ACTION_ID action[MAX_LEN_ROUTE:length];
+  UNIT_ORDER orders[MAX_LEN_ROUTE:length];
   TILE dest_tile;
 end
 

--- a/freeciv/freeciv/common/unit.c
+++ b/freeciv/freeciv/common/unit.c
@@ -59,6 +59,19 @@ struct cargo_iter {
 #define CARGO_ITER(iter) ((struct cargo_iter *) (iter))
 
 /**********************************************************************//**
+  Checks unit orders for equality.
+**************************************************************************/
+bool are_unit_orders_equal(const struct unit_order *order1,
+                           const struct unit_order *order2)
+{
+  return order1->order == order2->order
+      && order1->activity == order2->activity
+      && order1->sub_target == order2->sub_target
+      && order1->action == order2->action
+      && order1->dir == order2->dir;
+}
+
+/**********************************************************************//**
   Determines if punit can be airlifted to dest_city now!  So punit needs
   to be in a city now.
   If pdest_city is NULL, just indicate whether it's possible for the unit

--- a/freeciv/freeciv/common/unit.h
+++ b/freeciv/freeciv/common/unit.h
@@ -304,6 +304,9 @@ extern const Activity_type_id tile_changing_activities[ACTIVITY_LAST];
   activity_type_list_iterate_end                                            \
 }
 
+bool are_unit_orders_equal(const struct unit_order *order1,
+                           const struct unit_order *order2);
+
 int unit_shield_value(const struct unit *punit,
                       const struct unit_type *punittype,
                       const struct action *paction);

--- a/freeciv/freeciv/server/cityhand.c
+++ b/freeciv/freeciv/server/cityhand.c
@@ -711,16 +711,17 @@ void handle_city_manager(struct player *pplayer, int city_id, bool enabled,
   Handles a request to set city rally point for new units.
 **************************************************************************/
 void handle_city_rally_point(struct player *pplayer,
-                             const struct packet_city_rally_point *packet)
+                             int city_id, int length,
+                             bool persistent, bool vigilant,
+                             const struct unit_order *orders)
 {
-  int length = packet->length;
-  struct city *pcity = player_city_by_number(pplayer, packet->city_id);
-  struct unit_order *orders;
+  struct city *pcity = player_city_by_number(pplayer, city_id);
+  struct unit_order *checked_orders;
 
   if (NULL == pcity) {
     /* Probably lost. */
     log_verbose("handle_city_rally_point() bad city number %d.",
-                packet->city_id);
+                city_id);
     return;
   }
 
@@ -741,19 +742,17 @@ void handle_city_rally_point(struct player *pplayer,
       pcity->rally_point.orders = NULL;
     }
   } else {
-    orders = create_unit_orders(length, packet->orders, packet->dirs,
-                                packet->activities, packet->sub_targets,
-                                packet->actions);
-    if (!orders) {
+    checked_orders = create_unit_orders(length, orders);
+    if (!checked_orders) {
       pcity->rally_point.length = 0;
       log_error("invalid rally point orders for city number %d.",
-                packet->city_id);
+                city_id);
       return;
     }
 
-    pcity->rally_point.persistent = packet->persistent;
-    pcity->rally_point.vigilant = packet->vigilant;
-    pcity->rally_point.orders = orders;
+    pcity->rally_point.persistent = persistent;
+    pcity->rally_point.vigilant = vigilant;
+    pcity->rally_point.orders = checked_orders;
   }
 
   send_city_info(pplayer, pcity);

--- a/freeciv/freeciv/server/citytools.c
+++ b/freeciv/freeciv/server/citytools.c
@@ -2565,15 +2565,8 @@ void package_city(struct city *pcity, struct packet_city_info *packet,
   if (pcity->rally_point.length) {
     packet->rally_point_persistent = pcity->rally_point.persistent;
     packet->rally_point_vigilant = pcity->rally_point.vigilant;
-    for (i = 0; i < pcity->rally_point.length; i++) {
-      packet->rally_point_orders[i] = pcity->rally_point.orders[i].order;
-      packet->rally_point_dirs[i] = pcity->rally_point.orders[i].dir;
-      packet->rally_point_activities[i] = pcity->rally_point.orders[i]
-                                          .activity;
-      packet->rally_point_sub_targets[i] = pcity->rally_point.orders[i]
-                                           .sub_target;
-      packet->rally_point_actions[i] = pcity->rally_point.orders[i].action;
-    }
+    memcpy(packet->rally_point_orders, pcity->rally_point.orders,
+           pcity->rally_point.length * sizeof(struct unit_order));
   }
 
   BV_CLR_ALL(packet->improvements);

--- a/freeciv/freeciv/server/unithand.c
+++ b/freeciv/freeciv/server/unithand.c
@@ -5564,9 +5564,7 @@ void handle_unit_orders(struct player *pplayer,
   }
 
   if (length) {
-    order_list = create_unit_orders(length, packet->orders, packet->dir,
-                                    packet->activity, packet->sub_target,
-                                    packet->action);
+    order_list = create_unit_orders(length, packet->orders);
     if (!order_list) {
       log_error("received invalid orders from %s for %s (%d).",
                 player_name(pplayer), unit_rule_name(punit), packet->unit_id);
@@ -5614,13 +5612,13 @@ void handle_unit_orders(struct player *pplayer,
   log_debug("Orders for unit %d: length:%d", packet->unit_id, length);
   for (i = 0; i < length; i++) {
     log_debug("  %d,%s,%s,%d",
-              packet->orders[i], dir_get_name(packet->dir[i]),
-              packet->orders[i] == ORDER_PERFORM_ACTION ?
-                action_id_rule_name(packet->action[i]) :
-                packet->orders[i] == ORDER_ACTIVITY ?
-                  unit_activity_name(packet->activity[i]) :
+              packet->orders[i].order, dir_get_name(packet->orders[i].dir),
+              packet->orders[i].order == ORDER_PERFORM_ACTION ?
+                action_id_rule_name(packet->orders[i].action) :
+                packet->orders[i].order == ORDER_ACTIVITY ?
+                  unit_activity_name(packet->orders[i].activity) :
                   "no action/activity required",
-              packet->sub_target[i]);
+              packet->orders[i].sub_target);
   }
 #endif /* FREECIV_DEBUG */
 

--- a/freeciv/freeciv/server/unittools.c
+++ b/freeciv/freeciv/server/unittools.c
@@ -3077,19 +3077,12 @@ void package_unit(struct unit *punit, struct packet_unit_info *packet)
   packet->battlegroup = punit->battlegroup;
   packet->has_orders = punit->has_orders;
   if (punit->has_orders) {
-    int i;
-
     packet->orders_length = punit->orders.length;
     packet->orders_index = punit->orders.index;
     packet->orders_repeat = punit->orders.repeat;
     packet->orders_vigilant = punit->orders.vigilant;
-    for (i = 0; i < punit->orders.length; i++) {
-      packet->orders[i] = punit->orders.list[i].order;
-      packet->orders_dirs[i] = punit->orders.list[i].dir;
-      packet->orders_activities[i] = punit->orders.list[i].activity;
-      packet->orders_sub_targets[i] = punit->orders.list[i].sub_target;
-      packet->orders_actions[i] = punit->orders.list[i].action;
-    }
+    memcpy(packet->orders, punit->orders.list,
+           punit->orders.length * sizeof(struct unit_order));
   } else {
     packet->orders_length = packet->orders_index = 0;
     packet->orders_repeat = packet->orders_vigilant = FALSE;
@@ -5514,30 +5507,26 @@ bool is_unit_plural(struct unit *punit)
   from their contents if valid.
 **************************************************************************/
 struct unit_order *create_unit_orders(int length,
-                                      const enum unit_orders *orders,
-                                      const enum direction8 *dir,
-                                      const enum unit_activity *activity,
-                                      const int *sub_target,
-                                      const action_id *action)
+                                      const struct unit_order *orders)
 {
   int i;
   struct unit_order *unit_orders;
 
   for (i = 0; i < length; i++) {
-    if (orders[i] < 0 || orders[i] > ORDER_LAST) {
-      log_error("invalid order %d at index %d", orders[i], i);
+    if (orders[i].order < 0 || orders[i].order > ORDER_LAST) {
+      log_error("invalid order %d at index %d", orders[i].order, i);
       return NULL;
     }
-    switch (orders[i]) {
+    switch (orders[i].order) {
     case ORDER_MOVE:
     case ORDER_ACTION_MOVE:
-      if (!map_untrusted_dir_is_valid(dir[i])) {
-        log_error("in order %d, invalid move direction %d.", i, dir[i]);
+      if (!map_untrusted_dir_is_valid(orders[i].dir)) {
+        log_error("in order %d, invalid move direction %d.", i, orders[i].dir);
 	return NULL;
       }
       break;
     case ORDER_ACTIVITY:
-      switch (activity[i]) {
+      switch (orders[i].activity) {
       case ACTIVITY_FALLOUT:
       case ACTIVITY_POLLUTION:
       case ACTIVITY_PILLAGE:
@@ -5554,24 +5543,24 @@ struct unit_order *create_unit_orders(int length,
       case ACTIVITY_SENTRY:
         if (i != length - 1) {
           /* Only allowed as the last order. */
-          log_error("activity %d is not allowed at index %d.", activity[i],
+          log_error("activity %d is not allowed at index %d.", orders[i].activity,
                     i);
           return NULL;
         }
         break;
       case ACTIVITY_BASE:
-        if (!is_extra_caused_by(extra_by_number(sub_target[i]),
+        if (!is_extra_caused_by(extra_by_number(orders[i].sub_target),
                                 EC_BASE)) {
           log_error("at index %d, %s isn't a base.", i,
-                    extra_rule_name(extra_by_number(sub_target[i])));
+                    extra_rule_name(extra_by_number(orders[i].sub_target)));
           return NULL;
         }
         break;
       case ACTIVITY_GEN_ROAD:
-        if (!is_extra_caused_by(extra_by_number(sub_target[i]),
+        if (!is_extra_caused_by(extra_by_number(orders[i].sub_target),
                                 EC_ROAD)) {
           log_error("at index %d, %s isn't a road.", i,
-                    extra_rule_name(extra_by_number(sub_target[i])));
+                    extra_rule_name(extra_by_number(orders[i].sub_target)));
           return NULL;
         }
         break;
@@ -5589,28 +5578,28 @@ struct unit_order *create_unit_orders(int length,
       /* Unused. */
       case ACTIVITY_PATROL_UNUSED:
       case ACTIVITY_LAST:
-        log_error("at index %d, unsupported activity %d.", i, activity[i]);
+        log_error("at index %d, unsupported activity %d.", i, orders[i].activity);
         return NULL;
       }
 
-      if (sub_target[i] == EXTRA_NONE
-          && unit_activity_needs_target_from_client(activity[i])) {
+      if (orders[i].sub_target == EXTRA_NONE
+          && unit_activity_needs_target_from_client(orders[i].activity)) {
         /* The orders system can't do server side target assignment for
          * this activity. */
-        log_error("activity %d at index %d requires target.", activity[i],
+        log_error("activity %d at index %d requires target.", orders[i].activity,
                   i);
         return NULL;
       }
 
       break;
     case ORDER_PERFORM_ACTION:
-      if (!action_id_exists(action[i])) {
+      if (!action_id_exists(orders[i].action)) {
         /* Non-existent action. */
-        log_error("at index %d, the action %d doesn't exist.", i, action[i]);
+        log_error("at index %d, the action %d doesn't exist.", i, orders[i].action);
         return NULL;
       }
 
-      if (action_id_distance_inside_max(action[i], 2)) {
+      if (action_id_distance_inside_max(orders[i].action, 2)) {
         /* Long range actions aren't supported in unit orders. Clients
          * should order them performed via the unit_do_action packet.
          *
@@ -5628,39 +5617,39 @@ struct unit_order *create_unit_orders(int length,
          * this check and update the comment in the Qt client's
          * go_act_menu::create(). */
         log_error("at index %d, the action %s isn't supported in unit "
-                  "orders.", i, action_id_name_translation(action[i]));
+                  "orders.", i, action_id_name_translation(orders[i].action));
         return NULL;
       }
 
-      if (!action_id_distance_inside_max(action[i], 1)
-          && map_untrusted_dir_is_valid(dir[i])) {
+      if (!action_id_distance_inside_max(orders[i].action, 1)
+          && map_untrusted_dir_is_valid(orders[i].dir)) {
         /* Actor must be on the target tile. */
         log_error("at index %d, cannot do %s on a neighbor tile.", i,
-                  action_id_rule_name(action[i]));
+                  action_id_rule_name(orders[i].action));
         return NULL;
       }
 
       /* Validate individual actions. */
-      switch ((enum gen_action) action[i]) {
+      switch ((enum gen_action) orders[i].action) {
       case ACTION_SPY_TARGETED_SABOTAGE_CITY:
       case ACTION_SPY_TARGETED_SABOTAGE_CITY_ESC:
         /* Sabotage target is production (-1) or a building. */
-        if (!(sub_target[i] - 1 == -1
-              || improvement_by_number(sub_target[i] - 1))) {
+        if (!(orders[i].sub_target - 1 == -1
+              || improvement_by_number(orders[i].sub_target - 1))) {
           /* Sabotage target is invalid. */
           log_error("at index %d, cannot do %s without a target.", i,
-                    action_id_rule_name(action[i]));
+                    action_id_rule_name(orders[i].action));
           return NULL;
         }
         break;
       case ACTION_SPY_TARGETED_STEAL_TECH:
       case ACTION_SPY_TARGETED_STEAL_TECH_ESC:
-        if (sub_target[i] == A_NONE
-            || (!valid_advance_by_number(sub_target[i])
-                && sub_target[i] != A_FUTURE)) {
+        if (orders[i].sub_target == A_NONE
+            || (!valid_advance_by_number(orders[i].sub_target)
+                && orders[i].sub_target != A_FUTURE)) {
           /* Target tech is invalid. */
           log_error("at index %d, cannot do %s without a target.", i,
-                    action_id_rule_name(action[i]));
+                    action_id_rule_name(orders[i].action));
           return NULL;
         }
         break;
@@ -5668,13 +5657,13 @@ struct unit_order *create_unit_orders(int length,
       case ACTION_BASE:
       case ACTION_MINE:
       case ACTION_IRRIGATE:
-        if (sub_target[i] == EXTRA_NONE
-            || (sub_target[i] < 0
-                || sub_target[i] >= game.control.num_extra_types)
-            || extra_by_number(sub_target[i])->ruledit_disabled) {
+        if (orders[i].sub_target == EXTRA_NONE
+            || (orders[i].sub_target < 0
+                || orders[i].sub_target >= game.control.num_extra_types)
+            || extra_by_number(orders[i].sub_target)->ruledit_disabled) {
           /* Target extra is invalid. */
           log_error("at index %d, cannot do %s without a target.", i,
-                    action_id_rule_name(action[i]));
+                    action_id_rule_name(orders[i].action));
           return NULL;
         }
         break;
@@ -5732,7 +5721,7 @@ struct unit_order *create_unit_orders(int length,
         break;
       /* Invalid action. Should have been caught above. */
       case ACTION_COUNT:
-        fc_assert_ret_val_msg(action[i] != ACTION_NONE, NULL,
+        fc_assert_ret_val_msg(orders[i].action != ACTION_NONE, NULL,
                               "ACTION_NONE in ORDER_PERFORM_ACTION order. "
                               "Order number %d.", i);
       }
@@ -5757,13 +5746,7 @@ struct unit_order *create_unit_orders(int length,
   }
 
   unit_orders = fc_malloc(length * sizeof(*(unit_orders)));
-  for (i = 0; i < length; i++) {
-    unit_orders[i].order = orders[i];
-    unit_orders[i].dir = dir[i];
-    unit_orders[i].activity = activity[i];
-    unit_orders[i].sub_target = sub_target[i];
-    unit_orders[i].action = action[i];
-  }
+  memcpy(unit_orders, orders, length * sizeof(*(unit_orders)));
 
   return unit_orders;
 }

--- a/freeciv/freeciv/server/unittools.h
+++ b/freeciv/freeciv/server/unittools.h
@@ -197,10 +197,6 @@ extern char encoded_unit_emoji[128];
 #define UNIT_EMOJI(punit) get_web_unit_icon((const struct unit*)punit, &encoded_unit_emoji[0])
 
 struct unit_order *create_unit_orders(int length,
-                                      const enum unit_orders *orders,
-                                      const enum direction8 *dir,
-                                      const enum unit_activity *activity,
-                                      const int *sub_target,
-                                      const action_id *action);
+                                      const struct unit_order *orders);
 
 #endif  /* FC__UNITTOOLS_H */


### PR DESCRIPTION
Big network protocol change (@Lexxie9952)

Most of the web-client code was taken from freeciv/freeciv-web where this protocol has been in use for some time already. Connect orders changes were implemented from scratch, and those orders seemed to be in a bad shape (extraneous fields passed etc) already after the previous protocol change, so have quite a substantial rewrite.