### PR TITLE
Fix unit loss focus advance.

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -1076,19 +1076,20 @@ function unit_focus_urgent(punit)
 **************************************************************************/
 function control_unit_killed(punit)
 {
-  if (unit_is_in_focus(punit)) {
-    current_focus = unit_list_without(current_focus, punit);
-    update_active_units_dialog();
-    update_unit_order_commands();
-  }
-
   if (urgent_focus_queue != null) {
     urgent_focus_queue = unit_list_without(urgent_focus_queue, punit);
   }
 
-  if (current_focus != null && current_focus.length < 1) {
-    /* if the unit in focus is removed, then advance the unit focus. */
-    advance_unit_focus(false);
+  if (unit_is_in_focus(punit)) {
+    if (current_focus.length == 1) {
+      /* if the unit in focus is removed, then advance the unit focus. */
+      advance_unit_focus(false);
+    } else {
+      current_focus = unit_list_without(current_focus, punit);
+    }
+
+    update_active_units_dialog();
+    update_unit_order_commands();
   }
 }
 


### PR DESCRIPTION
It turns out that advance_unit_focus() needs at least one unit in focus to
advance.

Reported by Lexxie