### PR TITLE
Remove the correct unit from urgent_focus_queue.

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -1200,7 +1200,7 @@ function advance_unit_focus(same_type)
     }
 
     if (null != candidate) {
-      urgent_focus_queue = unit_list_without(urgent_focus_queue, punit);
+      urgent_focus_queue = unit_list_without(urgent_focus_queue, candidate);
       if (DEBUG_FOCUS)
         console.log("    removed candidate:%d urgent_focus_queue[%d]",candidate.id,urgent_focus_queue.length);
     }


### PR DESCRIPTION
Remove the candidate unit, not the unit that was last checked.