### PR TITLE
Correct version number web client reports to server

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/clinet.js
+++ b/freeciv-web/src/main/webapp/javascript/clinet.js
@@ -172,7 +172,7 @@ function check_websocket_ready()
 
     var login_message = {"pid":4, "username" : username,
     "capability": freeciv_version, "version_label": "-dev",
-    "major_version" : 2, "minor_version" : 5, "patch_version" : 99,
+    "major_version" : 3, "minor_version" : 0, "patch_version" : 92,
     "port": civserverport,
     "password": google_user_token == null ? sha_password : google_user_token};
     send_request(JSON.stringify(login_message));


### PR DESCRIPTION
That the web client reports itself as an ancient freeciv to server is probably harmless (server does not do much with client version number), but might as well fix it. Might save hours of time of debugging some subtle bug in the future.