### PR TITLE
Skeleton to track act sel dlg owner.

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/action_dialog.js
+++ b/freeciv-web/src/main/webapp/javascript/action_dialog.js
@@ -272,6 +272,13 @@ function popup_action_selection(actor_unit, action_probabilities,
   remove_active_dialog(id);
   $("<div id='act_sel_dialog_" + actor_unit['id'] + "'></div>").appendTo("div#game_page");
 
+  if (action_selection_in_progress_for != IDENTITY_NUMBER_ZERO
+      && action_selection_in_progress_for != actor_unit['id']) {
+    console.log("Looks like unit %d has an action selection dialog open"
+                + " but a dialog for unit %d is about to be opened.",
+                action_selection_in_progress_for, actor_unit['id']);
+  }
+
   var actor_homecity = cities[actor_unit['homecity']];
 
   var buttons = [];
@@ -634,6 +641,8 @@ function popup_action_selection(actor_unit, action_probabilities,
       buttons: buttons });
 
   $(id).dialog('open');
+  action_selection_in_progress_for = actor_unit['id'];
+  is_more_user_input_needed = false;
   $(id).dialog('widget').position({my:"center top", at:"center top", of:window})
   dialog_register(id);
 }

--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -111,6 +111,15 @@ var CHAT_ICON_EVERYBODY = String.fromCharCode(62075);
 var CHAT_ICON_ALLIES = String.fromCharCode(61746);
 var end_turn_info_message_shown = false;
 
+/* The ID of the unit that currently is in the action selection process.
+ *
+ * The action selection process begins when the client asks the server what
+ * actions a unit can take. It ends when the last follow up question is
+ * answered.
+ */
+var action_selection_in_progress_for = 0; /* before IDENTITY_NUMBER_ZERO */
+var is_more_user_input_needed = false;
+
 /****************************************************************************
 ...
 ****************************************************************************/
@@ -822,6 +831,27 @@ function check_text_input(event,chatboxtextarea) {
 }
 
 
+
+/**********************************************************************//**
+  The action selection process is no longer in progres for the specified
+  unit. It is safe to let another unit enter action selection.
+**************************************************************************/
+function action_selection_no_longer_in_progress(old_actor_id)
+{
+  /* IDENTITY_NUMBER_ZERO is accepted for cases where the unit is gone
+   * without a trace. */
+  if (old_actor_id != action_selection_in_progress_for
+      && old_actor_id != IDENTITY_NUMBER_ZERO) {
+    console.log("Decision taken for %d but selection is for %d.",
+                old_actor_id, action_selection_in_progress_for);
+  }
+
+  /* Stop objecting to allowing the next unit to ask. */
+  action_selection_in_progress_for = IDENTITY_NUMBER_ZERO;
+
+  /* Stop assuming the answer to a follow up question will arrive. */
+  is_more_user_input_needed = false;
+}
 
 /****************************************************************************
   Return TRUE iff a unit on this tile is in focus.


### PR DESCRIPTION
Add functionality that should be used to track if the action selection
dialog currently is open and who owns it. If a new unit opens a new action
selection dialog while another unit already has an action selection dialog
open the system forgets about the first open action selection dialog.

Like freeciv/freeciv-web@46a6fb2d but the functionality isn't actually used.