### PR TITLE
Install OS provided lua, if available

### DIFF
--- a/scripts/install/deb.sh
+++ b/scripts/install/deb.sh
@@ -76,6 +76,12 @@ else
   INSTALLED_TOMCAT=N
 fi
 
+# Install lua-5.4, if available. Otherwise it will be built from the copy
+# included with the server.
+if apt-cache -qq show liblua5.4-dev &> /dev/null; then
+  dependencies="${dependencies} liblua5.4-dev"
+fi
+
 if [ "${FCW_INSTALL_MODE}" = TEST ]; then
   dependencies="${dependencies} xvfb"
 fi


### PR DESCRIPTION
Submitting just to get this out of my own hands. This is currently really low priority for FCW. The patch has any effect only if the OS provides lua-5.4, and ubuntu-18.04 that FCW currently runs on does not. This is just preparing for the future when FCW runs on new enough OS.