### PR TITLE
Support using mariadb service instead of mysql one

### DIFF
--- a/scripts/install/dependency-services-default-start.sh
+++ b/scripts/install/dependency-services-default-start.sh
@@ -11,7 +11,8 @@ export JAVA_OPTS="-Djava.security.egd=file:/dev/urandom"
 export CATALINA_HOME=/var/lib/tomcat8
 
 # 0. mysql
-pidof mysqld > /dev/null || sudo service mysql start
+pidof mysqld > /dev/null || sudo service mariadb start ||
+    sudo service mysql start
 
 # 1. nginx
 echo "Starting nginx first."

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -256,7 +256,7 @@ echo "==== Filling configuration templates ===="
 "${basedir}/config/gen-from-templates.sh"
 
 echo "==== Setting up DB ===="
-pidof mysqld > /dev/null || start_svc mysql
+pidof mysqld > /dev/null || start_svc mariadb || start_svc mysql
 if [ -z "${DB_ROOT_PASSWORD}" ]; then
   echo "Will need the DB root password twice"
 fi


### PR DESCRIPTION
A step towards Debian Bullseye support.

--

I've already managed to run FCW on Bullseye locally, with hacky server solutions, but parts other than one here are not yet ready for mainline.