### PR TITLE
Add exception handling to PBEM savegame reading.

### DIFF
--- a/pbem/pbem.py
+++ b/pbem/pbem.py
@@ -95,9 +95,13 @@ def handle_savegame(root, file):
   filename = os.path.join(root,file)
   print("Handling savegame: " + filename);
   txt = None;
-  with lzma.open(filename,  mode="rt") as f:
-    txt = f.read().split("\n");
-    status.savegames_read += 1;
+  try:
+    with lzma.open(filename,  mode="rt") as f:
+      txt = f.read().split("\n");
+      status.savegames_read += 1;
+  except Exception as inst:
+    print("Error loading savegame: " + str(inst));
+    return;
 
   new_filename = "pbem_processed_" + str(random.randint(0,10000000000)) + ".xz";
   f.close();


### PR DESCRIPTION
Add exception handling to PBEM savegame reading.

The production server pbem has this error in the logs:

Traceback (most recent call last):
  File "/home/freeciv/freeciv-web/pbem/pbem.py", line 274, in <module>
    process_savegames();
  File "/home/freeciv/freeciv-web/pbem/pbem.py", line 222, in process_savegames
    handle_savegame(root, file);
  File "/home/freeciv/freeciv-web/pbem/pbem.py", line 99, in handle_savegame
    txt = f.read().split("\n");
  File "/usr/lib/python3.7/lzma.py", line 200, in read
    return self._buffer.read(size)
  File "/usr/lib/python3.7/_compression.py", line 99, in read
    raise EOFError("Compressed file ended before the "
EOFError: Compressed file ended before the end-of-stream marker was reached
Handling savegame: /var/lib/tomcat8/webapps/data/savegames/pbem/pbem-schizoidnightmares-1622065026.sav.xz
