### PR TITLE
Correct freeciv wiki URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,12 @@ some tasks you can work on. Pull requests on Github is welcome!
 Contributors to Freeciv-web
 ---------------------------
 Lexxie9952 [@lexxie9952](https://discordapp.com/users/Lexxie9952)
-Andreas Røsdal  [@andreasrosdal](https://github.com/andreasrosdal)  
-Marko Lindqvist [@cazfi](https://github.com/cazfi)  
-Sveinung Kvilhaugsvik [@kvilhaugsvik](https://github.com/kvilhaugsvik) 
-Máximo Castañeda [@lonemadmax](https://github.com/lonemadmax)  
-Gerik Bonaert [@adaxi](https://github.com/adaxi)  
-and the [Freeciv.org project](http://freeciv.wikia.com/wiki/People)!
+Andreas Røsdal  [@andreasrosdal](https://github.com/andreasrosdal)
+Marko Lindqvist [@cazfi](https://github.com/cazfi)
+Sveinung Kvilhaugsvik [@kvilhaugsvik](https://github.com/kvilhaugsvik)
+Máximo Castañeda [@lonemadmax](https://github.com/lonemadmax)
+Gerik Bonaert [@adaxi](https://github.com/adaxi)
+and the [Freeciv.org project](http://www.freeciv.org/wiki/People)!
 
 About FCW and this repository
 -----------------------------

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -9,7 +9,7 @@ Don't expect to be able to understand everything here even after reading the
 # Freeciv-web and Freeciv
 
 Freeciv-web uses a [patched](freeciv/apply_patches.sh) version of Freeciv's
-[master branch](http://freeciv.wikia.com/wiki/Freeciv_source_code_repository).
+[master branch](http://www.freeciv.org/wiki/Freeciv_source_code_repository).
 This makes it easier to get Freeciv-web related changes into Freeciv.
 It also makes it easier for Freeciv-web to take advantage of the newest
 Freeciv features.
@@ -35,9 +35,9 @@ Freeciv-web uses the Freeciv AI.
 Most of it lives in the [ai](http://repo.or.cz/freeciv.git/tree/HEAD:/ai)
 folder of Freeciv.
 More information about the Freeciv AI can be found at the
-[Freeciv wiki](http://freeciv.wikia.com/wiki/Category:AI).
+[Freeciv wiki](http://www.freeciv.org/wiki/Category:AI).
 Freeciv has AI related
-[introduction tasks](http://freeciv.wikia.com/wiki/Introduction_tasks).
+[introduction tasks](http://www.freeciv.org/wiki/Introduction_tasks).
 
 # Freeciv-web LongTurn
 


### PR DESCRIPTION
Use the proper URLs to freeciv wiki instead of the wikia-specific ones that just happen to work at the moment.