### PR TITLE
Encrypt transition

### DIFF
--- a/freeciv-web/src/main/java/org/freeciv/persistence/DbManager.java
+++ b/freeciv-web/src/main/java/org/freeciv/persistence/DbManager.java
@@ -22,7 +22,7 @@ public class DbManager {
 	}
 
 	public static String getQuerySaltHash() {
-		return " SELECT secure_hashed_password FROM auth " //
+		return " SELECT secure_hashed_password,digest_pw FROM auth " //
 				+ " WHERE LOWER(username) = LOWER(?) AND activated = '1' " //
 				+ " LIMIT 1 ";
 	}
@@ -148,8 +148,8 @@ public class DbManager {
 	}
 
 	public static String getQueryInsertAuthPlayer() {
-		return "INSERT INTO auth (username, email, secure_hashed_password, activated, ip) " //
-				+ "VALUES (?, ?, ?, ?, ?)";
+		return "INSERT INTO auth (username, email, secure_hashed_password, activated, ip, digest_pw) " //
+				+ "VALUES (?, ?, ?, ?, ?, TRUE)";
 	}
 	
     public static String getQueryInsertCheater() {

--- a/freeciv-web/src/main/java/org/freeciv/servlet/LoginUser.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/LoginUser.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package org.freeciv.servlet;
 
+import org.apache.commons.codec.digest.Crypt;
+
 import java.io.*;
 import javax.servlet.*;
 import javax.servlet.http.*;
@@ -76,13 +78,24 @@ public class LoginUser extends HttpServlet {
 				response.getOutputStream().print("Failed");
 			} else {
 				String hashedPasswordFromDB = rs1.getString(1);
-				if (hashedPasswordFromDB != null &&
-						hashedPasswordFromDB.equals(DigestUtils.sha256Hex(secure_password))) {
+                                Boolean compat_encrypt = !rs1.getBoolean(2);
+                                if (compat_encrypt) {
+                                    if (hashedPasswordFromDB != null &&
+                                        hashedPasswordFromDB.equals(Crypt.crypt(secure_password, hashedPasswordFromDB))) {
+                                        // Login OK!
+					response.getOutputStream().print("OK");
+                                    } else {
+					response.getOutputStream().print("Failed");
+                                    }
+                                } else {
+                                    if (hashedPasswordFromDB != null &&
+                                        hashedPasswordFromDB.equals(DigestUtils.sha256Hex(secure_password))) {
 					// Login OK!
 					response.getOutputStream().print("OK");
-				} else {
+                                    } else {
 					response.getOutputStream().print("Failed");
-				}
+                                    }
+                                }
 			}
 
 

--- a/freeciv-web/src/main/resources/db/migration/V1_15__encrypt_mode.sql
+++ b/freeciv-web/src/main/resources/db/migration/V1_15__encrypt_mode.sql
@@ -1,0 +1,2 @@
+alter table auth add column `digest_pw` BOOLEAN;
+update auth set digest_pw = FALSE;


### PR DESCRIPTION
Patch or patches to start transition from the old password encryption to the new one, required by upcoming database engine update.

First commit implements authentication part (authentication of each account by the method matching how password is currently stored) + creation of the new accounts (always) with the new encryption. At least this one is needed.

The second commit adds migration of existing accounts to the above. When user gets successfully authenticated by the old method (i.e. when user of an existing account logins for the first time since this commit has been applied), the plain-text password used is encrypted with the new method, and updated to the database.

I've tested these with persistent (one first populated without these commits & ENCRYPT change already in the master branch) database living on ubuntu-18.04 virtual machine. Both pre-existing and new accounts created after applying the commits authenticate correctly. Database fields seem to update in a sane way ('auth' table gets the new column, indicating whether account has already migrated or not, when freeciv-web is first updated, information on the table is changing as expected when accounts are created and authenticated).
What still needs to be tested is that this really resolves the issue for which it exist - to allow updating the database engine (as part of OS update) with all the migrated accounts still working.

These leave it open what happens when the account migration period ends - what old information we still keep after we lose the ability to do further migrations.