### PR TITLE
CI: Make github actions to run on ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   normal:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: check out Freeciv-web
         uses: actions/checkout@v2


### PR DESCRIPTION
Make FCW Continuous Integration build tests on github to run on ubuntu-20.04 instead of ubuntu-18.04.

It's for FCW project to decide when they want to make that switch, i.e., to merge this patch. There are arguments for waiting, and there are arguments for merging it already.
- As FCW vagrant builds, and I presume production, runs on ubuntu-18.04, there's obvious benefit in keeping CI testing the environment they deliver (not merging this patch yet)
- OTOH ubuntu-18.04 environment gets also tested in their ubuntu-18.04 based development (vagrant builds), so switching CI to test on ubuntu-20.04 (merging this patch already) would increase coverage of their testing to the environment they have to be migrating at some point anyway. They don't want to accidentally break build on their future environment, ubuntu-20.04.

---

I have had no github setup to test the patch before making this Pull Request. When github actions get triggered by creation of this Pull Request, it will be the first test of this patch. Pay attention to results.