### PR TITLE
Be more careful about disembark rewrite.

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -6424,21 +6424,6 @@ function key_unit_move(dir)
       return;
     }
 
-    if (punit['transported']) {
-      if (unit_can_do_action(punit, ACTION_TRANSPORT_DISEMBARK1)) {
-        request_new_unit_activity(punit, ACTIVITY_IDLE, EXTRA_NONE);
-        request_unit_do_action(ACTION_TRANSPORT_DISEMBARK1, punit['id'],
-                               newtile['index']);
-        unit_move_sound_play(punit);
-      } else if (unit_can_do_action(punit, ACTION_TRANSPORT_DISEMBARK2)) {
-        request_new_unit_activity(punit, ACTIVITY_IDLE, EXTRA_NONE);
-        request_unit_do_action(ACTION_TRANSPORT_DISEMBARK2, punit['id'],
-                               newtile['index']);
-        unit_move_sound_play(punit);
-      }
-      return;
-    }
-
     /* Send the order to move using the orders system. */
     var order = {
       "order"      : ORDER_ACTION_MOVE,
@@ -6447,6 +6432,20 @@ function key_unit_move(dir)
       "sub_target" : 0,
       "action"     : ACTION_COUNT
     };
+
+    if (punit['transported']
+        /* No non domestic units */
+        && newtile['units'].every(function(ounit) {
+             return ounit['owner'] == client.conn.playing.playerno;
+           })
+        /* No non domestic cities */
+        && (tile_city(newtile) == null
+            || tile_city(newtile)['owner'] == client.conn.playing.playerno)
+        && !tile_has_extra(newtile, EXTRA_HUT)
+        && (newtile['extras_owner'] == client.conn.playing.playerno
+            || !tile_has_territory_claiming_extra(newtile))) {
+      order["order"] = ORDER_MOVE;
+    }
 
     var packet = {
       "pid"      : packet_unit_orders,


### PR DESCRIPTION
Don't interpret numpad commands while transported as disembark when it can
be an attack, city conquest, hut popping or extra conquest. Leave the
disembark action choice to the server.

Closes freeciv/freeciv-web#378