### PR TITLE
Make sandbox load

### DIFF
--- a/freeciv/freeciv/data/sandbox/buildings.ruleset
+++ b/freeciv/freeciv/data/sandbox/buildings.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Sandbox buildings data for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/freeciv/freeciv/data/sandbox/cities.ruleset
+++ b/freeciv/freeciv/data/sandbox/cities.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Sandbox cities data for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/freeciv/freeciv/data/sandbox/effects.ruleset
+++ b/freeciv/freeciv/data/sandbox/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Sandbox effects data for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/freeciv/freeciv/data/sandbox/game.ruleset
+++ b/freeciv/freeciv/data/sandbox/game.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Sandbox game rules for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/freeciv/freeciv/data/sandbox/governments.ruleset
+++ b/freeciv/freeciv/data/sandbox/governments.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Sandbox governments data for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 [governments]

--- a/freeciv/freeciv/data/sandbox/nations.ruleset
+++ b/freeciv/freeciv/data/sandbox/nations.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Sandbox nations data for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/freeciv/freeciv/data/sandbox/styles.ruleset
+++ b/freeciv/freeciv/data/sandbox/styles.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Sandbox nation theme data for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/freeciv/freeciv/data/sandbox/techs.ruleset
+++ b/freeciv/freeciv/data/sandbox/techs.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Sandbox technology data for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 [control]

--- a/freeciv/freeciv/data/sandbox/terrain.ruleset
+++ b/freeciv/freeciv/data/sandbox/terrain.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Sandbox terrain data for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 [control]

--- a/freeciv/freeciv/data/sandbox/units.ruleset
+++ b/freeciv/freeciv/data/sandbox/units.ruleset
@@ -16,7 +16,7 @@
 
 [datafile]
 description="Sandbox Units data for Freeciv"
-options="Freeciv-ruleset-Devel-2017.Jan.02 +web-compatible"
+options="Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
 format_version=20
 
 [control]


### PR DESCRIPTION
In my (non fcw.org) build of fcw.org's Freeciv server the sandbox ruleset refuses to load. This fixes it.

If sandbox refuses to load when fcw.org's Freeciv server is compiled as a part of fcw.org too - even after ba2020e44af9ed9dec5ffed10cba947ab451d6ee - I recommend accepting this merge request.