### PR TITLE
Docker: Use host port 8080 instead of 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Freeciv-web can easily be built and run from Docker using `docker-compose`. Web 
 
  3. Connect to docker via host machine using standard browser
 
-http://localhost/
+http://localhost:8080/
 
 Enjoy. The overall dockerfile and required changes to scripts needs some further improvements.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - "data:/var/lib/tomcat8/webapps/data"
     ports:
-      - "80:80"
+      - "8080:80"
       - "4002"
       - "6000-6009:6000-6009"
       - "7000-7009:7000-7009"


### PR DESCRIPTION
This is something that I would want to make my own work easier. I have regular webserver on port 80, so I have to carry this change locally at least - and a couple of times I've lost a lot of time because I had missed it and FCW build failed in the final steps of taking the ports to use.
I know that other people without port 80 in use could argue that this is a step back for them.
In any case, this does not affect production, as FCW does not use docker there.