### PR TITLE
Make action selection dialog follow unit focus queue

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10,14 +10,7 @@ Basically you can help improve Freeciv-web in any way you like, as long at it ac
 Unimplemented Freeciv client features:
 - action selection dialog pops up and down based on unit focus rather than
   opening all at once.
-  - the Freeciv C clients give units that wants an action decision higher
-    priority in the unit focus queue. This keeps player decisions fast.
-  - makes turn change less confusing when many units on a goto reaches their
-    targets.
   - gives the user freedom to delay a response without losing the reminder.
-  - open action selection dialogs are stored in save games.
-  - action selection dialogs are based on more up to date information.
-    (Since it asks right before showing the dialog)
   - Implementation hints:
     - a unit's request for the player to chose an action is stored in its
       fields action_decision_want and action_decision_tile.
@@ -41,14 +34,6 @@ Unimplemented Freeciv client features:
       target_unit_id, target_tile_id, disturb_player) the
       server will respond with the information needed for the action
       selection dialog in a PACKET_UNIT_ACTIONS.
-    - the current situation is that the Freeciv-web client sends a
-      PACKET_UNIT_GET_ACTIONS as soon as a unit's action decision state
-      changes and the new state wants a decision. (See
-      unit_actor_wants_input() and process_diplomat_arrival()) Multiple
-      action selection dialogs will hide behind each other.
-    - the current situation is that the Freeciv-web client clears the action
-      decision as soon as an action selection dialog is received. (See
-      handle_unit_actions())
     - in Freeciv C clients a PACKET_UNIT_GET_ACTIONS is sent when a unit
       gets focus OR when a unit already in focus changes action decision
       state to one that wants a decision.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,37 +8,6 @@ Current TODO-list in prioritized order here:
 Basically you can help improve Freeciv-web in any way you like, as long at it actually makes the game better! Other things to improve there:
 
 Unimplemented Freeciv client features:
-- action selection dialog pops up and down based on unit focus rather than
-  opening all at once.
-  - gives the user freedom to delay a response without losing the reminder.
-  - Implementation hints:
-    - a unit's request for the player to chose an action is stored in its
-      fields action_decision_want and action_decision_tile.
-    - action_decision_want tells if an action decision is wanted and if it
-      was caused by the unit being moved inside a transport
-      (ACT_DEC_PASSIVE) or by the unit itself moving (ACT_DEC_ACTIVE). It is
-      defined and explained in fc_types.js
-    - action_decision_tile is the tile the unit wonders what to do to.
-    - a unit's request for the player to chose an action can be set by the
-      server based on unit movement or by the client via
-      PACKET_UNIT_SSCS_SET(unit_id, type, value) where type is USSDT_QUEUE
-      like key_unit_action_select() does.
-    - once the player has made a decision (deciding not to act by pressing
-      cancel is a decision too) the client must ask the server to clear the
-      unit's action_decision_want by sending a USSDT_UNQUEUE typed
-      PACKET_UNIT_SSCS_SET(unit_id, type, value).
-    - the action selection dialog lives in action_dialog.js. It has recently
-      become less repetitive. This should make it easier to send
-      PACKET_UNIT_SSCS_SET with USSDT_UNQUEUE on all user choices.
-    - when a client sends a PACKET_UNIT_GET_ACTIONS(actor_unit_id,
-      target_unit_id, target_tile_id, disturb_player) the
-      server will respond with the information needed for the action
-      selection dialog in a PACKET_UNIT_ACTIONS.
-    - in Freeciv C clients a PACKET_UNIT_GET_ACTIONS is sent when a unit
-      gets focus OR when a unit already in focus changes action decision
-      state to one that wants a decision.
-    - Freeciv's common/networking/packets.def has up to date packet field
-      info.
 - the popup_attack_actions client setting (so attack pop up can be avoided)
 - global work lists
 - advanced unit selection

--- a/freeciv-web/src/main/webapp/javascript/2dcanvas/mapctrl.js
+++ b/freeciv-web/src/main/webapp/javascript/2dcanvas/mapctrl.js
@@ -443,6 +443,7 @@ function map_select_units(canvas_x, canvas_y)
   }
 
   current_focus = selected_units;
+  action_selection_next_in_focus(IDENTITY_NUMBER_ZERO);
   update_active_units_dialog();
 }
 

--- a/freeciv-web/src/main/webapp/javascript/action_dialog.js
+++ b/freeciv-web/src/main/webapp/javascript/action_dialog.js
@@ -526,6 +526,15 @@ function popup_action_selection(actor_unit, action_probabilities,
   }
 
   buttons.push({
+      id      : "act_sel_wait" + actor_unit['id'],
+      "class" : 'act_sel_button',
+      text    : 'Wait',
+      click   : function() {
+        did_not_decide = true;
+        remove_action_selection_dialog(id, actor_unit['id'], true);
+      } });
+
+  buttons.push({
       id      : "act_sel_cancel" + actor_unit['id'],
       "class" : 'act_sel_button',
       text    : 'Cancel (𝗪)',

--- a/freeciv-web/src/main/webapp/javascript/action_dialog.js
+++ b/freeciv-web/src/main/webapp/javascript/action_dialog.js
@@ -55,6 +55,7 @@ function act_sel_queue_may_be_done(actor_unit_id)
     } else {
       /* An action, or no action at all, was selected. */
       action_decision_clear_want(actor_unit_id);
+      action_selection_next_in_focus(actor_unit_id);
     }
   }
 }

--- a/freeciv-web/src/main/webapp/javascript/action_dialog.js
+++ b/freeciv-web/src/main/webapp/javascript/action_dialog.js
@@ -327,6 +327,9 @@ function popup_action_selection(actor_unit, action_probabilities,
     console.log("Looks like unit %d has an action selection dialog open"
                 + " but a dialog for unit %d is about to be opened.",
                 action_selection_in_progress_for, actor_unit['id']);
+    console.log("Closing the action selection dialog for unit %d",
+                action_selection_in_progress_for);
+    action_selection_close();
   }
 
   var actor_homecity = cities[actor_unit['homecity']];

--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -849,6 +849,16 @@ function should_ask_server_for_actions(punit)
 }
 
 /**********************************************************************//**
+  Returns TRUE iff it is OK to ask the server about what actions a unit
+  can perform.
+**************************************************************************/
+function can_ask_server_for_actions()
+{
+  /* OK as long as no other unit already asked and aren't done yet. */
+  return action_selection_in_progress_for === IDENTITY_NUMBER_ZERO;
+}
+
+/**********************************************************************//**
   Ask the server about what actions punit may be able to perform against
   it's stored target tile.
 
@@ -928,6 +938,44 @@ function action_decision_clear_want(old_actor_id)
       "value"   : IDENTITY_NUMBER_ZERO
     };
     send_request(JSON.stringify(unqueue));
+  }
+}
+
+/**********************************************************************//**
+  Move on to the next unit in focus that needs an action decision.
+**************************************************************************/
+function action_selection_next_in_focus(old_actor_id)
+{
+  /* Go to the next unit in focus that needs a decision. */
+  for (var i = 0; i < current_focus.length; i++) {
+    var funit = current_focus[i];
+    if (old_actor_id != funit['id']
+        && should_ask_server_for_actions(funit)) {
+      ask_server_for_actions(funit);
+      return;
+    }
+  }
+}
+
+/**********************************************************************//**
+  Request that the player makes a decision for the specified unit.
+**************************************************************************/
+function action_decision_request(actor_unit)
+{
+  if (actor_unit == null) {
+    console.log("action_decision_request(): No actor unit");
+    return;
+  }
+
+  if (!unit_is_in_focus(actor_unit)) {
+    /* Getting feed back may be urgent. A unit standing next to an enemy
+     * could be killed while waiting. */
+    unit_focus_urgent(actor_unit);
+  } else if (can_client_issue_orders()
+             && can_ask_server_for_actions()) {
+    /* No need to wait. The actor unit is in focus. No other actor unit
+     * is currently asking about action selection. */
+    ask_server_for_actions(actor_unit);
   }
 }
 
@@ -1033,6 +1081,18 @@ function update_unit_focus()
 
   if (C_S_RUNNING != client_state()) return;
 
+  if (!can_ask_server_for_actions()) {
+    if (get_units_in_focus().length < 1) {
+      console.log("update_unit_focus(): action selection dialog open for"
+                  + " unit %d but unit not in focus?",
+                  action_selection_in_progress_for);
+    } else {
+      /* An actor unit is asking the player what to do. Don't steal his
+       * focus. */
+      return;
+    }
+  }
+
   /* iterate zero times for no units in focus,
    * otherwise quit for any of the conditions. */
   var funits = get_units_in_focus();
@@ -1076,8 +1136,11 @@ function advance_unit_focus(same_type)
     for (i = 0; i < urgent_focus_queue.length; i++) {
       var punit = urgent_focus_queue[i];
 
-      if (ACTIVITY_IDLE != punit.activity
-          || punit.has_orders) {
+      if ((ACTIVITY_IDLE != punit.activity
+           || punit.has_orders)
+          /* This isn't an action decision needed because of an
+           * ORDER_ACTION_MOVE located in the middle of an order. */
+          && !should_ask_server_for_actions(punit)) {
         /* We have assigned new orders to this unit since, remove it. */
         urgent_focus_queue = unit_list_without(urgent_focus_queue, punit);
         i--;
@@ -2158,6 +2221,7 @@ function set_unit_focus(punit)
     current_focus = [];
   } else {
     current_focus[0] = punit;
+    action_selection_next_in_focus(IDENTITY_NUMBER_ZERO);
   }
 
   if (punit) warcalc_set_default_vals(punit);
@@ -2210,6 +2274,7 @@ function set_unit_focus_and_redraw(punit)
     current_focus = [];
   } else {
     current_focus[0] = punit;
+    action_selection_next_in_focus(IDENTITY_NUMBER_ZERO);
     warcalc_set_default_vals(punit); // warcalc default vals as last clicked units
   }
 

--- a/freeciv-web/src/main/webapp/javascript/packhand.js
+++ b/freeciv-web/src/main/webapp/javascript/packhand.js
@@ -1061,6 +1061,9 @@ function handle_unit_remove(packet)
   /* Close the action selection dialog if the actor unit is lost */
   if (action_selection_in_progress_for === punit.id) {
     action_selection_close();
+    /* Open another action selection dialog if there are other actors in the
+     * current selection that want a decision. */
+    action_selection_next_in_focus(punit.id);
   }
 
   /* TODO: Notify agents. */
@@ -1129,15 +1132,17 @@ function handle_unit_packet_common(packet_unit)
 
   if (units[packet_unit['id']] == null) {
     /* This is a new unit. */
-    unit_actor_wants_input(packet_unit);
+    if (should_ask_server_for_actions(packet_unit)) {
+      action_decision_request(packet_unit);
+    }
     packet_unit['anim_list'] = [];
     units[packet_unit['id']] = packet_unit;
     units[packet_unit['id']]['facing'] = 6;
   } else {
-    if (units[packet_unit['id']]['action_decision_want']
-        != packet_unit['action_decision_want']) {
-      /* The unit's action_decision_want has changed. */
-      unit_actor_wants_input(packet_unit);
+    if (punit['action_decision_want'] != packet_unit['action_decision_want']
+        && should_ask_server_for_actions(packet_unit)) {
+      /* The unit wants the player to decide. */
+      action_decision_request(packet_unit);
     }
 
     update_unit_anim_list(units[packet_unit['id']], packet_unit);
@@ -1346,34 +1351,6 @@ function handle_unit_action_answer(packet)
 }
 
 /**************************************************************************
-  Handle server request for user input about diplomat action to do.
-**************************************************************************/
-function unit_actor_wants_input(pdiplomat)
-{
-  if (observing || client.conn.playing == null) return;
-
-  if (pdiplomat['action_decision_want'] == null
-      || pdiplomat['owner'] != client.conn.playing['playerno']) {
-    /* No authority to decide for this unit. */
-    return;
-  }
-
-  if (pdiplomat['action_decision_want'] == ACT_DEC_NOTHING) {
-    /* The unit doesn't want a decision. */
-    return;
-  }
-
-  if (pdiplomat['action_decision_want'] == ACT_DEC_PASSIVE
-      && !popup_actor_arrival) {
-    /* The player isn't interested in getting a pop up for a mere
-     * arrival. */
-    return;
-  }
-
-  ask_server_for_actions(pdiplomat);
-}
-
-/**************************************************************************
   Handle server reply about what actions an unit can do.
 **************************************************************************/
 function handle_unit_actions(packet)
@@ -1403,16 +1380,6 @@ function handle_unit_actions(packet)
     });
   }
 
-  if (disturb_player) {
-    /* Clear the unit's action_decision_want. This was the reply to a
-     * foreground request caused by it. Freeciv-web doesn't save open
-     * action selection dialogs. It doesn't even wait for any other action
-     * selection dialog to be answered before requesting data for the next
-     * one. This lack of a queue allows it to be cleared here. */
-
-    action_decision_clear_want(actor_unit_id);
-  }
-
   if (hasActions && disturb_player) {
     popup_action_selection(pdiplomat, action_probabilities,
                            ptile, target_extra, target_unit, target_city);
@@ -1420,6 +1387,7 @@ function handle_unit_actions(packet)
     /* Nothing to do. */
     action_selection_no_longer_in_progress(actor_unit_id);
     action_decision_clear_want(actor_unit_id);
+    action_selection_next_in_focus(actor_unit_id);
   } else if (hasActions) {
     /* This was a background request. */
 


### PR DESCRIPTION
May need a manual review to double check that I haven't overlooked anything fcw.org specific