### PR TITLE
act_sel_queue_done(): fix ordering.

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/action_dialog.js
+++ b/freeciv-web/src/main/webapp/javascript/action_dialog.js
@@ -68,9 +68,9 @@ function act_sel_queue_done(actor_unit_id)
 {
   /* Stop waiting. Move on to the next queued unit. */
   is_more_user_input_needed = false;
+  act_sel_queue_may_be_done(actor_unit_id);
   action_selection_restart = false;
   did_not_decide = false;
-  act_sel_queue_may_be_done(actor_unit_id);
 }
 
 /**************************************************************************


### PR DESCRIPTION
Don't clear action_selection_restart and did_not_decide until after
act_sel_queue_may_be_done() has run and potentially used them.

Co-Authored-By: Lexxie9952 <32187224+Lexxie9952@users.noreply.github.com>
Fixes: 98ac3c9bb17a89fc71f53dffc48e04e1fad701ab