### PR TITLE
Unit action decision wanted marker.

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/2dcanvas/tilespec.js
+++ b/freeciv-web/src/main/webapp/javascript/2dcanvas/tilespec.js
@@ -774,6 +774,13 @@ function fill_unit_sprite_array(punit, num_stacked)
                     "offset_y" : activities['offset_y'] + unit_offset['y']+19 });
     }
   }
+  if (should_ask_server_for_actions(punit)) {
+    result.push({
+      "key"      : "unit.action_decision_want",
+      "offset_x" : unit_activity_offset_x + unit_offset['x'],
+      "offset_y" : -unit_activity_offset_y + unit_offset['y'],
+    });
+  }
   if (unit_offset['x'] == 0 && unit_offset['y'] == 0) { // if unit is moving, don't draw these
     // Move point bar
     if (show_unit_movepct && punit['movesleft']!=null) result.push(get_mp_sprite(punit));
@@ -814,6 +821,7 @@ function fill_unit_sprite_array(punit, num_stacked)
     veteran['offset_y'] -= (UO_vy[id] - unit_offset['y']); // bundle in unit_offset so badge moves with the unit
     result.push(veteran);
   }
+
   return result;
 }
 

--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -836,6 +836,19 @@ function check_text_input(event,chatboxtextarea) {
 
 
 /**********************************************************************//**
+  Returns TRUE iff the client should ask the server about what actions a
+  unit can perform.
+**************************************************************************/
+function should_ask_server_for_actions(punit)
+{
+  return (punit['action_decision_want'] === ACT_DEC_ACTIVE
+          /* The player is interested in getting a pop up for a mere
+           * arrival. */
+          || (punit['action_decision_want'] === ACT_DEC_PASSIVE
+              && popup_actor_arrival));
+}
+
+/**********************************************************************//**
   Ask the server about what actions punit may be able to perform against
   it's stored target tile.
 


### PR DESCRIPTION
Show the graphics you just added. The time it will be shown is very short for now because fcw.org clears the status as soon as the action selection dialog arrives. Follow up patches will change that.

How to test:
Alternative 1) See that the unit was changed in the short time between asking and receiving an answer. More a blink.
Alternative 2) Temporarily remove action_decision_clear_want(actor_unit_id); from handle_unit_actions() during testing.